### PR TITLE
PML-19: Update event with trucatedArrays

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -44,13 +44,6 @@ func Elapsed(dur time.Duration) AttrFn {
 	}
 }
 
-// Fields sets random fields to the log.
-func Fields(fieldsAndValues ...any) AttrFn {
-	return func(l zerolog.Context) zerolog.Context {
-		return l.Fields(fieldsAndValues)
-	}
-}
-
 // Op sets the operation attribute.
 func Op(op string) AttrFn {
 	return func(l zerolog.Context) zerolog.Context {

--- a/mongolink/bulk.go
+++ b/mongolink/bulk.go
@@ -211,11 +211,15 @@ func (o *collectionBulkWrite) Delete(ns Namespace, event *DeleteEvent) {
 }
 
 func collectUpdateOps(event *UpdateEvent) any {
-	if len(event.UpdateDescription.TruncatedArrays) != 0 {
-		return collectUpdateOpsWithPipeline(event)
+	for _, trunc := range event.UpdateDescription.TruncatedArrays {
+		for _, update := range event.UpdateDescription.UpdatedFields {
+			if strings.HasPrefix(update.Key, trunc.Field) {
+				return collectUpdateOpsWithPipeline(event) // there is conflict field update
+			}
+		}
 	}
 
-	ops := make(bson.D, 0, 2) //nolint:mnd
+	ops := make(bson.D, 0, 1) //nolint:mnd
 
 	if len(event.UpdateDescription.UpdatedFields) != 0 {
 		ops = append(ops, bson.E{"$set", event.UpdateDescription.UpdatedFields})
@@ -229,6 +233,16 @@ func collectUpdateOps(event *UpdateEvent) any {
 		}
 
 		ops = append(ops, bson.E{"$unset", fields})
+	}
+
+	if len(event.UpdateDescription.TruncatedArrays) != 0 {
+		fields := make(bson.D, len(event.UpdateDescription.TruncatedArrays))
+		for i, field := range event.UpdateDescription.TruncatedArrays {
+			fields[i].Key = field.Field
+			fields[i].Value = bson.D{{"$each", bson.A{}}, {"$slice", field.NewSize}}
+		}
+
+		ops = append(ops, bson.E{"$push", fields})
 	}
 
 	return ops
@@ -295,7 +309,10 @@ func collectUpdateOpsWithPipeline(event *UpdateEvent) bson.A {
 
 	// Handle removed fields
 	if len(event.UpdateDescription.RemovedFields) != 0 {
-		pipeline = append(pipeline, bson.D{{Key: "$unset", Value: event.UpdateDescription.RemovedFields}})
+		pipeline = append(
+			pipeline,
+			bson.D{{Key: "$unset", Value: event.UpdateDescription.RemovedFields}},
+		)
 	}
 
 	return pipeline
@@ -310,8 +327,10 @@ func isArrayPath(field string, disambiguatedPaths map[string][]any) bool {
 				return true
 			}
 
-			return false
+			continue
 		}
+
+		return false
 	}
 
 	parts := strings.Split(field, ".")

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -26,10 +26,29 @@ def test_insert_many(t: Testing, phase: Runner.Phase):
 
 @pytest.mark.parametrize("phase", [Runner.Phase.APPLY, Runner.Phase.CLONE])
 def test_update_one(t: Testing, phase: Runner.Phase):
+    t.source["db_1"]["coll_1"].insert_many([{"i": i} for i in range(5)])
+    t.target["db_1"]["coll_1"].insert_many([{"i": i} for i in range(5)])
+
+    with t.run(phase):
+        for i in range(5):
+            t.source["db_1"]["coll_1"].update_one(
+                {"i": i},
+                {
+                    "$inc": {"i": (i * 100) - i},
+                    "$set": {f"field_{i}": f"value_{i}"},
+                },
+            )
+
+    t.compare_all()
+
+
+@pytest.mark.parametrize("phase", [Runner.Phase.APPLY, Runner.Phase.CLONE])
+def test_update_one_complex(t: Testing, phase: Runner.Phase):
     t.source["db_1"]["coll_1"].insert_many(
         [
             {
                 "i": i,
+                "j": i,
                 "a1": ["A", "B", "C", "D", "E"],
                 "a2": [1, 2, 3, 4, 5],
                 "f2": {"0": [{"i": i, "0": i} for i in range(5)], "1": "val"},
@@ -40,7 +59,7 @@ def test_update_one(t: Testing, phase: Runner.Phase):
     t.target["db_1"]["coll_1"].insert_many(
         [
             {
-                "i": i,
+                "j": i,
                 "a1": ["A", "B", "C", "D", "E"],
                 "a2": [1, 2, 3, 4, 5],
                 "f2": {"0": [{"i": i, "0": i} for i in range(5)], "1": "val"},
@@ -86,6 +105,124 @@ def test_update_one(t: Testing, phase: Runner.Phase):
             t.source["db_1"]["coll_1"].update_one(
                 {"i": i}, [{"$set": {"a2": {"$reverseArray": "$a2"}}}]
             )
+
+    t.compare_all()
+
+
+@pytest.mark.parametrize("phase", [Runner.Phase.APPLY, Runner.Phase.CLONE])
+def test_update_one_to_slice_array(t: Testing, phase: Runner.Phase):
+    docs = [{"_id": i, "arr": ["A", "B", "C", "D", "E", "F", "G"]} for i in range(4)]
+    t.source["db_1"]["coll_1"].insert_many(docs)
+    t.target["db_1"]["coll_1"].insert_many(docs)
+
+    with t.run(phase):
+        t.source["db_1"]["coll_1"].update_one(
+            {"_id": 0},
+            {"$push": {"arr": {"$each": [], "$slice": 3}}},
+        )
+        t.source["db_1"]["coll_1"].update_one(
+            {"_id": 1},
+            [{"$set": {"arr": {"$slice": ["$arr", 3]}}}],
+        )
+        t.source["db_1"]["coll_1"].update_one(
+            {"_id": 2},
+            [{"$set": {"arr": {"$slice": ["$arr", 1, 3]}}}],
+        )
+        t.source["db_1"]["coll_1"].update_one(
+            {"_id": 3},
+            {"$pull": {"arr": {"$in": ["C"]}}},
+        )
+
+        assert list(t.source["db_1"]["coll_1"].find(sort=[("_id", pymongo.ASCENDING)])) == [
+            {"_id": 0, "arr": ["A", "B", "C"]},
+            {"_id": 1, "arr": ["A", "B", "C"]},
+            {"_id": 2, "arr": ["B", "C", "D"]},
+            {"_id": 3, "arr": ["A", "B", "D", "E", "F", "G"]},
+        ]
+
+    t.compare_all()
+
+
+@pytest.mark.parametrize("phase", [Runner.Phase.APPLY, Runner.Phase.CLONE])
+def test_update_one_with_nested_path(t: Testing, phase: Runner.Phase):
+    docs = [
+        {"_id": 0, "a": {"0": "val"}},
+        {"_id": 1, "a": {"0": "val"}},
+        {"_id": 2, "a": ["val"]},
+        {"_id": 3, "a": {"0": ["val"]}},
+        {"_id": 4, "a": [{"0": "val"}]},
+        {"_id": 5, "a": {"0": ["val"]}},
+        {"_id": 6},
+    ]
+    t.source["db_1"]["coll_1"].insert_many(docs)
+    t.target["db_1"]["coll_1"].insert_many(docs)
+
+    with t.run(phase):
+        t.source["db_1"]["coll_1"].update_one({"_id": 0}, {"$set": {"a": {"0": "changed"}}})
+        t.source["db_1"]["coll_1"].update_one({"_id": 1}, {"$set": {"a.0": "changed"}})
+        t.source["db_1"]["coll_1"].update_one({"_id": 2}, {"$set": {"a.0": "changed"}})
+        t.source["db_1"]["coll_1"].update_one({"_id": 3}, {"$set": {"a.0.0": "changed"}})
+        t.source["db_1"]["coll_1"].update_one({"_id": 4}, {"$set": {"a.0.0": "changed"}})  # fails
+        t.source["db_1"]["coll_1"].update_one({"_id": 5}, {"$set": {"a": {"0.0": "changed"}}})
+        t.source["db_1"]["coll_1"].update_one({"_id": 6}, {"$set": {"a.0": {"0.0": "changed"}}})
+
+        assert list(t.source["db_1"]["coll_1"].find(sort=[("_id", pymongo.ASCENDING)])) == [
+            {"_id": 0, "a": {"0": "changed"}},
+            {"_id": 1, "a": {"0": "changed"}},
+            {"_id": 2, "a": ["changed"]},
+            {"_id": 3, "a": {"0": ["changed"]}},
+            {"_id": 4, "a": [{"0": "changed"}]},
+            {"_id": 5, "a": {"0.0": "changed"}},
+            {"_id": 6, "a": {"0": {"0.0": "changed"}}},
+        ]
+
+    t.compare_all()
+
+
+@pytest.mark.parametrize("phase", [Runner.Phase.APPLY, Runner.Phase.CLONE])
+def test_update_one_multiple_arrays(t: Testing, phase: Runner.Phase):
+    doc = {
+        "_id": "",
+        "a": ["A", "B", "C", "D", "E", "F", "G", "H", "I"],
+        "b": {"0": ["val1", "val2", "val3"]},
+    }
+    t.source["db_1"]["coll_1"].insert_one(doc)
+    t.target["db_1"]["coll_1"].insert_one(doc)
+
+    with t.run(phase):
+        t.source["db_1"]["coll_1"].update_one(
+            {"_id": ""},
+            [
+                {
+                    "$set": {
+                        "a": {
+                            "$filter": {
+                                "input": "$a",
+                                "as": "arr",
+                                "cond": {"$ne": ["$$arr", "C"]},
+                            }
+                        }
+                    }
+                },
+                {
+                    "$set": {
+                        "b.0": {
+                            "$concatArrays": [
+                                {"$slice": ["$b.0", 1]},
+                                ["changed2"],
+                                {"$slice": ["$b.0", 2, {"$size": "$b.0"}]},
+                            ],
+                        }
+                    }
+                },
+            ],
+        )
+
+        assert t.source["db_1"]["coll_1"].find_one({"_id": ""}) == {
+            "_id": "",
+            "a": ["A", "B", "D", "E", "F", "G", "H", "I"],
+            "b": {"0": ["val1", "changed2", "val3"]},
+        }
 
     t.compare_all()
 


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PML-19

PR implements support for `updateDescription.truncatedArrays` field in a update event.

It generates update command with pipeline to recreate the update event. Update command with a pipeline is generated only if `truncatedArrays` are present in the event since it is more memory heavy than regular update command with regular update operators (non pipeline).

As an example, for the update change event like this:
```json
{
  "ts": "1746869737.002",
  "ns": "test.employee",
  "op": "u",
  "updateDesc": {
    "updatedFields": {
      "projects.2": "D",
      "projects.3": "E",
      "tt.home": "NEW VAL"
    },
    "removedFields": [
      "department",
      "salary"
    ],
    "truncatedArrays": [
      {
        "field": "projects",
        "newSize": 4
      },
      {
        "field": "tt.22",
        "newSize": 1
      }
    ],
    "disambiguatedPaths": {
      "tt.22": [
        "tt",
        "22"
      ]
    }
  }
}
```

PML will create update command with pipeline operations like this:
```json
[
  {
    "$set": {
      "projects": {
        "$slice": [
          "$projects",
          4
        ]
      }
    }
  },
  {
    "$set": {
      "tt.22": {
        "$slice": [
          "$tt.22",
          1
        ]
      }
    }
  },
  {
    "$set": {
      "projects": {
        "$concatArrays": [
          {
            "$slice": [
              "$projects",
              2
            ]
          },
          [
            "D"
          ],
          {
            "$slice": [
              "$projects",
              3,
              {
                "$size": "$projects"
              }
            ]
          }
        ]
      }
    }
  },
  {
    "$set": {
      "projects": {
        "$concatArrays": [
          {
            "$slice": [
              "$projects",
              3
            ]
          },
          [
            "E"
          ],
          {
            "$slice": [
              "$projects",
              4,
              {
                "$size": "$projects"
              }
            ]
          }
        ]
      }
    }
  },
  {
    "$set": {
      "tt.home": "NEW VAL"
    }
  },
  {
    "$unset": [
      "department",
      "salary"
    ]
  }
]
```

Setting a particular array element is done with a pipeline stage like this. Example, setting a element at index 2 of the `projects` array to new value of `D`:
```json
  {
    "$set": {
      "projects": {
        "$concatArrays": [
          {
            "$slice": [
              "$projects",
              2
            ]
          },
          [
            "D"
          ],
          {
            "$slice": [
              "$projects",
              3,
              {
                "$size": "$projects"
              }
            ]
          }
        ]
      }
    }
  },
```