### PR TITLE
PML-47: Update /status endpoint response

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -239,15 +239,24 @@ func (s *server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	res := statusResponse{
-		Ok:          true,
-		State:       replStatus.State,
-		Finalizable: replStatus.Finalizable,
+		Ok:              true,
+		State:           replStatus.State,
+		Finalizable:     replStatus.Finalizable,
+		Info:            replStatus.Info,
+		EventsProcessed: replStatus.EventsProcessed,
+		Clone: CloneStatus{
+			Finished:             replStatus.Clone.Finished,
+			EstimatedTotalBytes:  replStatus.Clone.EstimatedTotalBytes,
+			EstimatedClonedBytes: replStatus.Clone.EstimatedClonedBytes,
+		},
 	}
+
 	if !replStatus.LastAppliedOpTime.IsZero() {
 		res.LastAppliedOpTime = fmt.Sprintf("%d.%d",
 			replStatus.LastAppliedOpTime.T,
 			replStatus.LastAppliedOpTime.I)
 	}
+
 	err = json.NewEncoder(w).Encode(res)
 	if err != nil {
 		log.Error(ctx, err, "write status")
@@ -272,13 +281,22 @@ type finalizeReponse struct {
 	Error string `json:"error,omitempty"`
 }
 
+type CloneStatus struct {
+	Finished             bool  `json:"finished"`
+	EstimatedTotalBytes  int64 `json:"estimatedTotalBytes"`
+	EstimatedClonedBytes int64 `json:"estimatedClonedBytes"`
+}
+
 type statusResponse struct {
 	Ok    bool   `json:"ok"`
 	Error string `json:"error,omitempty"`
 
-	State             repl.State `json:"state"`
-	Finalizable       bool       `json:"finalizable,omitempty"`
-	LastAppliedOpTime string     `json:"lastAppliedOpTime,omitempty"`
+	State             repl.State  `json:"state"`
+	Finalizable       bool        `json:"finalizable,omitempty"`
+	LastAppliedOpTime string      `json:"lastAppliedOpTime,omitempty"`
+	Info              string      `json:"info"`
+	EventsProcessed   int64       `json:"eventsProcessed"`
+	Clone             CloneStatus `json:"clone"`
 }
 
 func internalServerError(w http.ResponseWriter) {

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -29,6 +29,8 @@ type ChangeReplicator struct {
 	stopSig chan struct{}
 	doneSig chan struct{}
 	running bool
+
+	EventsProcessed int64
 }
 
 func (r *ChangeReplicator) GetLastAppliedOpTime() primitive.Timestamp {
@@ -320,6 +322,7 @@ func (r *ChangeReplicator) apply(ctx context.Context, data bson.Raw) error {
 	r.mu.Lock()
 	r.resumeToken = baseEvent.ID
 	r.lastAppliedOpTime = baseEvent.ClusterTime
+	r.EventsProcessed++
 	r.mu.Unlock()
 	return nil
 }


### PR DESCRIPTION
PR updates `/status` response with additional status fields:

- info - simple message showing PML operation
- eventsProcessed - number of processed events
- clone.finished - status indicating is the cloning phase finished
- clone.estimatedTotalBytes - estimated number of bytes in total that needs to be cloned
- clone.estimatedClonedBytes - estimated number of bytes currently cloned

The response now looks something like this:
```
╰─❯ curl -X GET localhost:2242/status | jq
{
  "ok": true,
  "state": "running",
  "finalizable": true,
  "lastAppliedOpTime": "1739789007.3",
  "info": "cloning data",
  "eventsProcessed": 4,
  "clone": {
    "finished": true,
    "estimatedTotalBytes": 594115483,
    "estimatedClonedBytes": 594115483
  }
}
```