### PR TITLE
PML-88: Fix test_rename_with_drop_target for APPLY phase.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Percona MongoLink is a tool for replicating data from a source MongoDB cluster t
 - **Automatic Index Management**: Ensure necessary indexes are created on the target.
 - **HTTP API**: Start, finalize, pause, resume, and check replication status via REST endpoints.
 
+## Know Limitations
+
+- Rename collection during clone phase is not supported.
+
+  The reason is because when backlog processing is done after clone phase (completing initial sync), the renamed collection is already dropped and thus rename event apply fails since it is missing.
+
 ## Setup
 
 ### Prerequisites


### PR DESCRIPTION
Fix test_rename_with_drop_target with sleeping to wait for clone to finish before performing `rename` collection on source. 

We will have this as a know limitation for now and address it later.

The reasoning for this is stated in the comment in the test, which is this:
```
            # Known limitation: rename with dropTarget is not supported during clone because
            # because when catching up is done after clone, the renamed collection is already
            # dropped and thus rename event apply fails since it is missing.
```