### PR TITLE
fix closed connection during insertMany()

### DIFF
--- a/mongolink/clone.go
+++ b/mongolink/clone.go
@@ -400,6 +400,7 @@ func (c *Clone) cloneCollection(ctx context.Context, db, coll string) error {
 	}()
 
 	const initialBufferSize = 1000
+	const maxBufferSize = 10000
 	docs := make([]any, 0, initialBufferSize)
 	batch := 1
 	batchSize := 0
@@ -407,7 +408,8 @@ func (c *Clone) cloneCollection(ctx context.Context, db, coll string) error {
 	targetColl := c.target.Database(db).Collection(spec.Name)
 
 	for cur.Next(ctx) {
-		if batchSize+len(cur.Current) > config.MaxCollectionCloneBatchSize {
+		if batchSize+len(cur.Current) > config.MaxCollectionCloneBatchSize ||
+			len(docs) == maxBufferSize {
 			_, err = targetColl.InsertMany(ctx, docs)
 			if err != nil {
 				return errors.Wrap(err, "insert documents")


### PR DESCRIPTION
quickfix for the issue with a large number of documents
```
cloning: db_0.coll_1: insert documents: connection(rs10:30100[-28]) unable to write wire message to network: write tcp 127.0.0.1:64071->127.0.0.1:30100: write: broken pipe
```