### PR TITLE
add version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
+GIT_HASH := $(shell git rev-parse --short HEAD)
+BUILD_ID := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+SET_VER := -X main.GitCommit=$(GIT_HASH) -X main.BuildID=$(BUILD_ID)
+
 # Flags for production build
-BUILD_FLAGS := -ldflags="-s -w" -trimpath -buildvcs=false -tags=performance
+BUILD_FLAGS := -ldflags="-s -w $(SET_VER)" -trimpath -buildvcs=false -tags=performance
 
 # Flags for test build (debugging, race detection, and more)
-TEST_BUILD_FLAGS := -race -gcflags=all="-N -l" -trimpath -tags=debug
+TEST_BUILD_FLAGS := -ldflags="$(SET_VER)" -gcflags=all="-N -l" -trimpath -race -tags=debug
 
 # Default target: build for production
 all: build

--- a/main.go
+++ b/main.go
@@ -35,6 +35,16 @@ const (
 	ServerResponseTimeout   = 5 * time.Second
 )
 
+var (
+	Version   = "v0.1" //nolint:gochecknoglobals
+	GitCommit = ""     //nolint:gochecknoglobals
+	BuildID   = ""     //nolint:gochecknoglobals
+)
+
+func buildVersion() string {
+	return Version + " " + GitCommit + " " + BuildID
+}
+
 //nolint:gochecknoglobals
 var rootCmd = &cobra.Command{
 	Use:   "mongolink",
@@ -95,12 +105,23 @@ var rootCmd = &cobra.Command{
 
 		startMongoLink, _ := cmd.Flags().GetBool("start")
 
+		log.Ctx(cmd.Context()).Info("Percona MongoLink " + buildVersion())
+
 		return runServer(cmd.Context(), serverOptions{
 			port:      port,
 			sourceURI: sourceURI,
 			targetURI: targetURI,
 			start:     startMongoLink,
 		})
+	},
+}
+
+//nolint:gochecknoglobals
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version",
+	Run: func(cmd *cobra.Command, _ []string) {
+		cmd.Println(buildVersion())
 	},
 }
 
@@ -335,7 +356,15 @@ func main() {
 	resetCmd.Flags().String("target", "", "MongoDB connection string for the target")
 
 	resetCmd.AddCommand(resetRecoveryCmd, resetHeartbeatCmd)
-	rootCmd.AddCommand(statusCmd, startCmd, finalizeCmd, pauseCmd, resumeCmd, resetCmd)
+	rootCmd.AddCommand(
+		versionCmd,
+		statusCmd,
+		startCmd,
+		finalizeCmd,
+		pauseCmd,
+		resumeCmd,
+		resetCmd,
+	)
 
 	err := rootCmd.Execute()
 	if err != nil {


### PR DESCRIPTION
- add `version` command
  ```
  $ bin/percona-mongolink version
  v0.1 80182f6 2025-03-21T10:03:36Z
  ```
- print version on start
  ```
  $ bin/percona-mongolink        
  2025-03-21 10:03:41.432 INF Percona MongoLink v0.1 80182f6 2025-03-21T10:03:36Z
  ```
- `make build` and `make test-build` add git commit hash and unix time in ISO format to the binary