### PR TITLE
PML-22: Test create multikey index

### DIFF
--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -87,7 +87,7 @@ class TestIndexes(BaseTesting):
         self.create_collection("db_1", "coll_1")
 
         with self.perform(phase):
-            self.source["db_1"]["coll_1"].create_index({"i": 1})
+            self.source["db_1"]["coll_1"].create_index({"i.j": 1})
 
         self.compare_all()
 


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PML-22

Add a e2e test for creating multikey indexes.

Note: creating and checking a multikey index is the same as a single field index (regardless if the key is an embedded field or not), so this test is essentially just to be complete.