### PR TITLE
PML-45: perform modify index on finalize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ vendor/
 
 .pytest_cache
 __pycache__
+
+/org.md
+/scratch.*

--- a/repl/event.go
+++ b/repl/event.go
@@ -348,6 +348,8 @@ type modifyOpDesc struct {
 	Validator       *bson.Raw `bson:"validator,omitempty"`
 	ValidatorLevel  *string   `bson:"validatorLevel,omitempty"`
 	ValidatorAction *string   `bson:"validatorAction,omitempty"`
+
+	Unknown map[string]any `bson:",inline"`
 }
 
 type modifyIndexOption struct {

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -489,6 +489,9 @@ func (r *ChangeReplicator) handleModify(ctx context.Context, data bson.Raw) erro
 	case opts.Validator != nil || opts.ValidatorLevel != nil || opts.ValidatorAction != nil:
 		log.Warn(ctx, "validator, validatorLevel and validatorAction are not supported")
 
+	case opts.Unknown == nil:
+		log.Debug(ctx, "empty modify event")
+
 	default:
 		log.Error(ctx, errors.New("unknown modify options"), "")
 	}

--- a/tests/mlink.py
+++ b/tests/mlink.py
@@ -90,8 +90,7 @@ class Runner:
         if status["state"] == MLink.State.FINALIZING:
             self.wait_for_state(MLink.State.FINALIZED)
         elif status["state"] == MLink.State.RUNNING:
-            optime = self.source.server_info()["operationTime"]
-            self.wait_for_optime(optime)
+            self.wait_for_current_optime()
             self.wait_for_finalizable()
             self.mlink.finalize()
             self.wait_for_state(MLink.State.FINALIZED)
@@ -102,15 +101,16 @@ class Runner:
             time.sleep(0.1)
             status = self.mlink.status()
 
-    def wait_for_optime(self, ts: bson.Timestamp, timeout=10):
+    def wait_for_current_optime(self, timeout=10):
         status = self.mlink.status()
         assert status["state"] == MLink.State.RUNNING
 
+        curr_optime = self.source.server_info()["operationTime"]
         for _ in range(timeout * 10):
             applied_optime: str = status.get("lastAppliedOpTime")
             if applied_optime:
                 t_s, i_s = applied_optime.split(".")
-                if ts <= bson.Timestamp(int(t_s), int(i_s)):
+                if curr_optime <= bson.Timestamp(int(t_s), int(i_s)):
                     return
 
             time.sleep(0.1)


### PR DESCRIPTION
during running state:
- `unique` and `prepareUnique` indexes are not built.
- the `hidden` prop is not set.
- TTL indexes are built with max allowed value.

during finalize:
- `unique` and `prepareUnique` indexes are built.
- the `hidden` prop is set.
- `expireAfterSeconds` value of TTL indexes is restored to the source value.