### PR TITLE
PLM-160: Improve CI e2e tests

### DIFF
--- a/.github/workflows/e2etests.yml
+++ b/.github/workflows/e2etests.yml
@@ -41,28 +41,14 @@ jobs:
         run: |
           make test-build
 
-      - name: Run PLM
-        run: |
-          echo "Starting project..."
-          bin/plm_test \
-            --source="mongodb://source:pass@rs00:30000" \
-            --target="mongodb://target:pass@rs10:30100" \
-            --reset-state --start --log-level debug &> server.log &
-          echo $! > server.pid
-          sleep 5
-          echo "Project started with PID $(cat server.pid)"
-          cat server.log
-
       - name: Run tests (pytest)
         run: |
           export TEST_SOURCE_URI=mongodb://adm:pass@rs00:30000
           export TEST_TARGET_URI=mongodb://adm:pass@rs10:30100
           export TEST_PLM_URL=http://127.0.0.1:2242
-          poetry run pytest
+          export TEST_PLM_BIN=./bin/plm_test
 
-      - name: Show server logs (on failure)
-        if: failure()
-        run: tail -n 500 server.log
+          poetry run pytest
 
       - name: Teardown Docker Compose
         if: always()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,7 +81,7 @@ def drop_all_database(source_conn: MongoClient, target_conn: MongoClient):
     testing.drop_all_database(target_conn)
 
 
-PML_PROC: subprocess.Popen = None
+PLM_PROC: subprocess.Popen = None
 
 
 def start_plm(plm_bin: str, request: pytest.FixtureRequest):
@@ -104,15 +104,15 @@ def manage_plm_process(request: pytest.FixtureRequest, plm_bin: str):
         yield
         return
 
-    global PML_PROC  # pylint: disable=W0603
-    PML_PROC = start_plm(plm_bin, request)
+    global PLM_PROC  # pylint: disable=W0603
+    PLM_PROC = start_plm(plm_bin, request)
 
     def teardown():
-        if PML_PROC and PML_PROC.poll() is None:
-            stop_plm(PML_PROC)
+        if PLM_PROC and PLM_PROC.poll() is None:
+            stop_plm(PLM_PROC)
 
     request.addfinalizer(teardown)
-    yield PML_PROC
+    yield PLM_PROC
 
 
 @pytest.hookimpl(hookwrapper=True)
@@ -129,7 +129,7 @@ def restart_plm_on_failure(request: pytest.FixtureRequest, plm_bin: str):
 
     if hasattr(request.node, "rep_call") and request.node.rep_call.failed:
         # the test failed. restart plm process with a new state
-        global PML_PROC  # pylint: disable=W0603
-        if PML_PROC and plm_bin:
-            stop_plm(PML_PROC)
-            PML_PROC = start_plm(plm_bin, request)
+        global PLM_PROC  # pylint: disable=W0603
+        if PLM_PROC and plm_bin:
+            stop_plm(PLM_PROC)
+            PLM_PROC = start_plm(plm_bin, request)

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -125,7 +125,7 @@ def test_create_view_with_collation(t: Testing, phase: Runner.Phase):
     t.compare_all()
 
 
-@pytest.mark.timeout(15)
+@pytest.mark.timeout(20)
 @pytest.mark.parametrize("phase", [Runner.Phase.APPLY, Runner.Phase.CLONE])
 def test_create_timeseries_ignored(t: Testing, phase: Runner.Phase):
     with t.run(phase):
@@ -327,7 +327,7 @@ def test_modify_view(t: Testing, phase: Runner.Phase):
     t.compare_all()
 
 
-@pytest.mark.timeout(15)
+@pytest.mark.timeout(20)
 @pytest.mark.parametrize("phase", [Runner.Phase.APPLY, Runner.Phase.CLONE])
 def test_modify_timeseries_options_ignored(t: Testing, phase: Runner.Phase):
     t.source["db_1"].create_collection(

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -2,6 +2,7 @@
 import random
 from datetime import datetime
 
+import time
 import pytest
 import testing
 from plm import PLM, Runner
@@ -597,6 +598,8 @@ def test_plm_110_rename_during_clone_and_repl(t: Testing):
     with t.run(phase=Runner.Phase.MANUAL) as r:
         r.start()
         r.wait_for_state(PLM.State.RUNNING)
+
+        time.sleep(1)  # ensure actual clone has started
 
         for ns in testing.list_all_namespaces(t.source):
             t.source.admin.command({"renameCollection": ns, "to": ns + "_renamed"})


### PR DESCRIPTION
[![PLM-160](https://badgen.net/badge/JIRA/PLM-160/green)](https://jira.percona.com/browse/PLM-160) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Run e2e tests with managed PLM process, not running PLM manually as a job step.

PR fixes running managed PLM process in test fixtures, increases timeout for two specific tests and minor refactor (renaming `PML_PROC` var name to `PLM_PROC`)

Also fixes correct execution of `test_plm_110_rename_during_clone_and_repl` test.

[PLM-160]: https://perconadev.atlassian.net/browse/PLM-160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ