### PR TITLE
PCSM-220: Missing shard key fields from the filter

### DIFF
--- a/hack/rs/compose.yml
+++ b/hack/rs/compose.yml
@@ -1,6 +1,6 @@
 services:
   rs00:
-    image: mongo:8
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: rs00
     hostname: rs00
     ports: ["30000:30000"]
@@ -19,7 +19,7 @@ services:
       ]
 
   rs01:
-    image: mongo:8
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: rs01
     hostname: rs01
     ports: ["30001:30001"]
@@ -38,7 +38,7 @@ services:
       ]
 
   rs02:
-    image: mongo:8
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: rs02
     hostname: rs02
     ports: ["30002:30002"]
@@ -57,7 +57,7 @@ services:
       ]
 
   rs10:
-    image: mongo:8
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: rs10
     hostname: rs10
     ports: ["30100:30100"]
@@ -76,7 +76,7 @@ services:
       ]
 
   rs11:
-    image: mongo:8
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: rs11
     hostname: rs11
     ports: ["30101:30101"]
@@ -95,7 +95,7 @@ services:
       ]
 
   rs12:
-    image: mongo:8
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: rs12
     hostname: rs12
     ports: ["30102:30102"]

--- a/hack/sh-ha/compose.yml
+++ b/hack/sh-ha/compose.yml
@@ -2,7 +2,7 @@ services:
 
   # ----------------- Source -----------------
   src-mongos:
-    image: percona/percona-server-mongodb:8.0
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: src-mongos
     hostname: src-mongos
     ports: ["27017:27017"]
@@ -17,7 +17,7 @@ services:
       ]
 
   src-cfg0:
-    image: percona/percona-server-mongodb:8.0
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: src-cfg0
     hostname: src-cfg0
     ports: ["27000:27000"]
@@ -33,7 +33,7 @@ services:
         "27000",
       ]
   src-cfg1:
-    image: percona/percona-server-mongodb:8.0
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: src-cfg1
     hostname: src-cfg1
     ports: ["27001:27001"]
@@ -49,7 +49,7 @@ services:
         "27001",
       ]
   src-cfg2:
-    image: percona/percona-server-mongodb:8.0
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: src-cfg2
     hostname: src-cfg2
     ports: ["27002:27002"]
@@ -66,7 +66,7 @@ services:
       ]
 
   src-rs00:
-    image: percona/percona-server-mongodb:8.0
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: src-rs00
     hostname: src-rs00
     ports: ["30000:30000"]
@@ -82,7 +82,7 @@ services:
         "30000",
       ]
   src-rs01:
-    image: percona/percona-server-mongodb:8.0
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: src-rs01
     hostname: src-rs01
     ports: ["30001:30001"]
@@ -98,7 +98,7 @@ services:
         "30001",
       ]
   src-rs02:
-    image: percona/percona-server-mongodb:8.0
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: src-rs02
     hostname: src-rs02
     ports: ["30002:30002"]
@@ -115,7 +115,7 @@ services:
       ]
 
   src-rs10:
-    image: percona/percona-server-mongodb:8.0
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: src-rs10
     hostname: src-rs10
     ports: ["30100:30100"]
@@ -131,7 +131,7 @@ services:
         "30100",
       ]
   src-rs11:
-    image: percona/percona-server-mongodb:8.0
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: src-rs11
     hostname: src-rs11
     ports: ["30101:30101"]
@@ -147,7 +147,7 @@ services:
         "30101",
       ]
   src-rs12:
-    image: percona/percona-server-mongodb:8.0
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: src-rs12
     hostname: src-rs12
     ports: ["30102:30102"]
@@ -165,7 +165,7 @@ services:
 
   # ----------------- Target -----------------
   tgt-mongos:
-    image: percona/percona-server-mongodb:8.0
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: tgt-mongos
     hostname: tgt-mongos
     ports: ["29017:27017"]
@@ -180,7 +180,7 @@ services:
       ]
 
   tgt-cfg0:
-    image: percona/percona-server-mongodb:8.0
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: tgt-cfg0
     hostname: tgt-cfg0
     ports: ["28000:28000"]
@@ -196,7 +196,7 @@ services:
         "28000",
       ]
   tgt-cfg1:
-    image: percona/percona-server-mongodb:8.0
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: tgt-cfg1
     hostname: tgt-cfg1
     ports: ["28001:28001"]
@@ -212,7 +212,7 @@ services:
         "28001",
       ]
   tgt-cfg2:
-    image: percona/percona-server-mongodb:8.0
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: tgt-cfg2
     hostname: tgt-cfg2
     ports: ["28002:28002"]
@@ -229,7 +229,7 @@ services:
       ]
 
   tgt-rs00:
-    image: percona/percona-server-mongodb:8.0
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: tgt-rs00
     hostname: tgt-rs00
     ports: ["40000:40000"]
@@ -245,7 +245,7 @@ services:
         "40000",
       ]
   tgt-rs01:
-    image: percona/percona-server-mongodb:8.0
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: tgt-rs01
     hostname: tgt-rs01
     ports: ["40001:40001"]
@@ -261,7 +261,7 @@ services:
         "40001",
       ]
   tgt-rs02:
-    image: percona/percona-server-mongodb:8.0
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: tgt-rs02
     hostname: tgt-rs02
     ports: ["40002:40002"]
@@ -278,7 +278,7 @@ services:
       ]
 
   tgt-rs10:
-    image: percona/percona-server-mongodb:8.0
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: tgt-rs10
     hostname: tgt-rs10
     ports: ["40100:40100"]
@@ -294,7 +294,7 @@ services:
         "40100",
       ]
   tgt-rs11:
-    image: percona/percona-server-mongodb:8.0
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: tgt-rs11
     hostname: tgt-rs11
     ports: ["40101:40101"]
@@ -310,7 +310,7 @@ services:
         "40101",
       ]
   tgt-rs12:
-    image: percona/percona-server-mongodb:8.0
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: tgt-rs12
     hostname: tgt-rs12
     ports: ["40102:40102"]

--- a/hack/sh-ha/run.sh
+++ b/hack/sh-ha/run.sh
@@ -38,7 +38,6 @@ msh "adm:pass@src-mongos:27017" --eval "
     sh.addShard('rs1/src-rs11:30101'); //
     sh.addShard('rs1/src-rs12:30102');
 "
-msh "adm:pass@src-mongos:27017" --eval "db.adminCommand('transitionFromDedicatedConfigServer');"
 
 dcf up -d tgt-cfg0 tgt-cfg1 tgt-cfg2 tgt-rs00 tgt-rs01 tgt-rs02 tgt-rs10 tgt-rs11 tgt-rs12
 
@@ -64,4 +63,3 @@ msh "adm:pass@tgt-mongos:27017" --eval "
     sh.addShard('rs1/tgt-rs11:40101'); //
     sh.addShard('rs1/tgt-rs12:40102');
 "
-msh "adm:pass@tgt-mongos:27017" --eval "db.adminCommand('transitionFromDedicatedConfigServer');"

--- a/hack/sh-ha/run.sh
+++ b/hack/sh-ha/run.sh
@@ -11,7 +11,6 @@ SDIR="$BASE/sh-ha"
 
 chmod 400 "$SDIR"/mongo/keyFile
 
-export MONGO_IMAGE=mongo:8
 export compose=$SDIR/compose.yml
 
 # dcf up -d src-cfg0 src-rs00 src-rs10 tgt-cfg0 tgt-rs00 tgt-rs10

--- a/hack/sh/compose.yml
+++ b/hack/sh/compose.yml
@@ -2,7 +2,7 @@ services:
 
   # ----------------- Source -----------------
   src-mongos:
-    image: percona/percona-server-mongodb:8.0
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: src-mongos
     hostname: src-mongos
     ports: ["27017:27017"]
@@ -17,7 +17,7 @@ services:
       ]
 
   src-cfg0:
-    image: percona/percona-server-mongodb:8.0
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: src-cfg0
     hostname: src-cfg0
     ports: ["27000:27000"]
@@ -34,7 +34,7 @@ services:
       ]
 
   src-rs00:
-    image: percona/percona-server-mongodb:8.0
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: src-rs00
     hostname: src-rs00
     ports: ["30000:30000"]
@@ -51,7 +51,7 @@ services:
       ]
 
   src-rs10:
-    image: percona/percona-server-mongodb:8.0
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: src-rs10
     hostname: src-rs10
     ports: ["30100:30100"]
@@ -69,7 +69,7 @@ services:
 
   # ----------------- Target -----------------
   tgt-mongos:
-    image: percona/percona-server-mongodb:8.0
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: tgt-mongos
     hostname: tgt-mongos
     ports: ["29017:27017"]
@@ -84,7 +84,7 @@ services:
       ]
 
   tgt-cfg0:
-    image: percona/percona-server-mongodb:8.0
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: tgt-cfg0
     hostname: tgt-cfg0
     ports: ["28000:28000"]
@@ -101,7 +101,7 @@ services:
       ]
 
   tgt-rs00:
-    image: percona/percona-server-mongodb:8.0
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: tgt-rs00
     hostname: tgt-rs00
     ports: ["40000:40000"]
@@ -118,7 +118,7 @@ services:
       ]
 
   tgt-rs10:
-    image: percona/percona-server-mongodb:8.0
+    image: "${MONGO_IMAGE:-percona/percona-server-mongodb:8.0}"
     container_name: tgt-rs10
     hostname: tgt-rs10
     ports: ["40100:40100"]

--- a/hack/sh/run.sh
+++ b/hack/sh/run.sh
@@ -25,7 +25,7 @@ msh "adm:pass@src-mongos:27017" --eval "
     sh.addShard('rs0/src-rs00:30000'); //
     sh.addShard('rs1/src-rs10:30100');
 "
-msh "adm:pass@src-mongos:27017" --eval "db.adminCommand('transitionFromDedicatedConfigServer');"
+# msh "adm:pass@src-mongos:27017" --eval "db.adminCommand('transitionFromDedicatedConfigServer');"
 
 dcf up -d tgt-cfg0 tgt-rs00 tgt-rs10
 
@@ -38,4 +38,4 @@ msh "adm:pass@tgt-mongos:27017" --eval "
     sh.addShard('rs0/tgt-rs00:40000'); //
     sh.addShard('rs1/tgt-rs10:40100');
 "
-msh "adm:pass@tgt-mongos:27017" --eval "db.adminCommand('transitionFromDedicatedConfigServer');"
+# msh "adm:pass@tgt-mongos:27017" --eval "db.adminCommand('transitionFromDedicatedConfigServer');"

--- a/hack/sh/run.sh
+++ b/hack/sh/run.sh
@@ -11,7 +11,6 @@ SDIR="$BASE/sh"
 
 chmod 400 "$SDIR"/mongo/keyFile
 
-export MONGO_IMAGE=mongo:8
 export compose=$SDIR/compose.yml
 
 # dcf up -d src-cfg0 src-rs00 src-rs10 tgt-cfg0 tgt-rs00 tgt-rs10

--- a/pcsm/catalog.go
+++ b/pcsm/catalog.go
@@ -91,10 +91,11 @@ type databaseCatalog struct {
 }
 
 type collectionCatalog struct {
-	AddedAt bson.Timestamp
-	UUID    *bson.Binary
-	Indexes []indexCatalogEntry
-	Sharded bool
+	AddedAt  bson.Timestamp
+	UUID     *bson.Binary
+	Indexes  []indexCatalogEntry
+	Sharded  bool
+	ShardKey bson.D
 }
 
 type indexCatalogEntry struct {
@@ -772,6 +773,7 @@ func (c *Catalog) UUIDMap() UUIDMap {
 					Database:   db,
 					Collection: coll,
 					Sharded:    collCat.Sharded,
+					ShardKey:   collCat.ShardKey,
 				}
 			}
 		}
@@ -1192,6 +1194,7 @@ func (c *Catalog) ShardCollection(
 	databaseEntry := c.Databases[db]
 	collectionEntry := databaseEntry.Collections[coll]
 	collectionEntry.Sharded = true
+	collectionEntry.ShardKey = shardKey
 	databaseEntry.Collections[coll] = collectionEntry
 	c.Databases[db] = databaseEntry
 	c.lock.Unlock()

--- a/pcsm/clone.go
+++ b/pcsm/clone.go
@@ -263,7 +263,11 @@ func (c *Clone) run() error {
 	lg.With(log.Size(c.totalSize)).
 		Infof("Estimated Total Size %s", humanize.Bytes(c.totalSize))
 
-	namespaces := c.listPrioritizedNamespaces()
+	namespaces, err := c.listPrioritizedNamespaces()
+	if err != nil {
+		return errors.Wrap(err, "list prioritized namespaces")
+	}
+
 	if len(namespaces) != 0 {
 		err = c.doClone(ctx, namespaces)
 		if err != nil {
@@ -346,9 +350,9 @@ func (c *Clone) doClone(ctx context.Context, namespaces []namespaceInfo) error {
 				}
 
 				c.lock.Lock()
-				elem := c.sizeMap[prevNS.Namespace]
-				delete(c.sizeMap, prevNS.Namespace)
-				c.sizeMap[prevNS.Namespace] = elem
+				elem := c.sizeMap[prevNS.String()]
+				delete(c.sizeMap, prevNS.String())
+				c.sizeMap[prevNS.String()] = elem
 				c.lock.Unlock()
 
 				lg.Infof("Collection %s was renamed to %s. Retrying to clone the collection",
@@ -390,7 +394,7 @@ func (c *Clone) doCollectionClone(
 	var copiedSizeBytesSinceLastLog uint64
 
 	c.lock.Lock()
-	nsSize := c.sizeMap[ns]
+	nsSize := c.sizeMap[ns.String()]
 	c.lock.Unlock()
 
 	lg.With(log.Count(nsSize.Count), log.Size(nsSize.Size)).
@@ -475,9 +479,9 @@ func (c *Clone) doCollectionClone(
 
 				// update estimated size
 				c.lock.Lock()
-				c.totalSize -= c.sizeMap[ns].Size
+				c.totalSize -= c.sizeMap[ns.String()].Size
 				totalSize := c.totalSize
-				delete(c.sizeMap, ns)
+				delete(c.sizeMap, ns.String())
 				c.lock.Unlock()
 
 				metrics.SetEstimatedTotalSizeBytes(totalSize)
@@ -538,10 +542,10 @@ func (c *Clone) doCollectionClone(
 	}
 
 	c.lock.Lock()
-	diff := c.sizeMap[ns].Size - totalCopiedSizeBytes
+	diff := c.sizeMap[ns.String()].Size - totalCopiedSizeBytes
 	c.totalSize -= diff // adjust
 	totalSize := c.totalSize
-	delete(c.sizeMap, ns)
+	delete(c.sizeMap, ns.String())
 	c.lock.Unlock()
 
 	metrics.SetEstimatedTotalSizeBytes(totalSize)
@@ -563,7 +567,7 @@ func (c *Clone) doCollectionClone(
 	return nil
 }
 
-type sizeMap map[Namespace]sizeMapElem
+type sizeMap map[string]sizeMapElem
 
 type sizeMapElem struct {
 	UUID  *bson.Binary
@@ -615,9 +619,10 @@ func (c *Clone) collectSizeMap(ctx context.Context) error {
 				}
 
 				collGrp.Go(func() error {
+					ns := db + "." + spec.Name
 					if spec.Type == topo.TypeView {
 						mu.Lock()
-						sm[Namespace{Database: db, Collection: spec.Name}] = sizeMapElem{}
+						sm[ns] = sizeMapElem{}
 						mu.Unlock()
 
 						return nil
@@ -629,11 +634,11 @@ func (c *Clone) collectSizeMap(ctx context.Context) error {
 							return nil
 						}
 
-						return errors.Wrapf(err, "get collection stats for %q", db+"."+spec.Name)
+						return errors.Wrapf(err, "get collection stats for %q", ns)
 					}
 
 					mu.Lock()
-					sm[Namespace{Database: db, Collection: spec.Name}] = sizeMapElem{
+					sm[ns] = sizeMapElem{
 						UUID:  spec.UUID,
 						Size:  uint64(stats.Size), //nolint:gosec
 						Count: stats.Count,
@@ -673,21 +678,27 @@ type namespaceInfo struct {
 	UUID *bson.Binary
 }
 
-func (c *Clone) listPrioritizedNamespaces() []namespaceInfo {
+func (c *Clone) listPrioritizedNamespaces() ([]namespaceInfo, error) {
 	namespaces := []namespaceInfo{}
+
 	for ns, elem := range c.sizeMap {
+		namespace, err := parseNamespace(ns)
+		if err != nil {
+			return nil, errors.Wrapf(err, "parse namespace %q", ns)
+		}
+
 		namespaces = append(namespaces, namespaceInfo{
-			Namespace: ns,
+			Namespace: namespace,
 			UUID:      elem.UUID,
 		})
 	}
 
 	// sort from larger to smaller
 	slices.SortFunc(namespaces, func(a, b namespaceInfo) int {
-		return cmp.Compare(c.sizeMap[b.Namespace].Size, c.sizeMap[a.Namespace].Size)
+		return cmp.Compare(c.sizeMap[b.Namespace.String()].Size, c.sizeMap[a.Namespace.String()].Size)
 	})
 
-	return namespaces
+	return namespaces, nil
 }
 
 type NamespaceNotFoundError struct {

--- a/pcsm/events.go
+++ b/pcsm/events.go
@@ -98,6 +98,9 @@ type Namespace struct {
 
 	// Sharded indicates whether the collection is sharded.
 	Sharded bool
+
+	// ShardKey is the shard key used for the collection.
+	ShardKey bson.D
 }
 
 func (ns Namespace) String() string {

--- a/tests/test_documents_sharded.py
+++ b/tests/test_documents_sharded.py
@@ -1,0 +1,46 @@
+# pylint: disable=missing-docstring,redefined-outer-name
+from datetime import datetime
+
+import pytest
+from pcsm import Runner
+from testing import Testing
+
+
+@pytest.mark.parametrize("phase", [Runner.Phase.APPLY])
+def test_insert_without_shardkey_in_doc(t: Testing, phase: Runner.Phase):
+    with t.run(phase):
+        t.source["db_1"].create_collection("coll_1")
+        t.source.admin.command("shardCollection", "db_1.coll_1", key={"key_id_1": 1})
+        t.source["db_1"].create_collection("coll_2")
+        t.source.admin.command("shardCollection", "db_1.coll_2", key={"key_id_1": 1, "key_id_2": 1})
+        t.source["db_1"].create_collection("coll_3")
+        t.source.admin.command(
+            "shardCollection", "db_1.coll_3", key={"key_id_1": 1, "key_id_2": "hashed"}
+        )
+
+        t.source["db_1"]["coll_1"].insert_many(
+            [
+                {"_id": 1, "data": "some data 1"},
+                {"_id": 2, "data": "some data 2", "key_id_1": 10},
+            ]
+        )
+
+        t.source["db_1"]["coll_2"].insert_many(
+            [
+                {"_id": 1, "data": "some data 1"},
+                {"_id": 2, "data": "some data 2", "key_id_1": 20},
+                {"_id": 3, "data": "some data 2", "key_id_2": 20},
+                {"_id": 4, "data": "some data 3", "key_id_1": 20, "key_id_2": 30},
+            ]
+        )
+
+        t.source["db_1"]["coll_3"].insert_many(
+            [
+                {"_id": 1, "data": "some data 1"},
+                {"_id": 2, "data": "some data 2", "key_id_1": 30},
+                {"_id": 3, "data": "some data 3", "key_id_2": 40},
+                {"_id": 4, "data": "some data 4", "key_id_1": 30, "key_id_2": 40},
+            ]
+        )
+
+    t.compare_all_sharded()


### PR DESCRIPTION
[![PCSM-220](https://img.shields.io/badge/JIRA-PCSM--220-green?logo=)](https://jira.percona.com/browse/PCSM-220) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Problem**
PCSM uses `replaceOne` to apply `insert` events because to be idempotent when performing recovery (when we try to re-apply already inserted documents). When performing `replaceOne` operation for sharded collections for documents where shard key field(s) are missing for MongoDB versions bellow 8.0, it fails with:
```
bulk write exception: write errors: [Failed to target upsert by query :: could not extract exact shard key]"
```
The reason is `replaceOne` operation requires full shard key in the `filter` document for MongoDB below 8.0.


**Solution**
PCSM now stores shardKey for sharded collections in the catalog. When the `insert` event comes in, for MongoDB versions below 8.0, PCSM checks what shard key fields are missing from the incoming document then all those missing fields are appended to the filter with `null` value.


[PCSM-220]: https://perconadev.atlassian.net/browse/PCSM-220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ