### PR TITLE
PCSM-201 Add some configurability to local environment scripts

### DIFF
--- a/hack/cleanup.sh
+++ b/hack/cleanup.sh
@@ -61,16 +61,19 @@ cleanup_env() {
 for env in "${ENVS_TO_CLEAN[@]}"; do
     case $env in
         rs)
-            cleanup_env "rs" "$SCRIPT_DIR/rs/compose.yml"
-            docker volume ls -q | grep -E '^rs[0-9]+' | xargs -r docker volume rm 2>/dev/null || true
+            cleanup_env "rs" "$SCRIPT_DIR/rs/compose.yml" "r1"
+            docker volume ls -q | grep -E '^r1_rs[0-9]+' | xargs -r docker volume rm 2>/dev/null || true
+            docker network ls -q --filter "name=r1_" | xargs -r docker network rm 2>/dev/null || true
             ;;
         sh)
             cleanup_env "sh" "$SCRIPT_DIR/sh/compose.yml" "s1"
             docker volume ls -q | grep -E '^(src-|tgt-|s1_)' | xargs -r docker volume rm 2>/dev/null || true
+            docker network ls -q --filter "name=s1_" | xargs -r docker network rm 2>/dev/null || true
             ;;
         sh-ha)
             cleanup_env "sh-ha" "$SCRIPT_DIR/sh-ha/compose.yml" "s1"
             docker volume ls -q | grep -E '^s1_' | xargs -r docker volume rm 2>/dev/null || true
+            docker network ls -q --filter "name=s1_" | xargs -r docker network rm 2>/dev/null || true
             ;;
     esac
 done

--- a/hack/rs/run.sh
+++ b/hack/rs/run.sh
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
+# Start MongoDB replica sets for source and target
+#
+# Usage:
+#   ./run.sh           # Default: start both rs0 and rs1
+#   RS_COUNT=1 ./run.sh   # Start only rs0
+#   RS_COUNT=2 ./run.sh   # Start both rs0 and rs1
+#
+# Limits: Max 2 replica sets (rs0 and rs1)
+# Each replica set has 3 members (rs{N}0, rs{N}1, rs{N}2)
+# Ports: rs0 uses 30000-30002, rs1 uses 30100-30102
+
+export COMPOSE_PROJECT_NAME=r1
 
 BASE=$(dirname "$(dirname "$0")")
+echo "BASE=$BASE"
 
 # shellcheck source=/dev/null
 source "$BASE/util"
@@ -9,16 +22,55 @@ RDIR="$BASE/rs"
 
 export compose="$RDIR/compose.yml"
 
-dcf up -d rs00 rs01 rs02 rs10 rs11 rs12
+# Port mappings for each replica set (must match compose.yml)
+# rs0: 30000, 30001, 30002
+# rs1: 30100, 30101, 30102
+RS_PORTS=(
+    "30000 30001 30002"
+    "30100 30101 30102"
+)
 
-mwait "rs00:30000"
-mwait "rs01:30001"
-mwait "rs02:30002"
+# Dynamically defined by the length of sets of ports
+MAX_RS_COUNT=${#RS_PORTS[@]}
 
-rsinit "scripts/rs0" "rs00:30000"
+# Configuration: Number of replica sets to start
+# Can be overridden with environment variable: RS_COUNT=1 ./run.sh
+RS_COUNT="${RS_COUNT:-$MAX_RS_COUNT}"
 
-mwait "rs10:30100"
-mwait "rs11:30101"
-mwait "rs12:30102"
+if [ "$RS_COUNT" -gt "$MAX_RS_COUNT" ]; then
+    echo "ERROR: RS_COUNT=$RS_COUNT exceeds maximum $MAX_RS_COUNT"
+    echo "Available init scripts: $RDIR/mongo/scripts/rs{0..$((MAX_RS_COUNT-1))}.js"
+    exit 1
+fi
 
-rsinit "scripts/rs1" "rs10:30100"
+if [ "$RS_COUNT" -lt 1 ]; then
+    echo "ERROR: RS_COUNT=$RS_COUNT must be at least 1"
+    exit 1
+fi
+
+echo "Starting $RS_COUNT replica set(s) (max: $MAX_RS_COUNT)"
+
+# Build list of services to start and initialize each replica set
+SERVICES=""
+for rs_idx in $(seq 0 $((RS_COUNT - 1))); do
+    echo "Starting replica set rs${rs_idx}"
+    SERVICES="$SERVICES rs${rs_idx}0 rs${rs_idx}1 rs${rs_idx}2"
+done
+
+# Start the selected services
+dcf up -d $SERVICES
+
+# Initialize each replica set
+for rs_idx in $(seq 0 $((RS_COUNT - 1))); do
+    # Get ports for this replica set
+    read -r -a PORTS <<< "${RS_PORTS[$rs_idx]}"
+
+    # Wait for all members
+    for member_idx in 0 1 2; do
+        PORT=${PORTS[$member_idx]}
+        mwait "rs${rs_idx}${member_idx}:${PORT}"
+    done
+
+    # Initialize replica set
+    rsinit "scripts/rs${rs_idx}" "rs${rs_idx}0:${PORTS[0]}"
+done

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -228,7 +228,7 @@ def test_update_one_multiple_arrays(t: Testing, phase: Runner.Phase):
 
 
 @pytest.mark.parametrize("phase", [Runner.Phase.APPLY])
-def test_update_one_with_trucated_arrays(t: Testing, phase: Runner.Phase):
+def test_update_one_with_truncated_arrays(t: Testing, phase: Runner.Phase):
     t.source["db_1"]["coll_1"].insert_one(
         {
             "i": "f1",


### PR DESCRIPTION
[![PCSM-201](https://img.shields.io/badge/JIRA-PCSM--201-green?logo=)](https://jira.percona.com/browse/PCSM-201) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The PR adds infrastructure improvements to support testing PCSM replication from a ReplicaSet source to a Sharded cluster target. This configuration validates that PCSM can replicate collections from RS topology to sharded topology.

- **`hack/rs/run.sh`**: Made replica set count configurable via `RS_COUNT` environment variable (default: 2, max: 2). Added dynamic service initialization based on count.

- **`hack/sh/run.sh`**: Added support for skipping source or target cluster creation via `SRC_SHARDS=0` or `TGT_SHARDS=0`. This enables RS→Sharded testing by using `hack/rs/run.sh` for the source and `hack/sh/run.sh` with `SRC_SHARDS=0` for the target.

- **`hack/cleanup.sh`**: Improved cleanup to remove networks and volumes created by both environments, ensuring clean teardown between test runs.

- **`tests/test_documents.py`**: Fixed typo in test name (`trucated` → `truncated`)

**Testing:**

RS→Sharded configuration validated locally with:
```bash
RS_COUNT=1 ./hack/rs/run.sh
SRC_SHARDS=0 TGT_SHARDS=2 ./hack/sh/run.sh
```

E2E test suite ran against MongoDB 6.0, 7.0, and 8.0.

[PCSM-201]: https://perconadev.atlassian.net/browse/PCSM-201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ