### PR TITLE
PLM-178: Fix selective filter logic

### DIFF
--- a/sel/sel_test.go
+++ b/sel/sel_test.go
@@ -30,9 +30,9 @@ func TestFilter(t *testing.T) {
 				"coll_2": false,
 			},
 			"db_2": {
-				"coll_0": false,
-				"coll_1": false,
-				"coll_2": false,
+				"coll_0": true,
+				"coll_1": true,
+				"coll_2": true,
 			},
 		}
 
@@ -103,12 +103,12 @@ func TestFilter(t *testing.T) {
 
 		namespaces := map[string]map[string]bool{
 			"db_0": {
-				"coll_0": false,
-				"coll_1": false,
-				"coll_2": false,
+				"coll_0": true,
+				"coll_1": true,
+				"coll_2": true,
 			},
 			"db_1": {
-				"coll_0": false,
+				"coll_0": true,
 				"coll_1": true,
 				"coll_2": false,
 			},

--- a/sel/sel_test.go
+++ b/sel/sel_test.go
@@ -103,12 +103,12 @@ func TestFilter(t *testing.T) {
 
 		namespaces := map[string]map[string]bool{
 			"db_0": {
-				"coll_0": true,
-				"coll_1": true,
-				"coll_2": true,
+				"coll_0": false,
+				"coll_1": false,
+				"coll_2": false,
 			},
 			"db_1": {
-				"coll_0": true,
+				"coll_0": false,
 				"coll_1": true,
 				"coll_2": false,
 			},

--- a/sel/sel_test.go
+++ b/sel/sel_test.go
@@ -99,6 +99,7 @@ func TestFilter(t *testing.T) {
 		excludedFilter := []string{
 			"db_0.*",
 			"db_1.coll_0",
+			"db_3.coll_1",
 		}
 
 		namespaces := map[string]map[string]bool{
@@ -116,6 +117,11 @@ func TestFilter(t *testing.T) {
 				"coll_0": true,
 				"coll_1": true,
 				"coll_2": false,
+			},
+			"db_3": {
+				"coll_0": true,
+				"coll_1": false,
+				"coll_2": true,
 			},
 		}
 

--- a/tests/test_selective.py
+++ b/tests/test_selective.py
@@ -93,23 +93,26 @@ def test_create_collection(t: testing.Testing, phase: Runner.Phase):
         t.plm,
         phase,
         include_ns=["db_0.*", "db_1.coll_0", "db_1.coll_1", "db_2.coll_0", "db_2.coll_1"],
-        exclude_ns=["db_0.*", "db_1.coll_0"],
+        exclude_ns=["db_0.*", "db_1.coll_0", "db_3.coll_1"],
     ):
-        for db in range(3):
+        for db in range(4):
             for coll in range(3):
                 t.source["db_1"]["coll_1"].create_index({"i": 1})
                 t.source[f"db_{db}"][f"coll_{coll}"].insert_one({})
 
     expected = {
-        # "db_0.coll_0",
-        # "db_0.coll_1",
-        # "db_0.coll_2",
-        # "db_1.coll_0",
+        "db_0.coll_0",
+        "db_0.coll_1",
+        "db_0.coll_2",
+        "db_1.coll_0",
         "db_1.coll_1",
         # "db_1.coll_2",
         "db_2.coll_0",
         "db_2.coll_1",
         # "db_2.coll_2",
+        "db_3.coll_0",
+        # "db_3.coll_1",
+        "db_3.coll_2",
     }
 
     assert expected == set(testing.list_all_namespaces(t.target))

--- a/tests/test_selective.py
+++ b/tests/test_selective.py
@@ -101,15 +101,18 @@ def test_create_collection(t: testing.Testing, phase: Runner.Phase):
                 t.source[f"db_{db}"][f"coll_{coll}"].insert_one({})
 
     expected = {
-        "db_0.coll_0",
-        "db_0.coll_1",
-        "db_0.coll_2",
-        "db_1.coll_0",
+        # "db_0.coll_0",
+        # "db_0.coll_1",
+        # "db_0.coll_2",
+
+        # "db_1.coll_0",
         "db_1.coll_1",
         # "db_1.coll_2",
+
         "db_2.coll_0",
         "db_2.coll_1",
         # "db_2.coll_2",
+
         "db_3.coll_0",
         # "db_3.coll_1",
         "db_3.coll_2",


### PR DESCRIPTION
[![PLM-178](https://badgen.net/badge/JIRA/PLM-178/green)](https://jira.percona.com/browse/PLM-178) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

When there is a filter like this:
```
plm start --include-namespaces="db1.coll_1,db2.coll_1" --exclude-namespaces="db3.coll_1"
```
filter logic wrongly excludes all collections from `db3`, but only `db3.coll_1` should be excluded. If the there is no include filter specified, than the exclusion works correctly.

Also, now if the DB is not specified in the filter at all, by default it (with all the it's collections) is included.

[PLM-178]: https://perconadev.atlassian.net/browse/PLM-178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ