### PR TITLE
PLM-187: Set proper capacity for builtIndexes slice

### DIFF
--- a/plm/clone.go
+++ b/plm/clone.go
@@ -732,7 +732,13 @@ func (c *Clone) createIndexes(ctx context.Context, ns Namespace) error {
 		return nil
 	}
 
-	builtIndexes := make([]*topo.IndexSpecification, 0, len(indexes)-len(unfinishedBuilds))
+	builtIndexesCap := len(indexes) - len(unfinishedBuilds)
+	if builtIndexesCap < 0 {
+		builtIndexesCap = 0
+	}
+
+	builtIndexes := make([]*topo.IndexSpecification, 0, builtIndexesCap)
+
 	incompleteIndexes := make([]*topo.IndexSpecification, 0, len(unfinishedBuilds))
 
 	for _, index := range indexes {


### PR DESCRIPTION
[![PLM-187](https://badgen.net/badge/JIRA/PLM-187/green)](https://jira.percona.com/browse/PLM-187) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Set proper capacity for builtIndexes slice.

[PLM-187]: https://perconadev.atlassian.net/browse/PLM-187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ