### PR TITLE
PCSM-167: Status response improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,10 @@ The /status endpoint provides the current state of the PCSM replication process,
 
 - `lagTimeSeconds`: the current lag time in logical seconds between source and target clusters.
 - `eventsApplied`: the number of events applied to the target cluster.
-- `lastReplicatedOpTime`: the last replicated operation time.
+- `lastReplicatedOpTime`: the last replicated operation time
+- `lastReplicatedOpTime.ts`: op time timestamp
+- `lastReplicatedOpTime.isoDate`: op time ts in human-readable form
+
 
 - `initialSync.completed`: indicates if the initial sync is completed.
 - `initialSync.lagTimeSeconds`: the lag time in logical seconds until the initial sync completed.
@@ -318,7 +321,10 @@ Example:
 
     "lagTimeSeconds": 22,
     "eventsApplied": 5000,
-    "lastReplicatedOpTime": "1740335200.5",
+    "lastReplicatedOpTime": {
+        "ts": "1762241863.1",
+        "isoDate": "2025-11-04T07:37:43Z"
+    },
 
     "initialSync": {
         "completed": false,

--- a/README.md
+++ b/README.md
@@ -297,16 +297,16 @@ The /status endpoint provides the current state of the PCSM replication process,
 - `info`: provides additional information about the current state.
 - `error` (optional): the error message if the operation failed.
 
-- `lagTime`: the current lag time in logical seconds between source and target clusters.
-- `eventsProcessed`: the number of events processed.
+- `lagTimeSeconds`: the current lag time in logical seconds between source and target clusters.
+- `eventsApplied`: the number of events applied to the target cluster.
 - `lastReplicatedOpTime`: the last replicated operation time.
 
 - `initialSync.completed`: indicates if the initial sync is completed.
-- `initialSync.lagTime`: the lag time in logical seconds until the initial sync completed.
+- `initialSync.lagTimeSeconds`: the lag time in logical seconds until the initial sync completed.
 
 - `initialSync.cloneCompleted`: indicates if the cloning process is completed.
-- `initialSync.estimatedCloneSize`: the estimated total size of the clone.
-- `initialSync.clonedSize`: the size of the data that has been cloned.
+- `initialSync.estimatedCloneSizeBytes`: the estimated total size of the clone.
+- `initialSync.clonedSizeBytes`: the size of the data that has been cloned.
 
 Example:
 
@@ -316,17 +316,17 @@ Example:
     "state": "running",
     "info": "Initial Sync",
 
-    "lagTime": 22,
-    "eventsProcessed": 5000,
+    "lagTimeSeconds": 22,
+    "eventsApplied": 5000,
     "lastReplicatedOpTime": "1740335200.5",
 
     "initialSync": {
         "completed": false,
-        "lagTime": 5,
+        "lagTimeSeconds": 5,
 
         "cloneCompleted": false,
-        "estimatedCloneSize": 5000000000,
-        "clonedSize": 2500000000
+        "estimatedCloneSizeBytes": 5000000000,
+        "clonedSizeBytes": 2500000000
     }
 }
 ```

--- a/main.go
+++ b/main.go
@@ -689,8 +689,8 @@ func (s *server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res.EventsProcessed = status.Repl.EventsProcessed
-	res.LagTime = status.TotalLagTime
+	res.EventsApplied = status.Repl.EventsApplied
+	res.LagTimeSeconds = status.TotalLagTimeSeconds
 
 	if !status.Repl.LastReplicatedOpTime.IsZero() {
 		res.LastReplicatedOpTime = fmt.Sprintf("%d.%d",
@@ -699,12 +699,12 @@ func (s *server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	res.InitialSync = &statusInitialSyncResponse{
-		Completed: status.InitialSyncCompleted,
-		LagTime:   status.InitialSyncLagTime,
+		Completed:      status.InitialSyncCompleted,
+		LagTimeSeconds: status.InitialSyncLagTimeSeconds,
 
-		CloneCompleted:     status.Clone.IsFinished(),
-		EstimatedCloneSize: status.Clone.EstimatedTotalSize,
-		ClonedSize:         status.Clone.CopiedSize,
+		CloneCompleted:          status.Clone.IsFinished(),
+		EstimatedCloneSizeBytes: status.Clone.EstimatedTotalSizeBytes,
+		ClonedSizeBytes:         status.Clone.CopiedSizeBytes,
 	}
 
 	switch {
@@ -992,10 +992,10 @@ type statusResponse struct {
 	// Info provides additional information about the current state.
 	Info string `json:"info,omitempty"`
 
-	// LagTime is the current lag time in logical seconds.
-	LagTime int64 `json:"lagTime"`
-	// EventsProcessed is the number of events processed.
-	EventsProcessed int64 `json:"eventsProcessed"`
+	// LagTimeSeconds is the current lag time in logical seconds.
+	LagTimeSeconds int64 `json:"lagTimeSeconds"`
+	// EventsApplied is the number of events applied.
+	EventsApplied int64 `json:"eventsApplied"`
 	// LastReplicatedOpTime is the last replicated operation time.
 	LastReplicatedOpTime string `json:"lastReplicatedOpTime,omitempty"`
 
@@ -1005,13 +1005,13 @@ type statusResponse struct {
 
 // statusInitialSyncResponse represents the initial sync status in the /status response.
 type statusInitialSyncResponse struct {
-	// LagTime is the lag time in logical seconds until the initial sync completed.
-	LagTime int64 `json:"lagTime,omitempty"`
+	// LagTimeSeconds is the lag time in logical seconds until the initial sync completed.
+	LagTimeSeconds int64 `json:"lagTimeSeconds,omitempty"`
 
-	// EstimatedCloneSize is the estimated total size of the clone.
-	EstimatedCloneSize uint64 `json:"estimatedCloneSize,omitempty"`
-	// ClonedSize is the size of the data that has been cloned.
-	ClonedSize uint64 `json:"clonedSize"`
+	// EstimatedCloneSizeBytes is the estimated total size of the clone in bytes.
+	EstimatedCloneSizeBytes uint64 `json:"estimatedCloneSizeBytes,omitempty"`
+	// ClonedSizeBytes is the size of the data that has been cloned.
+	ClonedSizeBytes uint64 `json:"clonedSizeBytes"`
 
 	// Completed indicates if the initial sync is completed.
 	Completed bool `json:"completed"`

--- a/main.go
+++ b/main.go
@@ -689,6 +689,7 @@ func (s *server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	res.EventsRead = status.Repl.EventsRead
 	res.EventsApplied = status.Repl.EventsApplied
 	res.LagTimeSeconds = status.TotalLagTimeSeconds
 
@@ -1002,6 +1003,8 @@ type statusResponse struct {
 
 	// LagTimeSeconds is the current lag time in logical seconds.
 	LagTimeSeconds int64 `json:"lagTimeSeconds"`
+	// EventsRead is the number of events read from the source. Not counting tick events.
+	EventsRead int64 `json:"eventsRead"`
 	// EventsApplied is the number of events applied.
 	EventsApplied int64 `json:"eventsApplied"`
 	// LastReplicatedOpTime is the last replicated operation time.

--- a/main.go
+++ b/main.go
@@ -693,9 +693,17 @@ func (s *server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	res.LagTimeSeconds = status.TotalLagTimeSeconds
 
 	if !status.Repl.LastReplicatedOpTime.IsZero() {
-		res.LastReplicatedOpTime = fmt.Sprintf("%d.%d",
+		ts := fmt.Sprintf("%d.%d",
 			status.Repl.LastReplicatedOpTime.T,
 			status.Repl.LastReplicatedOpTime.I)
+
+		isoDate := time.Unix(int64(status.Repl.LastReplicatedOpTime.T),
+			int64(status.Repl.LastReplicatedOpTime.I)).UTC()
+
+		res.LastReplicatedOpTime = &lastReplicatedOpTime{
+			TS:      ts,
+			ISODate: isoDate.Format(time.RFC3339),
+		}
 	}
 
 	res.InitialSync = &statusInitialSyncResponse{
@@ -997,10 +1005,15 @@ type statusResponse struct {
 	// EventsApplied is the number of events applied.
 	EventsApplied int64 `json:"eventsApplied"`
 	// LastReplicatedOpTime is the last replicated operation time.
-	LastReplicatedOpTime string `json:"lastReplicatedOpTime,omitempty"`
+	LastReplicatedOpTime *lastReplicatedOpTime `json:"lastReplicatedOpTime,omitempty"`
 
 	// InitialSync contains the initial sync status details.
 	InitialSync *statusInitialSyncResponse `json:"initialSync,omitempty"`
+}
+
+type lastReplicatedOpTime struct {
+	TS      string `json:"ts"`
+	ISODate string `json:"isoDate"`
 }
 
 // statusInitialSyncResponse represents the initial sync status in the /status response.

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -12,6 +12,13 @@ const metricNamespace = "percona_clustersync_mongodb"
 // Counters.
 var (
 	//nolint:gochecknoglobals
+	eventsReadTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name:      "events_read_total",
+		Help:      "Total number of events read from the source.",
+		Namespace: metricNamespace,
+	})
+
+	//nolint:gochecknoglobals
 	eventsAppliedTotal = prometheus.NewCounter(prometheus.CounterOpts{
 		Name:      "events_applied_total",
 		Help:      "Total number of events applied.",
@@ -142,6 +149,11 @@ func SetCopyReadBatchDurationSeconds(dur time.Duration) {
 // operation.
 func SetCopyInsertBatchDurationSeconds(dur time.Duration) {
 	copyInsertBatchDurationSeconds.Set(float64(dur.Seconds()))
+}
+
+// IncEventsRead increments the total number of events read counter.
+func IncEventsRead() {
+	eventsReadTotal.Inc()
 }
 
 // AddEventsApplied increments the total number of events applied counter.

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -12,9 +12,9 @@ const metricNamespace = "percona_clustersync_mongodb"
 // Counters.
 var (
 	//nolint:gochecknoglobals
-	eventsProcessedTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Name:      "events_processed_total",
-		Help:      "Total number of events processed.",
+	eventsAppliedTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name:      "events_applied_total",
+		Help:      "Total number of events applied.",
 		Namespace: metricNamespace,
 	})
 
@@ -101,7 +101,7 @@ func Init(reg prometheus.Registerer) {
 		copyReadBatchDurationSeconds,
 		copyInsertBatchDurationSeconds,
 
-		eventsProcessedTotal,
+		eventsAppliedTotal,
 		lagTimeSeconds,
 		intialSyncLagTimeSeconds,
 	)
@@ -144,9 +144,9 @@ func SetCopyInsertBatchDurationSeconds(dur time.Duration) {
 	copyInsertBatchDurationSeconds.Set(float64(dur.Seconds()))
 }
 
-// AddEventsProcessed increments the total number of events processed counter.
-func AddEventsProcessed(v int) {
-	eventsProcessedTotal.Add(float64(v))
+// AddEventsApplied increments the total number of events applied counter.
+func AddEventsApplied(v int) {
+	eventsAppliedTotal.Add(float64(v))
 }
 
 // SetLagTimeSeconds sets the lag time in seconds gauge.

--- a/pcsm/catalog.go
+++ b/pcsm/catalog.go
@@ -134,7 +134,6 @@ func (c *Catalog) UnlockWrite() {
 func (c *Catalog) Checkpoint() *catalogCheckpoint { //nolint:revive
 	// do not call [sync.RWMutex.RLock] to avoid deadlock through recursive read-locking
 	// that may happen during clone or change replication
-
 	if len(c.Databases) == 0 {
 		return nil
 	}

--- a/pcsm/clone.go
+++ b/pcsm/clone.go
@@ -47,8 +47,8 @@ type Clone struct {
 
 // CloneStatus represents the status of the cloning process.
 type CloneStatus struct {
-	EstimatedTotalSize uint64 // Estimated total bytes to be copied
-	CopiedSize         uint64 // Bytes copied so far
+	EstimatedTotalSizeBytes uint64 // Estimated total bytes to be copied
+	CopiedSizeBytes         uint64 // Bytes copied so far
 
 	StartTS  bson.Timestamp
 	FinishTS bson.Timestamp
@@ -148,13 +148,13 @@ func (c *Clone) Status() CloneStatus {
 	defer c.lock.Unlock()
 
 	return CloneStatus{
-		EstimatedTotalSize: c.totalSize,
-		CopiedSize:         c.copiedSize.Load(),
-		StartTS:            c.startTS,
-		FinishTS:           c.finishTS,
-		StartTime:          c.startTime,
-		FinishTime:         c.finishTime,
-		Err:                c.err,
+		EstimatedTotalSizeBytes: c.totalSize,
+		CopiedSizeBytes:         c.copiedSize.Load(),
+		StartTS:                 c.startTS,
+		FinishTS:                c.finishTS,
+		StartTime:               c.startTime,
+		FinishTime:              c.finishTime,
+		Err:                     c.err,
 	}
 }
 

--- a/pcsm/pcsm.go
+++ b/pcsm/pcsm.go
@@ -57,10 +57,10 @@ type Status struct {
 	// Error is the error message if the operation failed.
 	Error error
 
-	// TotalLagTime is the current lag time in logical seconds between source and target clusters.
-	TotalLagTime int64
-	// InitialSyncLagTime is the lag time during the initial sync.
-	InitialSyncLagTime int64
+	// TotalLagTimeSeconds is the current lag time in logical seconds between source and target clusters.
+	TotalLagTimeSeconds int64
+	// InitialSyncLagTimeSeconds is the lag time during the initial sync.
+	InitialSyncLagTimeSeconds int64
 	// InitialSyncCompleted indicates if the initial sync is completed.
 	InitialSyncCompleted bool
 
@@ -261,15 +261,15 @@ func (ml *PCSM) Status(ctx context.Context) *Status {
 		switch {
 		case !s.Repl.LastReplicatedOpTime.IsZero():
 			totalLag := int64(sourceTime.T) - int64(s.Repl.LastReplicatedOpTime.T)
-			s.TotalLagTime = totalLag
+			s.TotalLagTimeSeconds = totalLag
 		case !s.Clone.StartTS.IsZero():
 			totalLag := int64(sourceTime.T) - int64(s.Clone.StartTS.T)
-			s.TotalLagTime = totalLag
+			s.TotalLagTimeSeconds = totalLag
 		}
 	}
 
 	if !s.InitialSyncCompleted {
-		s.InitialSyncLagTime = s.TotalLagTime
+		s.InitialSyncLagTimeSeconds = s.TotalLagTimeSeconds
 	}
 
 	return s

--- a/pcsm/repl.go
+++ b/pcsm/repl.go
@@ -488,6 +488,7 @@ func (r *Repl) run(opts *options.ChangeStreamOptionsBuilder) {
 		}
 
 		r.eventsRead.Add(1)
+		metrics.IncEventsRead()
 
 		if change.Namespace.Database == config.PCSMDatabase {
 			if r.bulkWrite.Empty() {

--- a/tests/pcsm.py
+++ b/tests/pcsm.py
@@ -233,7 +233,8 @@ class Runner:
     def last_applied_op(self):
         """Get the last applied operation time."""
         status = self.pcsm.status()
-        if last_replicated_op_time := status.get("lastReplicatedOpTime"):
+        last_replicated_op_time = status.get("lastReplicatedOpTime", {}).get("ts")
+        if last_replicated_op_time:
             t_s, i_s = last_replicated_op_time.split(".")
             return bson.Timestamp(int(t_s), int(i_s))
 


### PR DESCRIPTION
[![PCSM-167](https://badgen.net/badge/JIRA/PCSM-167/green)](https://jira.percona.com/browse/PCSM-167) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

PR improves status response, example:

```
❯ pcsm status
{
  "ok": true,
  "state": "running",
  "info": "Replicating Changes",
  "lagTimeSeconds": 1,
  "eventsRead": 3,
  "eventsApplied": 3,
  "lastReplicatedOpTime": {
    "ts": "1762241863.1",
    "isoDate": "2025-11-04T07:37:43Z"
  },
  "initialSync": {
    "estimatedCloneSizeBytes": 165,
    "clonedSizeBytes": 165,
    "completed": true,
    "cloneCompleted": true
  }
}
```

Addition:
- `eventsRead` - total number of events read from the source cluster. These do not include tick events.

Updated fields:
- `lastReplicatedOpTime` is now a object that holds the `ts` field, a timestamp and `isoDate`, a human readable form of the timestamp so it is clearer to the user.
- Added units like `seconds` and `bytes` to the corresponding fields.

[PCSM-167]: https://perconadev.atlassian.net/browse/PCSM-167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ