### PR TITLE
add log for mongo driver

### DIFF
--- a/config/const.go
+++ b/config/const.go
@@ -1,0 +1,13 @@
+package config
+
+import "go.mongodb.org/mongo-driver/v2/mongo/options"
+
+// MongoDB logging configuration constants.
+const (
+	// MongoLogEnabled indicates if MongoDB logging is enabled.
+	MongoLogEnabled = false
+	// MongoLogComponent specifies the MongoDB log component.
+	MongoLogComponent = options.LogComponentAll
+	// MongoLogLevel specifies the MongoDB log level.
+	MongoLogLevel = options.LogLevelInfo
+)

--- a/log/mongo.go
+++ b/log/mongo.go
@@ -1,0 +1,30 @@
+package log
+
+import (
+	"context"
+
+	"github.com/rs/zerolog"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+// mongoLogger is a wrapper for zerolog.Logger that implements the options.LogSink interface.
+type mongoLogger struct {
+	zl *zerolog.Logger
+}
+
+var _ options.LogSink = mongoLogger{}
+
+// MongoLogger returns a logSink for MongoDB logging.
+func MongoLogger(ctx context.Context) mongoLogger {
+	return mongoLogger{zerolog.Ctx(ctx)}
+}
+
+// Info logs an info level message with additional key-value pairs.
+func (s mongoLogger) Info(level int, message string, keysAndValues ...any) {
+	s.zl.Info().Timestamp().Int("level", level).Fields(keysAndValues).Msg(message)
+}
+
+// Error logs an error level message with an error and additional key-value pairs.
+func (s mongoLogger) Error(err error, message string, keysAndValues ...any) {
+	s.zl.Error().Timestamp().Err(err).Fields(keysAndValues).Msg(message)
+}

--- a/topo/connect.go
+++ b/topo/connect.go
@@ -9,6 +9,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo/readconcern"
 	"go.mongodb.org/mongo-driver/v2/mongo/readpref"
 
+	"github.com/percona-lab/percona-mongolink/config"
 	"github.com/percona-lab/percona-mongolink/errors"
 	"github.com/percona-lab/percona-mongolink/log"
 )
@@ -30,6 +31,12 @@ func Connect(ctx context.Context, uri string) (*mongo.Client, error) {
 				SetDeprecationErrors(true)).
 		SetReadPreference(readpref.Primary()).
 		SetReadConcern(readconcern.Majority())
+
+	if config.MongoLogEnabled {
+		opts = opts.SetLoggerOptions(options.Logger().
+			SetSink(log.MongoLogger(ctx)).
+			SetComponentLevel(config.MongoLogComponent, config.MongoLogLevel))
+	}
 
 	conn, err := mongo.Connect(opts)
 	if err != nil {


### PR DESCRIPTION
MongoLog* fields control the log of mongo-driver.
useful for diagnostic and testing during development.