### PR TITLE
PML-118: Exclude indexes being built at the moment of getting the all indexes from source

### DIFF
--- a/mongolink/catalog.go
+++ b/mongolink/catalog.go
@@ -363,7 +363,7 @@ func (c *Catalog) CreateIndexes(
 	// NOTE: [mongo.IndexView.CreateMany] uses [mongo.IndexModel]
 	// which does not support `prepareUnique`.
 	for _, index := range idxs {
-		if !index.IsIncomplete() {
+		if index.Ready() {
 			res := c.target.Database(db).RunCommand(ctx, bson.D{
 				{"createIndexes", coll},
 				{"indexes", bson.A{index}},
@@ -628,7 +628,7 @@ func (c *Catalog) Finalize(ctx context.Context) error {
 	for db, colls := range c.Databases {
 		for coll, collEntry := range colls.Collections {
 			for _, index := range collEntry.Indexes {
-				if index.IsIncomplete() {
+				if !index.Ready() {
 					lg.Warnf("Index %s on %s.%s was incomplete during replication, skipping it",
 						index.Name, db, coll)
 

--- a/topo/schema.go
+++ b/topo/schema.go
@@ -84,8 +84,8 @@ func (s *IndexSpecification) IsClustered() bool {
 	return s.Clustered != nil && *s.Clustered
 }
 
-func (s *IndexSpecification) IsIncomplete() bool {
-	return s.Incomplete
+func (s *IndexSpecification) Ready() bool {
+	return !s.Incomplete
 }
 
 func ListDatabaseNames(ctx context.Context, m *mongo.Client) ([]string, error) {
@@ -151,12 +151,6 @@ func ListIndexes(
 	if err != nil {
 		return nil, errors.Wrap(err, "list indexes")
 	}
-	defer func() {
-		err := cur.Close(ctx)
-		if err != nil {
-			log.Ctx(ctx).Errorf(err, "close cursor")
-		}
-	}()
 
 	var indexes []*IndexSpecification
 
@@ -184,7 +178,7 @@ func ListIndexes(
 		return indexes, nil
 	}
 
-	inprogIndexes := make(map[string]struct{}, 0)
+	inprogIndexes := make(map[string]struct{})
 
 	for _, inprog := range currOp.Inprog {
 		for _, index := range inprog.Command.Indexes {


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PML-118

**Problem**
Issue was that when PML clone start, when creating collections we also do `getIndexes` and create those as well on the collection. Since `getIndexes` returns *all* indexes, the ones that are ready and the ones that are being built, the problem can arise when PML creates a index that after that moment is failed for some reason.

Now on the target we have a index that is actually not present on the source, and besides that, it can happen that clone fails with failed data inserts because of this failed index.

**Solution**
When PML call `ListIndexes` to get all indexes for a collection, now PML calls `db.currentOp({ "command.createIndexes": { $exists: true } })` to see if there are indexes that are in progress and if there are any, PML marks them as `incomplete` and adds them to catalog without creating them.

This can be seen in the logs:
```
2025-05-16 07:18:40.170 WRN Index a.b_1_words_text build in progress, marking it as incomplete ns=init_test_db.invalid_text_collection1 s=copy
```

And in the catalog it will be stored like this:
```
{
  "catalog": {
    "init_test_db": {
      "collections": {
        "invalid_text_collection1": {
          "addedat": {
            "t": 1747309708,
            "i": 106
          },
          "indexes": [
            {
              "name": "_id_",
              "ns": "",
              "key": { "_id": 1 },
              "v": 2,
              "ready": null
            },
            {
              "name": "a.b_1_words_text",
              "ns": "",
              "key": { "a.b": 1, "_fts": "text", "_ftsx": 1 },
              "v": 2,
              "weights": { "words": 1 },
              "default_language": "english",
              "language_override": "language",
              "textIndexVersion": 3,
              "incomplete": true                                    <==========================               
            }
          ]
        }
      }
    }
  }
}
```

Later, when `finalize` is called, if PML encounters indexes marked as incomplete, it will skip them with a log message like:
```
2025-05-16 07:18:48.341 WRN Index a.b_1_words_text on init_test_db.invalid_text_collection1 was incomplete during replication, skipping it
```