### PR TITLE
PCSM-200: Set simple collation for bulk writes on sharded collections for target below 8.0

### DIFF
--- a/pcsm/bulk.go
+++ b/pcsm/bulk.go
@@ -20,6 +20,9 @@ import (
 var yes = true // for ref
 
 //nolint:gochecknoglobals
+var simpleCollation = &options.Collation{Locale: "simple"}
+
+//nolint:gochecknoglobals
 var clientBulkOptions = options.ClientBulkWrite().
 	SetOrdered(true).
 	SetBypassDocumentValidation(false)
@@ -41,12 +44,14 @@ type bulkWrite interface {
 }
 
 type clientBulkWrite struct {
-	writes []mongo.ClientBulkWrite
+	useSimpleCollation bool
+	writes             []mongo.ClientBulkWrite
 }
 
-func newClientBulkWrite(size int) *clientBulkWrite {
+func newClientBulkWrite(size int, useSimpleCollation bool) *clientBulkWrite {
 	return &clientBulkWrite{
-		make([]mongo.ClientBulkWrite, 0, size),
+		useSimpleCollation: useSimpleCollation,
+		writes:             make([]mongo.ClientBulkWrite, 0, size),
 	}
 }
 
@@ -76,67 +81,93 @@ func (o *clientBulkWrite) Do(ctx context.Context, m *mongo.Client) (int, error) 
 }
 
 func (o *clientBulkWrite) Insert(ns Namespace, event *InsertEvent) {
+	m := &mongo.ClientReplaceOneModel{
+		Filter:      event.DocumentKey,
+		Replacement: event.FullDocument,
+		Upsert:      &yes,
+	}
+
+	if ns.Sharded && o.useSimpleCollation {
+		m.Collation = simpleCollation
+	}
+
 	bw := mongo.ClientBulkWrite{
 		Database:   ns.Database,
 		Collection: ns.Collection,
-		Model: &mongo.ClientReplaceOneModel{
-			Filter:      event.DocumentKey,
-			Replacement: event.FullDocument,
-			Upsert:      &yes,
-		},
+		Model:      m,
 	}
 
 	o.writes = append(o.writes, bw)
 }
 
 func (o *clientBulkWrite) Update(ns Namespace, event *UpdateEvent) {
+	m := &mongo.ClientUpdateOneModel{
+		Filter: event.DocumentKey,
+		Update: collectUpdateOps(event),
+	}
+
+	if ns.Sharded && o.useSimpleCollation {
+		m.Collation = simpleCollation
+	}
+
 	bw := mongo.ClientBulkWrite{
 		Database:   ns.Database,
 		Collection: ns.Collection,
-		Model: &mongo.ClientUpdateOneModel{
-			Filter: event.DocumentKey,
-			Update: collectUpdateOps(event),
-		},
+		Model:      m,
 	}
 
 	o.writes = append(o.writes, bw)
 }
 
 func (o *clientBulkWrite) Replace(ns Namespace, event *ReplaceEvent) {
+	m := &mongo.ClientReplaceOneModel{
+		Filter:      event.DocumentKey,
+		Replacement: event.FullDocument,
+	}
+
+	if ns.Sharded && o.useSimpleCollation {
+		m.Collation = simpleCollation
+	}
+
 	bw := mongo.ClientBulkWrite{
 		Database:   ns.Database,
 		Collection: ns.Collection,
-		Model: &mongo.ClientReplaceOneModel{
-			Filter:      event.DocumentKey,
-			Replacement: event.FullDocument,
-		},
+		Model:      m,
 	}
 
 	o.writes = append(o.writes, bw)
 }
 
 func (o *clientBulkWrite) Delete(ns Namespace, event *DeleteEvent) {
+	m := &mongo.ClientDeleteOneModel{
+		Filter: event.DocumentKey,
+	}
+
+	if ns.Sharded && o.useSimpleCollation {
+		m.Collation = simpleCollation
+	}
+
 	bw := mongo.ClientBulkWrite{
 		Database:   ns.Database,
 		Collection: ns.Collection,
-		Model: &mongo.ClientDeleteOneModel{
-			Filter: event.DocumentKey,
-		},
+		Model:      m,
 	}
 
 	o.writes = append(o.writes, bw)
 }
 
 type collectionBulkWrite struct {
-	max    int
-	count  int
-	writes map[Namespace][]mongo.WriteModel
+	useSimpleCollation bool
+	max                int
+	count              int
+	writes             map[Namespace][]mongo.WriteModel
 }
 
-func newCollectionBulkWrite(size int) *collectionBulkWrite {
+func newCollectionBulkWrite(size int, nonDefaultCollationSupport bool) *collectionBulkWrite {
 	return &collectionBulkWrite{
-		max:    size,
-		writes: make(map[Namespace][]mongo.WriteModel),
+		useSimpleCollation: nonDefaultCollationSupport,
+		max:                size,
+		writes:             make(map[Namespace][]mongo.WriteModel),
 	}
 }
 
@@ -185,37 +216,61 @@ func (o *collectionBulkWrite) Do(ctx context.Context, m *mongo.Client) (int, err
 }
 
 func (o *collectionBulkWrite) Insert(ns Namespace, event *InsertEvent) {
-	o.writes[ns] = append(o.writes[ns], &mongo.ReplaceOneModel{
+	m := &mongo.ReplaceOneModel{
 		Filter:      event.DocumentKey,
 		Replacement: event.FullDocument,
 		Upsert:      &yes,
-	})
+	}
+
+	if ns.Sharded && o.useSimpleCollation {
+		m.Collation = simpleCollation
+	}
+
+	o.writes[ns] = append(o.writes[ns], m)
 
 	o.count++
 }
 
 func (o *collectionBulkWrite) Update(ns Namespace, event *UpdateEvent) {
-	o.writes[ns] = append(o.writes[ns], &mongo.UpdateOneModel{
+	m := &mongo.UpdateOneModel{
 		Filter: event.DocumentKey,
 		Update: collectUpdateOps(event),
-	})
+	}
+
+	if ns.Sharded && o.useSimpleCollation {
+		m.Collation = simpleCollation
+	}
+
+	o.writes[ns] = append(o.writes[ns], m)
 
 	o.count++
 }
 
 func (o *collectionBulkWrite) Replace(ns Namespace, event *ReplaceEvent) {
-	o.writes[ns] = append(o.writes[ns], &mongo.ReplaceOneModel{
+	m := &mongo.ReplaceOneModel{
 		Filter:      event.DocumentKey,
 		Replacement: event.FullDocument,
-	})
+	}
+
+	if ns.Sharded && o.useSimpleCollation {
+		m.Collation = simpleCollation
+	}
+
+	o.writes[ns] = append(o.writes[ns], m)
 
 	o.count++
 }
 
 func (o *collectionBulkWrite) Delete(ns Namespace, event *DeleteEvent) {
-	o.writes[ns] = append(o.writes[ns], &mongo.DeleteOneModel{
+	m := &mongo.DeleteOneModel{
 		Filter: event.DocumentKey,
-	})
+	}
+
+	if ns.Sharded && o.useSimpleCollation {
+		m.Collation = simpleCollation
+	}
+
+	o.writes[ns] = append(o.writes[ns], m)
 
 	o.count++
 }

--- a/pcsm/catalog.go
+++ b/pcsm/catalog.go
@@ -1188,7 +1188,6 @@ func (c *Catalog) ShardCollection(
 
 	log.Ctx(ctx).Debugf("Sharded collection %s.%s", db, coll)
 
-	// update c.databases[db].collections[coll].sharded = true
 	c.lock.Lock()
 	databaseEntry := c.Databases[db]
 	collectionEntry := databaseEntry.Collections[coll]

--- a/pcsm/catalog.go
+++ b/pcsm/catalog.go
@@ -1186,7 +1186,7 @@ func (c *Catalog) ShardCollection(
 		return err //nolint:wrapcheck
 	}
 
-	log.Ctx(ctx).Infof("Sharded collection %s.%s", db, coll)
+	log.Ctx(ctx).Debugf("Sharded collection %s.%s", db, coll)
 
 	// update c.databases[db].collections[coll].sharded = true
 	c.lock.Lock()

--- a/pcsm/clone.go
+++ b/pcsm/clone.go
@@ -341,7 +341,7 @@ func (c *Clone) doClone(ctx context.Context, namespaces []namespaceInfo) error {
 
 				prevNS := ns
 				ns = namespaceInfo{
-					Namespace: Namespace{prevNS.Database, name},
+					Namespace: Namespace{Database: prevNS.Database, Collection: name},
 					UUID:      prevNS.UUID,
 				}
 
@@ -407,7 +407,7 @@ func (c *Clone) doCollectionClone(
 	spec, err := topo.GetCollectionSpec(ctx, c.source, ns.Database, ns.Collection)
 	if err != nil {
 		if errors.Is(err, topo.ErrNotFound) {
-			return NamespaceNotFoundError(ns)
+			return NamespaceNotFoundError{ns.Database, ns.Collection}
 		}
 
 		return errors.Wrap(err, "$collStats")
@@ -617,7 +617,7 @@ func (c *Clone) collectSizeMap(ctx context.Context) error {
 				collGrp.Go(func() error {
 					if spec.Type == topo.TypeView {
 						mu.Lock()
-						sm[Namespace{db, spec.Name}] = sizeMapElem{}
+						sm[Namespace{Database: db, Collection: spec.Name}] = sizeMapElem{}
 						mu.Unlock()
 
 						return nil
@@ -633,7 +633,7 @@ func (c *Clone) collectSizeMap(ctx context.Context) error {
 					}
 
 					mu.Lock()
-					sm[Namespace{db, spec.Name}] = sizeMapElem{
+					sm[Namespace{Database: db, Collection: spec.Name}] = sizeMapElem{
 						UUID:  spec.UUID,
 						Size:  uint64(stats.Size), //nolint:gosec
 						Count: stats.Count,

--- a/pcsm/clone.go
+++ b/pcsm/clone.go
@@ -445,9 +445,9 @@ func (c *Clone) doCollectionClone(
 		if err != nil {
 			return errors.Wrap(err, "shard collection")
 		}
-	}
 
-	lg.Infof("Collection %q sharded", ns.String())
+		lg.Infof("Collection %q sharded", ns.String())
+	}
 
 	c.catalog.SetCollectionTimestamp(ctx, ns.Database, ns.Collection, capturedAt)
 

--- a/pcsm/copy.go
+++ b/pcsm/copy.go
@@ -598,7 +598,7 @@ func NewSegmenter(
 	stats, err := topo.GetCollStats(ctx, m, ns.Database, ns.Collection)
 	if err != nil {
 		if errors.Is(err, topo.ErrNotFound) {
-			return nil, NamespaceNotFoundError(ns)
+			return nil, NamespaceNotFoundError{ns.Database, ns.Collection}
 		}
 
 		return nil, errors.Wrap(err, "$collStats")
@@ -897,7 +897,7 @@ func NewCappedSegmenter(
 	stats, err := topo.GetCollStats(ctx, m, ns.Database, ns.Collection)
 	if err != nil {
 		if errors.Is(err, topo.ErrNotFound) {
-			return nil, NamespaceNotFoundError(ns)
+			return nil, NamespaceNotFoundError{ns.Database, ns.Collection}
 		}
 
 		return nil, errors.Wrap(err, "$collStats")

--- a/pcsm/copy_test.go
+++ b/pcsm/copy_test.go
@@ -33,7 +33,7 @@ func getNamespace() pcsm.Namespace {
 		panic("PCSM_TEST_NAMESPACE contains invalid namespace")
 	}
 
-	return pcsm.Namespace{db, coll}
+	return pcsm.Namespace{Database: db, Collection: coll}
 }
 
 func getSourceURI() string {

--- a/pcsm/events.go
+++ b/pcsm/events.go
@@ -95,6 +95,9 @@ type Namespace struct {
 
 	// Collection is the name of the collection where the event occurred.
 	Collection string `bson:"coll"`
+
+	// Sharded indicates whether the collection is sharded.
+	Sharded bool
 }
 
 func (ns Namespace) String() string {

--- a/pcsm/repl.go
+++ b/pcsm/repl.go
@@ -573,7 +573,7 @@ func (r *Repl) run(opts *options.ChangeStreamOptionsBuilder) {
 			metrics.AddEventsApplied(1)
 
 			switch change.OperationType { //nolint:exhaustive
-			case Create, Rename, Drop, DropDatabase:
+			case Create, Rename, Drop, DropDatabase, ShardCollection:
 				uuidMap = r.catalog.UUIDMap()
 			}
 		}
@@ -741,6 +741,8 @@ func (r *Repl) applyDDLChange(ctx context.Context, change *ChangeEvent) error {
 			change.Namespace.Collection,
 			event.OperationDescription.ShardKey,
 			event.OperationDescription.Unique)
+
+		lg.Infof("Collection %q has been sharded", change.Namespace)
 
 	case ReshardCollection:
 		fallthrough

--- a/tests/test_collections_sharded.py
+++ b/tests/test_collections_sharded.py
@@ -57,6 +57,13 @@ def test_create_collection_with_collation(t: Testing, phase: Runner.Phase):
         t.source.admin.command(
             "shardCollection", "db_1.coll_1", key={"name": 1}, collation={"locale": "simple"}
         )
+        t.source["db_1"]["coll_1"].insert_many([{"name": "n3"}, {"name": "n2"}, {"name": "n3"}])
+
+        t.source["db_1"].create_collection("coll_2", collation={"locale": "en", "strength": 2})
+        t.source.admin.command(
+            "shardCollection", "db_1.coll_2", key={"_id": "hashed"}, collation={"locale": "simple"}
+        )
+        t.source["db_1"]["coll_2"].insert_many([{"_id": 11}, {"_id": 22}, {"_id": 33}])
 
     t.compare_all_sharded()
 


### PR DESCRIPTION
[![PCSM-200](https://img.shields.io/badge/JIRA-PCSM--200-green?logo=)](https://jira.percona.com/browse/PCSM-200) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Problem**

In replication PCSM is collecting all CRUD events in memory and then sending them in bulk to the target cluster. For a sharded collection that has a non-default collation for MongoDB versions below 8, when performing a bulk write operation it fails with:
```
bulk write exception: write errors: [Failed to target upsert by query :: caused by :: Cannot target single shard due to collation of key _id for namespace test_db1.test_coll]"
```

In order to solve this, bulk write operation for this case has to hold collation specified to `locale:simple`, something like this
```
db.test_coll.bulkWrite([
  {
    replaceOne: {
      filter: { _id: 444},
      replacement: { _id: 444, value: 1 },
      upsert: true,
      collation: { locale: "simple"}   <==============
    }
  }
])
```

**Solution**

Update the catalog so that it holds a `sharded` field for sharded collection so PCSM knows from the catalog that it is a sharded collection. This will most likely be used in the future when working on improving sharding support.

Besides this field now, based on the target version, `collectionBulkWrite` and `cliendBulkWrite` structs will hold a `useSimpleCollation` flag.

With these two new fields, now when we read some CRUD event, we can determine to add a collation `locale:simple` option to the bulk write command.

[PCSM-200]: https://perconadev.atlassian.net/browse/PCSM-200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ