### PR TITLE
[bugfix] total batch size can exceed MaxCollectionCloneBatchSize

### DIFF
--- a/mongolink/clone.go
+++ b/mongolink/clone.go
@@ -242,8 +242,6 @@ func (c *Clone) cloneCollection(
 			docs = docs[:0]
 			batch++
 			batchSize = 0
-
-			continue
 		}
 
 		docs = append(docs, cur.Current)


### PR DESCRIPTION
- [bugfix] the total batch size can exceed the MaxCollectionCloneBatchSize
- [lint:mnd] fix random number in code
- [lint:[modernize](https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize)] use `any` instead of `interface{}`