### PR TITLE
PCSM-195: Add support for unique sharded collections

### DIFF
--- a/pcsm/catalog.go
+++ b/pcsm/catalog.go
@@ -1160,13 +1160,15 @@ func (c *Catalog) ShardCollection(
 	unique bool,
 ) error {
 	cmd := bson.D{
-		{"shardCollection", db + "." + coll},
-		{"key", shardKey},
-		{"collation", bson.D{{"locale", "simple"}}},
+		{Key: "shardCollection", Value: db + "." + coll},
+		{Key: "key", Value: shardKey},
 	}
 
 	if unique {
-		cmd = append(cmd, bson.E{"unique", true})
+		cmd = append(cmd,
+			bson.E{Key: "unique", Value: true},
+			bson.E{Key: "enforceUniquenessCheck", Value: false},
+		)
 	}
 
 	err := runWithRetry(ctx, func(ctx context.Context) error {

--- a/pcsm/catalog.go
+++ b/pcsm/catalog.go
@@ -1162,6 +1162,7 @@ func (c *Catalog) ShardCollection(
 	cmd := bson.D{
 		{Key: "shardCollection", Value: db + "." + coll},
 		{Key: "key", Value: shardKey},
+		{"collation", bson.D{{"locale", "simple"}}},
 	}
 
 	if unique {

--- a/tests/test_collections_sharded.py
+++ b/tests/test_collections_sharded.py
@@ -19,6 +19,16 @@ def test_shard_collection(t: Testing, phase: Runner.Phase):
 
 
 @pytest.mark.parametrize("phase", [Runner.Phase.APPLY, Runner.Phase.CLONE])
+def test_shard_unique_collection(t: Testing, phase: Runner.Phase):
+    with t.run(phase):
+        t.source["db_1"].create_collection("coll_1")
+        t.source.admin.command("shardCollection", "db_1.coll_1", key={"a": 1}, unique=True)
+        t.source.admin.command("shardCollection", "db_1.coll_2", key={"a": 1, "b": 1}, unique=True)
+
+    t.compare_all_sharded()
+
+
+@pytest.mark.parametrize("phase", [Runner.Phase.APPLY, Runner.Phase.CLONE])
 def test_drop_sharded(t: Testing, phase: Runner.Phase):
     t.source["db_1"].drop_collection("coll_1")
     t.source["db_1"].create_collection("coll_1")


### PR DESCRIPTION
[![PCSM-195](https://badgen.net/badge/JIRA/PCSM-195/green)](https://jira.percona.com/browse/PCSM-195) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

PR add support for unique sharded collections by setting `enforceUniquenessCheck=true` option to `shardCollection` command.

This update also applies to for https://perconadev.atlassian.net/browse/PLM-194.

[PCSM-195]: https://perconadev.atlassian.net/browse/PCSM-195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ