### PR TITLE
PLM184: Check if error is not NamespaceExists

### DIFF
--- a/plm/catalog.go
+++ b/plm/catalog.go
@@ -227,7 +227,7 @@ func (c *Catalog) doCreateCollection(
 
 		return errors.Wrapf(err, "create collection %s.%s", db, coll)
 	})
-	if err != nil {
+	if err != nil && !topo.IsNamespaceExists(err) {
 		return err //nolint:wrapcheck
 	}
 

--- a/topo/errors.go
+++ b/topo/errors.go
@@ -23,6 +23,10 @@ func IsNamespaceNotFound(err error) bool {
 	return isMongoCommandError(err, "NamespaceNotFound")
 }
 
+func IsNamespaceExists(err error) bool {
+	return isMongoCommandError(err, "NamespaceExists")
+}
+
 // IsCollectionDropped checks if the error is caused by a collection being dropped.
 func IsCollectionDropped(err error) bool {
 	var cmdErr mongo.CommandError


### PR DESCRIPTION
[![PLM-184](https://badgen.net/badge/JIRA/PLM-184/green)](https://jira.percona.com/browse/PLM-184) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

For PSMDB 6.0 when creating a collection that already exists, it returns `NamespaceExists` error which idempotency for creating collections in a retry loop. For versions above 7.0 this is not the case.

This PR simply ignores `NamespaceExists` error when creating a collection.

[PLM-184]: https://perconadev.atlassian.net/browse/PLM-184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ