### PR TITLE
PLM-126: Handle collections with NaN ID document

### DIFF
--- a/plm/copy.go
+++ b/plm/copy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -204,6 +205,12 @@ func (cm *CopyManager) copyCollection(
 	isCapped, _ := spec.Options.Lookup("capped").BooleanOK()
 
 	var nextSegment nextSegmentFunc
+
+	readResultC := make(chan readBatchResult)
+
+	var batchID atomic.Uint32
+	var nextID nextBatchIDFunc = func() uint32 { return batchID.Add(1) }
+
 	if isCapped { //nolint:nestif
 		segmenter, err := NewCappedSegmenter(ctx,
 			cm.source, namespace, cm.options.ReadBatchSizeBytes)
@@ -234,13 +241,14 @@ func (cm *CopyManager) copyCollection(
 		}
 
 		nextSegment = segmenter.Next
+
+		go segmenter.handleNanDoc(readResultC, nextID)
 	}
 
 	collectionReadCtx, stopCollectionRead := context.WithCancel(ctx)
 
 	// pendingSegments tracks in-progress read segments
 	pendingSegments := &sync.WaitGroup{}
-	readResultC := make(chan readBatchResult)
 
 	allBatchesSent := make(chan struct{}) // closes when all batches are sent to inserters
 
@@ -260,8 +268,6 @@ func (cm *CopyManager) copyCollection(
 	// spawn readSegment in loop until the collection is exhausted or canceled.
 	go func() {
 		var segmentID uint32
-		var batchID atomic.Uint32
-		var nextID nextBatchIDFunc = func() uint32 { return batchID.Add(1) }
 
 		readStopped := collectionReadCtx.Done()
 
@@ -297,6 +303,7 @@ func (cm *CopyManager) copyCollection(
 			}
 
 			pendingSegments.Add(1)
+
 			go func() {
 				defer func() {
 					<-cm.readLimit
@@ -560,6 +567,7 @@ type Segmenter struct {
 	batchSize   int32
 	keyRanges   []keyRange
 	currIDRange keyRange
+	nanDoc      bson.Raw // document with NaN _id, if any
 }
 
 type keyRange struct {
@@ -625,7 +633,7 @@ func NewSegmenter(
 
 	mcoll := m.Database(ns.Database).Collection(ns.Collection)
 
-	idKeyRange, err := getIDKeyRange(ctx, mcoll)
+	idKeyRange, nanDoc, err := getIDKeyRange(ctx, mcoll)
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
 			return nil, errEOC // empty collection
@@ -640,6 +648,7 @@ func NewSegmenter(
 			segmentSize: segmentSize,
 			batchSize:   batchSize,
 			currIDRange: idKeyRange,
+			nanDoc:      *nanDoc,
 		}
 
 		return s, nil
@@ -770,21 +779,65 @@ func (seg *Segmenter) findSegmentMaxKey(
 	return raw.Lookup("_id"), nil
 }
 
+// handleNanDoc sends a document with NaN _id to the readResultC channel if it exists.
+func (seg *Segmenter) handleNanDoc(
+	readResults chan<- readBatchResult,
+	nextID nextBatchIDFunc,
+) {
+	if len(seg.nanDoc) == 0 {
+		return
+	}
+
+	readResults <- readBatchResult{
+		ID:        nextID(),
+		Documents: []any{seg.nanDoc},
+		SizeBytes: len(seg.nanDoc),
+	}
+}
+
 // getIDKeyRange returns the minimum and maximum _id values in the collection.
 // It uses two FindOne operations with sort directions of 1 (ascending) and -1 (descending)
 // to determine the full _id range. This is used to define the collection boundaries
 // when the _id type is uniform across all documents.
-func getIDKeyRange(ctx context.Context, mcoll *mongo.Collection) (keyRange, error) {
+func getIDKeyRange(ctx context.Context, mcoll *mongo.Collection) (keyRange, *bson.Raw, error) {
 	findOptions := options.FindOne().SetSort(bson.D{{"_id", 1}}).SetProjection(bson.D{{"_id", 1}})
+
 	minRaw, err := mcoll.FindOne(ctx, bson.D{}, findOptions).Raw()
 	if err != nil {
-		return keyRange{}, errors.Wrap(err, "min _id")
+		return keyRange{}, nil, errors.Wrap(err, "min _id")
+	}
+
+	nanDoc := bson.Raw{}
+
+	if strings.Contains(minRaw.Lookup("_id").DebugString(), "NaN") {
+		nanDoc = minRaw
+
+		findOptions = options.FindOne().SetSort(bson.D{{"_id", 1}}).
+			SetProjection(bson.D{{"_id", 1}}).SetSkip(1)
+
+		minRaw, err = mcoll.FindOne(ctx, bson.D{}, findOptions).Raw()
+		if err != nil {
+			return keyRange{}, nil, errors.Wrap(err, "min _id (next document)")
+		}
 	}
 
 	findOptions = options.FindOne().SetSort(bson.D{{"_id", -1}}).SetProjection(bson.D{{"_id", 1}})
+
 	maxRaw, err := mcoll.FindOne(ctx, bson.D{}, findOptions).Raw()
 	if err != nil {
-		return keyRange{}, errors.Wrap(err, "max _id")
+		return keyRange{}, nil, errors.Wrap(err, "max _id")
+	}
+
+	if strings.Contains(maxRaw.Lookup("_id").DebugString(), "NaN") {
+		nanDoc = maxRaw
+
+		findOptions = options.FindOne().SetSort(bson.D{{"_id", -1}}).
+			SetProjection(bson.D{{"_id", 1}}).SetSkip(1)
+
+		maxRaw, err = mcoll.FindOne(ctx, bson.D{}, findOptions).Raw()
+		if err != nil {
+			return keyRange{}, nil, errors.Wrap(err, "min _id (next document)")
+		}
 	}
 
 	ret := keyRange{
@@ -792,7 +845,7 @@ func getIDKeyRange(ctx context.Context, mcoll *mongo.Collection) (keyRange, erro
 		Max: maxRaw.Lookup("_id"),
 	}
 
-	return ret, nil
+	return ret, &nanDoc, nil
 }
 
 // getIDKeyRangeByType returns a slice of keyRange grouped by the BSON type of the _id field.
@@ -812,6 +865,7 @@ func getIDKeyRangeByType(ctx context.Context, mcoll *mongo.Collection) ([]keyRan
 	}
 
 	var segmentRanges []keyRange
+
 	err = cur.All(ctx, &segmentRanges)
 	if err != nil {
 		return nil, errors.Wrap(err, "all")

--- a/plm/copy.go
+++ b/plm/copy.go
@@ -242,7 +242,7 @@ func (cm *CopyManager) copyCollection(
 
 		nextSegment = segmenter.Next
 
-		go segmenter.handleNanDoc(readResultC, nextID)
+		go segmenter.handleNanIDDoc(readResultC, nextID)
 	}
 
 	collectionReadCtx, stopCollectionRead := context.WithCancel(ctx)
@@ -779,8 +779,8 @@ func (seg *Segmenter) findSegmentMaxKey(
 	return raw.Lookup("_id"), nil
 }
 
-// handleNanDoc sends a document with NaN _id to the readResultC channel if it exists.
-func (seg *Segmenter) handleNanDoc(
+// handleNanIDDoc sends a document with NaN _id to the readResultC channel if it exists.
+func (seg *Segmenter) handleNanIDDoc(
 	readResults chan<- readBatchResult,
 	nextID nextBatchIDFunc,
 ) {

--- a/plm/copy.go
+++ b/plm/copy.go
@@ -801,9 +801,8 @@ func (seg *Segmenter) handleNanIDDoc(
 // to determine the full _id range. This is used to define the collection boundaries
 // when the _id type is uniform across all documents.
 func getIDKeyRange(ctx context.Context, mcoll *mongo.Collection) (keyRange, *bson.Raw, error) {
-	findOptions := options.FindOne().SetSort(bson.D{{"_id", 1}}).SetProjection(bson.D{{"_id", 1}})
-
-	minRaw, err := mcoll.FindOne(ctx, bson.D{}, findOptions).Raw()
+	minRaw, err := mcoll.FindOne(ctx, bson.D{},
+		options.FindOne().SetSort(bson.D{{"_id", 1}}).SetProjection(bson.D{{"_id", 1}})).Raw()
 	if err != nil {
 		return keyRange{}, nil, errors.Wrap(err, "min _id")
 	}
@@ -813,18 +812,16 @@ func getIDKeyRange(ctx context.Context, mcoll *mongo.Collection) (keyRange, *bso
 	if strings.Contains(minRaw.Lookup("_id").DebugString(), "NaN") {
 		nanDoc = minRaw
 
-		findOptions = options.FindOne().SetSort(bson.D{{"_id", 1}}).
-			SetProjection(bson.D{{"_id", 1}}).SetSkip(1)
-
-		minRaw, err = mcoll.FindOne(ctx, bson.D{}, findOptions).Raw()
+		minRaw, err = mcoll.FindOne(ctx, bson.D{},
+			options.FindOne().SetSort(bson.D{{"_id", 1}}).SetProjection(bson.D{{"_id", 1}}).SetSkip(1)).
+			Raw()
 		if err != nil {
 			return keyRange{}, nil, errors.Wrap(err, "min _id (next document)")
 		}
 	}
 
-	findOptions = options.FindOne().SetSort(bson.D{{"_id", -1}}).SetProjection(bson.D{{"_id", 1}})
-
-	maxRaw, err := mcoll.FindOne(ctx, bson.D{}, findOptions).Raw()
+	maxRaw, err := mcoll.FindOne(ctx, bson.D{},
+		options.FindOne().SetSort(bson.D{{"_id", -1}}).SetProjection(bson.D{{"_id", 1}})).Raw()
 	if err != nil {
 		return keyRange{}, nil, errors.Wrap(err, "max _id")
 	}
@@ -832,10 +829,9 @@ func getIDKeyRange(ctx context.Context, mcoll *mongo.Collection) (keyRange, *bso
 	if strings.Contains(maxRaw.Lookup("_id").DebugString(), "NaN") {
 		nanDoc = maxRaw
 
-		findOptions = options.FindOne().SetSort(bson.D{{"_id", -1}}).
-			SetProjection(bson.D{{"_id", 1}}).SetSkip(1)
-
-		maxRaw, err = mcoll.FindOne(ctx, bson.D{}, findOptions).Raw()
+		maxRaw, err = mcoll.FindOne(ctx, bson.D{},
+			options.FindOne().SetSort(bson.D{{"_id", -1}}).SetProjection(bson.D{{"_id", 1}}).SetSkip(1)).
+			Raw()
 		if err != nil {
 			return keyRange{}, nil, errors.Wrap(err, "min _id (next document)")
 		}

--- a/plm/copy.go
+++ b/plm/copy.go
@@ -816,7 +816,7 @@ func getIDKeyRange(ctx context.Context, mcoll *mongo.Collection) (keyRange, *bso
 			options.FindOne().SetSort(bson.D{{"_id", 1}}).SetProjection(bson.D{{"_id", 1}}).SetSkip(1)).
 			Raw()
 		if err != nil {
-			return keyRange{}, nil, errors.Wrap(err, "min _id (next document)")
+			return keyRange{}, nil, errors.Wrap(err, "min _id (skip NaN)")
 		}
 	}
 
@@ -833,7 +833,7 @@ func getIDKeyRange(ctx context.Context, mcoll *mongo.Collection) (keyRange, *bso
 			options.FindOne().SetSort(bson.D{{"_id", -1}}).SetProjection(bson.D{{"_id", 1}}).SetSkip(1)).
 			Raw()
 		if err != nil {
-			return keyRange{}, nil, errors.Wrap(err, "min _id (next document)")
+			return keyRange{}, nil, errors.Wrap(err, "max _id (skip NaN)")
 		}
 	}
 

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -589,6 +589,7 @@ def test_plm_109_rename_complex(t: Testing, phase: Runner.Phase):
 
     t.compare_all()
 
+
 @pytest.mark.timeout(30)
 def test_plm_110_rename_during_clone_and_repl(t: Testing):
     payload = random.randbytes(1000)
@@ -626,5 +627,18 @@ def test_plm_110_rename_during_clone_and_repl(t: Testing):
         for ns in testing.list_all_namespaces(t.source):
             db, coll = ns.split(".", 1)
             t.source[db][coll].insert_many({"payload": payload} for _ in range(500))
+
+    t.compare_all()
+
+
+def test_plm_126_clone_with_nan_id_document(t: Testing):
+    t.source["db_1"]["coll_1"].insert_one({"_id": float("nan"), "i": 100})
+    t.source["db_1"]["coll_1"].insert_many(
+        [{"_id": random.uniform(1e5, 1e10), "i": i} for i in range(50)]
+    )
+
+    with t.run(phase=Runner.Phase.CLONE) as r:
+        r.start()
+        r.wait_for_clone_completed()
 
     t.compare_all()

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -632,13 +632,13 @@ def test_plm_110_rename_during_clone_and_repl(t: Testing):
     t.compare_all()
 
 
-def test_plm_126_clone_with_nan_id_document(t: Testing):
+def test_clone_with_nan_id_document(t: Testing):
     t.source["db_1"]["coll_1"].insert_one({"_id": float("nan"), "i": 100})
     t.source["db_1"]["coll_1"].insert_many(
         [{"_id": random.uniform(1e5, 1e10), "i": i} for i in range(50)]
     )
 
-    with t.run(phase=Runner.Phase.CLONE) as r:
+    with t.run(phase=Runner.Phase.MANUAL) as r:
         r.start()
         r.wait_for_clone_completed()
 
@@ -647,7 +647,6 @@ def test_plm_126_clone_with_nan_id_document(t: Testing):
     assert sourceDocCount == targetDocCount
 
 
-@pytest.mark.skip(reason="Clone with NaN _id is not supported for multi-id types")
 def test_clone_with_nan_id_document_multi_id_types(t: Testing):
     t.source["db_1"]["coll_1"].insert_one({"_id": Decimal128("NaN"), "i": 200})
     t.source["db_1"]["coll_1"].insert_many(
@@ -657,11 +656,13 @@ def test_clone_with_nan_id_document_multi_id_types(t: Testing):
         [{"_id": Decimal128(str(random.uniform(1e5, 1e10))), "i": i} for i in range(50)]
     )
     t.source["db_1"]["coll_1"].insert_many(
-        [{"_id": "inel" + str(random.uniform(1e5, 1e10)), "i": i} for i in range(50)]
+        [{"_id": str(random.uniform(1e5, 1e10)), "i": i} for i in range(50)]
     )
 
-    with t.run(phase=Runner.Phase.CLONE) as r:
+    with t.run(phase=Runner.Phase.MANUAL) as r:
         r.start()
         r.wait_for_clone_completed()
 
-    t.compare_all()
+    sourceDocCount = t.source["db_1"]["coll_1"].count_documents({})
+    targetDocCount = t.target["db_1"]["coll_1"].count_documents({})
+    assert sourceDocCount == targetDocCount


### PR DESCRIPTION
[![PLM-126](https://badgen.net/badge/JIRA/PLM-126/green)](https://jira.percona.com/browse/PLM-126) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Problem**

When there is a `NaN` `_id` document in a collection it will always be smallest or largest and because of that it breaks PLM segmenter. In particular when we query documents with keyrange that contains `NaN` as min or max key ID, the query returns no results. Because of that PLM doesn't clone the whole collection or first or last segment of a collection if there are multiple segments to be cloned.

Similar thing happens for multi-type ID collection, where depending on the type, a type group can have `NaN` id as its min or max and thus cause the same issue.

**Solution**
If we see there is a `NaN` id document, we write it separately and we skip that document when we return the keyrange (or exclude it from the result for multi-type ID collections).

[PLM-126]: https://perconadev.atlassian.net/browse/PLM-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ