### PR TITLE
PLM-131: Failed index reports and recreate

### DIFF
--- a/plm/catalog.go
+++ b/plm/catalog.go
@@ -463,7 +463,7 @@ func (c *Catalog) AddIncompleteIndexes(
 	c.addIndexesToCatalog(ctx, db, coll, indexEntries)
 }
 
-// AddFailedIndexes adds indexes in the catalog that failed to crate on the target cluster.
+// AddFailedIndexes adds indexes in the catalog that failed to create on the target cluster.
 // The indexes have set [indexCatalogEntry.Failed] flag.
 func (c *Catalog) AddFailedIndexes(
 	ctx context.Context,

--- a/plm/catalog.go
+++ b/plm/catalog.go
@@ -858,7 +858,7 @@ func (c *Catalog) finalizeSkippedIndexes(ctx context.Context) {
 	lg.Info("Finalizing skipped indexes")
 
 	// create index as is, wihtout any temporary modifications
-	createIndex := func(db string, coll string, idx *topo.IndexSpecification,
+	createIndex := func(db, coll string, idx *topo.IndexSpecification,
 	) error {
 		if idx == nil {
 			lg.Error(nil, "No index to create")

--- a/plm/catalog.go
+++ b/plm/catalog.go
@@ -767,6 +767,7 @@ func (c *Catalog) Finalize(ctx context.Context) error {
 			for _, index := range collEntry.Indexes {
 				if !index.Ready() || index.Failed {
 					finalizeSkipped = true
+
 					continue
 				}
 

--- a/plm/plm.go
+++ b/plm/plm.go
@@ -620,7 +620,7 @@ func (ml *PLM) Finalize(ctx context.Context, options FinalizeOptions) error {
 		return errors.New("initial sync is not completed")
 	}
 
-	lg := log.Ctx(ctx)
+	lg := log.New("finalize")
 	lg.Info("Starting Finalization")
 
 	if status.Repl.IsRunning() {
@@ -663,7 +663,7 @@ func (ml *PLM) Finalize(ctx context.Context, options FinalizeOptions) error {
 		go ml.onStateChanged(StateFinalized)
 	}()
 
-	log.New("plm").Info("Finalizing")
+	lg.Info("Finalizing")
 
 	go ml.onStateChanged(StateFinalizing)
 

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -509,10 +509,7 @@ def test_continue_creating_indexes_if_some_fail(t: Testing, phase: Runner.Phase)
             name="idx_3",
         )
 
-    target_idx_count = len(t.target["db_1"]["coll_1"].index_information())
-    source_idx_count = len(t.source["db_1"]["coll_1"].index_information())
-
-    assert source_idx_count - 1 == target_idx_count
+    t.compare_all()
 
 
 def test_plm_95_drop_index_for_non_existing_namespace(t: Testing):

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -33,6 +33,15 @@ def test_create_unique(t: Testing, phase: Runner.Phase):
 
 
 @pytest.mark.parametrize("phase", [Runner.Phase.APPLY, Runner.Phase.CLONE])
+def test_create_non_unique_with_the_same_fields_as_unique(t: Testing, phase: Runner.Phase):
+    with t.run(phase):
+        t.source["db_1"]["coll_1"].create_index({"i": 1}, unique=True, name="unique_idx")
+        t.source["db_1"]["coll_1"].create_index({"i": 1}, name="non_unique_idx")
+
+    t.compare_all()
+
+
+@pytest.mark.parametrize("phase", [Runner.Phase.APPLY, Runner.Phase.CLONE])
 def test_create_prepare_unique(t: Testing, phase: Runner.Phase):
     with t.run(phase):
         t.source["db_1"]["coll_1"].create_index({"i": 1}, prepareUnique=True)


### PR DESCRIPTION
[![PLM-131](https://badgen.net/badge/JIRA/PLM-131/green)](https://jira.percona.com/browse/PLM-131) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Problem:**
Failed indexes can be easily missed in the logs and when finalization comes, the user can't see failed indexes unless manually checking target cluster and comparing to the source.

**Solution:**
PR fixes this by reporting failed indexes during finalization.

Besides this, now PLM will try to recreate during finalization failed indexes and indexes that were skipped because their build was in progress at the time of replication.

What this gives us is the ability to replicate unique and non-unique indexes that have the same fields. Before this it was not possible to replicate them since PLM will create unique as non-unique and then modify them in finalize step.

With this change PLM will track all failed indexes and in finalize stage it will first modify non-unique to unique and then create original non-unique (that originally failed due to having same fields).

[PLM-131]: https://perconadev.atlassian.net/browse/PLM-131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ