### PR TITLE
PCSM-237: Fix race conditions for clone phase in tests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @inelpandzic @boris-ilijic
+* @inelpandzic @chupe

--- a/tests/test_selective.py
+++ b/tests/test_selective.py
@@ -5,7 +5,9 @@ from pcsm import Runner
 from pymongo import MongoClient
 
 
-def perform_with_options(source, pcsm, phase: Runner.Phase, include_ns=None, exclude_ns=None):
+def perform_with_options(
+    source, target, pcsm, phase: Runner.Phase, include_ns=None, exclude_ns=None
+):
     """Perform the PCSM operation with the given options."""
     pcsm_options = {}
     if include_ns:
@@ -13,7 +15,7 @@ def perform_with_options(source, pcsm, phase: Runner.Phase, include_ns=None, exc
     if exclude_ns:
         pcsm_options["exclude_namespaces"] = exclude_ns
 
-    return Runner(source, pcsm, phase, pcsm_options)
+    return Runner(source, target, pcsm, phase, pcsm_options)
 
 
 def check_if_target_is_subset(source: MongoClient, target: MongoClient):
@@ -35,6 +37,7 @@ def check_if_target_is_subset(source: MongoClient, target: MongoClient):
 def test_create_collection_with_include_only(t: testing.Testing, phase: Runner.Phase):
     with perform_with_options(
         t.source,
+        t.target,
         t.pcsm,
         phase,
         include_ns=["db_0.*", "db_1.coll_0", "db_1.coll_1", "db_2.coll_0", "db_2.coll_1"],
@@ -63,7 +66,7 @@ def test_create_collection_with_include_only(t: testing.Testing, phase: Runner.P
 @pytest.mark.parametrize("phase", [Runner.Phase.APPLY, Runner.Phase.CLONE])
 def test_create_collection_with_exclude_only(t: testing.Testing, phase: Runner.Phase):
     with perform_with_options(
-        t.source, t.pcsm, phase, exclude_ns=["db_0.*", "db_1.coll_0", "db_1.coll_1"]
+        t.source, t.target, t.pcsm, phase, exclude_ns=["db_0.*", "db_1.coll_0", "db_1.coll_1"]
     ):
         for db in range(3):
             for coll in range(3):
@@ -90,6 +93,7 @@ def test_create_collection_with_exclude_only(t: testing.Testing, phase: Runner.P
 def test_create_collection(t: testing.Testing, phase: Runner.Phase):
     with perform_with_options(
         t.source,
+        t.target,
         t.pcsm,
         phase,
         include_ns=["db_0.*", "db_1.coll_0", "db_1.coll_1", "db_2.coll_0", "db_2.coll_1"],
@@ -104,15 +108,12 @@ def test_create_collection(t: testing.Testing, phase: Runner.Phase):
         # "db_0.coll_0",
         # "db_0.coll_1",
         # "db_0.coll_2",
-
         # "db_1.coll_0",
         "db_1.coll_1",
         # "db_1.coll_2",
-
         "db_2.coll_0",
         "db_2.coll_1",
         # "db_2.coll_2",
-
         "db_3.coll_0",
         # "db_3.coll_1",
         "db_3.coll_2",

--- a/tests/test_selective_sharded.py
+++ b/tests/test_selective_sharded.py
@@ -5,7 +5,9 @@ from pcsm import Runner
 from pymongo import MongoClient
 
 
-def perform_with_options(source, pcsm, phase: Runner.Phase, include_ns=None, exclude_ns=None):
+def perform_with_options(
+    source, target, pcsm, phase: Runner.Phase, include_ns=None, exclude_ns=None
+):
     """Perform the PCSM operation with the given options."""
     pcsm_options = {}
     if include_ns:
@@ -13,7 +15,7 @@ def perform_with_options(source, pcsm, phase: Runner.Phase, include_ns=None, exc
     if exclude_ns:
         pcsm_options["exclude_namespaces"] = exclude_ns
 
-    return Runner(source, pcsm, phase, pcsm_options)
+    return Runner(source, target, pcsm, phase, pcsm_options)
 
 
 def check_if_target_is_subset(source: MongoClient, target: MongoClient):
@@ -35,6 +37,7 @@ def check_if_target_is_subset(source: MongoClient, target: MongoClient):
 def test_create_collection_with_include_only(t: testing.Testing, phase: Runner.Phase):
     with perform_with_options(
         t.source,
+        t.target,
         t.pcsm,
         phase,
         include_ns=["db_0.*", "db_1.coll_0", "db_1.coll_1", "db_2.coll_0", "db_2.coll_1"],
@@ -64,7 +67,7 @@ def test_create_collection_with_include_only(t: testing.Testing, phase: Runner.P
 @pytest.mark.parametrize("phase", [Runner.Phase.APPLY, Runner.Phase.CLONE])
 def test_create_collection_with_exclude_only(t: testing.Testing, phase: Runner.Phase):
     with perform_with_options(
-        t.source, t.pcsm, phase, exclude_ns=["db_0.*", "db_1.coll_0", "db_1.coll_1"]
+        t.source, t.target, t.pcsm, phase, exclude_ns=["db_0.*", "db_1.coll_0", "db_1.coll_1"]
     ):
         for db in range(3):
             for coll in range(3):
@@ -92,6 +95,7 @@ def test_create_collection_with_exclude_only(t: testing.Testing, phase: Runner.P
 def test_create_collection(t: testing.Testing, phase: Runner.Phase):
     with perform_with_options(
         t.source,
+        t.target,
         t.pcsm,
         phase,
         include_ns=["db_0.*", "db_1.coll_0", "db_1.coll_1", "db_2.coll_0", "db_2.coll_1"],
@@ -107,15 +111,12 @@ def test_create_collection(t: testing.Testing, phase: Runner.Phase):
         # "db_0.coll_0",
         # "db_0.coll_1",
         # "db_0.coll_2",
-
         # "db_1.coll_0",
         "db_1.coll_1",
         # "db_1.coll_2",
-
         "db_2.coll_0",
         "db_2.coll_1",
         # "db_2.coll_2",
-
         "db_3.coll_0",
         # "db_3.coll_1",
         "db_3.coll_2",

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -17,7 +17,7 @@ class Testing:
 
     def run(self, phase: Runner.Phase, wait_timeout=None):
         """Perform the PCSM operation for the given phase."""
-        return Runner(self.source, self.pcsm, phase, {}, wait_timeout=wait_timeout)
+        return Runner(self.source, self.target, self.pcsm, phase, {}, wait_timeout=wait_timeout)
 
     def compare_all(self, sort=None):
         """Compare all databases and collections between source and target MongoDB."""


### PR DESCRIPTION
[![PCSM-237](https://img.shields.io/badge/JIRA-PCSM--237-green?logo=)](https://jira.percona.com/browse/PCSM-237) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

### Problem

  Intermittent test failures with `WaitTimeoutError` in CLONE phase tests when PCSM has nothing to replicate:
  - `test_drop_capped_collection[phase:clone]`
  - `test_drop_database[phase:clone]`
  - `test_create_timeseries_ignored[phase:clone]`

In CLONE phase, test operations complete before PCSM starts. When there's nothing to replicate (dropped collections, ignored timeseries), initial sync completes instantly. The test's `finalize()` then calls `wait_for_current_optime()` which appends an oplog note and waits for PCSM to process it. However, PCSM may not be actively  processing new oplog entries when initial sync is already complete, causing a 10-second timeout.

### Solution

  Two-part fix in `tests/pcsm.py`:

  1. **Add 0.5s delay after `resume()`** - Gives replication stream time to become active before expecting oplog processing

  2. **Phase-aware wait logic** - Skip `wait_for_current_optime()` when both conditions are true:
     - Phase is CLONE (operations happened before PCSM started)
     - Initial sync already completed (PCSM has caught up by definition)

     For APPLY/MANUAL phases, always wait to ensure real-time operations are replicated.

  3. **Metadata visibility fallback** - When skipping wait, use ping retries with exponential backoff to ensure MongoDB driver
   metadata cache is refreshed

[PCSM-237]: https://perconadev.atlassian.net/browse/PCSM-237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ