### PR TITLE
PCSM-167: Restore eventsRead during recovery

### DIFF
--- a/pcsm/repl.go
+++ b/pcsm/repl.go
@@ -116,7 +116,7 @@ func (r *Repl) Checkpoint() *replCheckpoint { //nolint:revive
 	cp := &replCheckpoint{
 		StartTime:            r.startTime,
 		PauseTime:            r.pauseTime,
-		EventsRead:           r.eventsRead.Load(),
+		EventsRead:           r.eventsApplied,
 		EventsApplied:        r.eventsApplied,
 		LastReplicatedOpTime: r.lastReplicatedOpTime,
 	}
@@ -151,6 +151,7 @@ func (r *Repl) Recover(cp *replCheckpoint) error {
 	r.startTime = cp.StartTime
 	r.pauseTime = pauseTime
 	r.eventsApplied = cp.EventsApplied
+	r.eventsRead.Store(cp.EventsApplied)
 	r.lastReplicatedOpTime = cp.LastReplicatedOpTime
 
 	if cp.UseClientBulkWrite {


### PR DESCRIPTION
[![PCSM-167](https://badgen.net/badge/JIRA/PCSM-167/green)](https://jira.percona.com/browse/PCSM-167) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

During recovery `eventsRead` were not restored from the checkpoint and thus lead to a weird status after recovery, where we applied more events than we read:
```
❯ pcsm status
{
  "ok": true,
  "state": "running",
  "info": "Replicating Changes",
  "lagTimeSeconds": 2,
  "eventsRead": 322,     <======================
  "eventsApplied": 354, <======================
  "lastReplicatedOpTime": {
    "ts": "1763282460.1",
    "isoDate": "2025-11-16T08:41:00Z"
  },
  "initialSync": {
    "estimatedCloneSizeBytes": 12540,
    "clonedSizeBytes": 12540,
    "completed": true,
    "cloneCompleted": true
  }
}
```
That is because when we recover, we have `eventsApplied` correct and `eventsRead` set to zero.


Problem on top of this is also `eventsRead` value was also wrongly stored to the checkpoint, because the value which was stored was `r.eventsRead.Load()` which is not correct. Checkpointing is done periodically and generally the value of `eventsRead` versus `eventsApplied` will be larger in the PCSM status because some of the events are yet to be applied and PCSM can do a checkpoint with that difference. 
But when we perform the recovery, we need to restore `eventsRead` to be the value of `eventsApplied` since all the difference, or all the events that we read that did not make to apply when we crashed, are gone and will be re-read when we recover from the last checkpoint.

[PCSM-167]: https://perconadev.atlassian.net/browse/PCSM-167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ