### PR TITLE
PLM-147: Check if _id_ index is dropped during clone

### DIFF
--- a/topo/errors.go
+++ b/topo/errors.go
@@ -27,7 +27,8 @@ func IsNamespaceNotFound(err error) bool {
 func IsCollectionDropped(err error) bool {
 	var cmdErr mongo.CommandError
 	if errors.As(err, &cmdErr) && cmdErr.Name == "QueryPlanKilled" {
-		return strings.Contains(cmdErr.Message, "collection dropped")
+		return strings.Contains(cmdErr.Message, "collection dropped") ||
+			strings.Contains(cmdErr.Message, "index '_id_' dropped")
 	}
 
 	return false


### PR DESCRIPTION
[![PLM-147](https://badgen.net/badge/JIRA/PLM-147/green)](https://jira.percona.com/browse/PLM-147) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

When a collection is dropped during clone, we can have a `QueryPlanKilled` error with `index '_id_' dropped` and not just `collection dropped` which we currently only check. We need to check if `index '_id_' dropped` as well.

[PLM-147]: https://perconadev.atlassian.net/browse/PLM-147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ