### PR TITLE
PLM-173: Improve locking in catalog

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @inelpandzic
+* @inelpandzic @boris-ilijic

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @inelpandzic @boris-ilijic
+* @inelpandzic

--- a/plm/catalog.go
+++ b/plm/catalog.go
@@ -160,7 +160,6 @@ func (c *Catalog) CreateCollection(
 	coll string,
 	opts *CreateCollectionOptions,
 ) error {
-
 	if opts.ViewOn != "" {
 		if strings.HasPrefix(opts.ViewOn, TimeseriesPrefix) {
 			return errors.New("timeseries is not supported: " + db + "." + coll)
@@ -270,7 +269,6 @@ func (c *Catalog) doCreateView(
 
 // DropCollection drops a collection in the target MongoDB.
 func (c *Catalog) DropCollection(ctx context.Context, db, coll string) error {
-
 	err := runWithRetry(ctx, func(ctx context.Context) error {
 		return c.target.Database(db).Collection(coll).Drop(ctx)
 	})
@@ -289,7 +287,6 @@ func (c *Catalog) DropCollection(ctx context.Context, db, coll string) error {
 
 // DropDatabase drops a database in the target MongoDB.
 func (c *Catalog) DropDatabase(ctx context.Context, db string) error {
-
 	lg := log.Ctx(ctx)
 
 	colls, err := topo.ListCollectionNames(ctx, c.target, db)
@@ -505,7 +502,6 @@ func (c *Catalog) ModifyCappedCollection(
 	sizeBytes *int64,
 	maxDocs *int64,
 ) error {
-
 	cmd := bson.D{{"collMod", coll}}
 	if sizeBytes != nil {
 		cmd = append(cmd, bson.E{"cappedSize", sizeBytes})
@@ -522,7 +518,6 @@ func (c *Catalog) ModifyCappedCollection(
 
 // ModifyView modifies a view in the target MongoDB.
 func (c *Catalog) ModifyView(ctx context.Context, db, view, viewOn string, pipeline any) error {
-
 	cmd := bson.D{
 		{"collMod", view},
 		{"viewOn", viewOn},
@@ -540,7 +535,6 @@ func (c *Catalog) ModifyChangeStreamPreAndPostImages(
 	coll string,
 	enabled bool,
 ) error {
-
 	cmd := bson.D{
 		{"collMod", coll},
 		{"changeStreamPreAndPostImages", bson.D{{"enabled", enabled}}},
@@ -560,7 +554,6 @@ func (c *Catalog) ModifyValidation(
 	validationLevel *string,
 	validationAction *string,
 ) error {
-
 	cmd := bson.D{{"collMod", coll}}
 	if validator != nil {
 		cmd = append(cmd, bson.E{"validator", validator})
@@ -581,7 +574,6 @@ func (c *Catalog) ModifyValidation(
 
 // ModifyIndex modifies an index in the target MongoDB.
 func (c *Catalog) ModifyIndex(ctx context.Context, db, coll string, mods *ModifyIndexOption) error {
-
 	if mods.ExpireAfterSeconds != nil {
 		cmd := bson.D{
 			{"collMod", coll},
@@ -628,7 +620,6 @@ func (c *Catalog) ModifyIndex(ctx context.Context, db, coll string, mods *Modify
 }
 
 func (c *Catalog) Rename(ctx context.Context, db, coll, targetDB, targetColl string) error {
-
 	lg := log.Ctx(ctx)
 
 	opts := bson.D{
@@ -659,7 +650,6 @@ func (c *Catalog) Rename(ctx context.Context, db, coll, targetDB, targetColl str
 
 // DropIndex drops an index in the target MongoDB.
 func (c *Catalog) DropIndex(ctx context.Context, db, coll, index string) error {
-
 	lg := log.Ctx(ctx)
 
 	err := runWithRetry(ctx, func(ctx context.Context) error {

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -127,7 +127,7 @@ def test_create_view_with_collation(t: Testing, phase: Runner.Phase):
     t.compare_all()
 
 
-@pytest.mark.timeout(20)
+@pytest.mark.timeout(40)
 @pytest.mark.parametrize("phase", [Runner.Phase.APPLY, Runner.Phase.CLONE])
 def test_create_timeseries_ignored(t: Testing, phase: Runner.Phase):
     with t.run(phase):
@@ -329,7 +329,7 @@ def test_modify_view(t: Testing, phase: Runner.Phase):
     t.compare_all()
 
 
-@pytest.mark.timeout(20)
+@pytest.mark.timeout(40)
 @pytest.mark.parametrize("phase", [Runner.Phase.APPLY, Runner.Phase.CLONE])
 def test_modify_timeseries_options_ignored(t: Testing, phase: Runner.Phase):
     t.source["db_1"].create_collection(


### PR DESCRIPTION
[![PLM-173](https://badgen.net/badge/JIRA/PLM-173/green)](https://jira.percona.com/browse/PLM-173) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

PR improves locking in catalog in the sense that we hold the lock only when mutating the catalog itself, but not for other stuff like DB operation that can be long now that we have retries mechanicm.

[PLM-173]: https://perconadev.atlassian.net/browse/PLM-173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ