### PR TITLE
PLM-172: Retryable write operation for bulk writes in repl and clone

### DIFF
--- a/topo/errors.go
+++ b/topo/errors.go
@@ -69,8 +69,8 @@ func IsTransient(err error) bool {
 	}
 
 	le, ok := err.(mongo.LabeledError) //nolint:errorlint
-	if ok {
-		return le.HasErrorLabel("RetryableWriteError")
+	if ok && le.HasErrorLabel("RetryableWriteError") {
+		return true
 	}
 
 	transientErrorCodes := map[int]struct{}{

--- a/topo/errors.go
+++ b/topo/errors.go
@@ -61,9 +61,9 @@ func isMongoCommandError(err error, name string) bool {
 	return false
 }
 
-// IsTransientError checks if the error is a transient error that can be retried.
+// IsTransient checks if the error is a transient error that can be retried.
 // It checks for specific MongoDB error codes that indicate transient issues.
-func IsTransientError(err error) bool {
+func IsTransient(err error) bool {
 	if mongo.IsNetworkError(err) || mongo.IsTimeout(err) || errors.Is(err, context.DeadlineExceeded) {
 		return true
 	}

--- a/topo/topo.go
+++ b/topo/topo.go
@@ -218,7 +218,7 @@ func RunWithRetry(
 			return nil
 		}
 
-		if !IsTransientError(err) {
+		if !IsTransient(err) {
 			return err //nolint:wrapcheck
 		}
 

--- a/topo/topo.go
+++ b/topo/topo.go
@@ -211,6 +211,7 @@ func RunWithRetry(
 	var err error
 
 	currentInterval := retryInterval
+
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		err = fn(ctx)
 		if err == nil {

--- a/topo/topo_test.go
+++ b/topo/topo_test.go
@@ -25,6 +25,7 @@ func TestRunWithRetry_NonTransientError(t *testing.T) {
 	if !errors.Is(err, nonTransiantErr) {
 		t.Errorf("expected error %v, got %v", nonTransiantErr, err)
 	}
+
 	if calls != 1 {
 		t.Errorf("expected fn to be called once, got %d", calls)
 	}
@@ -51,10 +52,12 @@ func TestRunWithRetry_FalureOnAllRetries(t *testing.T) {
 	}
 
 	maxRetries := 3
+
 	err := RunWithRetry(t.Context(), fn, 1*time.Millisecond, maxRetries)
 	if !errors.As(err, &transientErr) {
 		t.Errorf("expected error %v, got %v", transientErr, err)
 	}
+
 	if calls != maxRetries {
 		t.Errorf("expected fn to be called %d times, got %d", maxRetries, calls)
 	}
@@ -86,6 +89,7 @@ func TestRunWithRetry_SuccessOnRetry(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected nil error, got %v", err)
 	}
+
 	if calls != 2 {
 		t.Errorf("expected fn to be called 2 times, got %d", calls)
 	}


### PR DESCRIPTION
[![PLM-172](https://badgen.net/badge/JIRA/PLM-172/green)](https://jira.percona.com/browse/PLM-172) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

PR adds retriable writes to bulk writes in replication and clone. 

It adds descriptive error messages in catalog DB operations so retry messages are clear in the sense of what operation is being retried. This addresses [this comment](https://github.com/percona/percona-link-mongodb/pull/105#discussion_r2140967069) from @boris-ilijic .

This PR also handles https://perconadev.atlassian.net/browse/PLM-174 by adding additional transient error checks for `errors.IsTransient(error)`.

[PLM-172]: https://perconadev.atlassian.net/browse/PLM-172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ