### PR TITLE
PCSM-230: Fix filtered sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md - Percona ClusterSync for MongoDB
+
+## Build/Lint/Test Commands
+- **Build**: `make build` (production) or `make test-build` (with race detection)
+- **Lint**: `make lint` (uses golangci-lint with gofmt, gofumpt, goimports)
+- **Test Go**: `go test -race ./...` or `make test`
+- **Test Python**: `poetry run pytest` or `make pytest`
+- **Single Go Test**: `go test -race -run TestName ./package`
+- **Single Python Test**: `poetry run pytest tests/test_file.py::test_name`
+- **Clean**: `make clean`
+
+## Code Style Guidelines
+- **Imports**: Group stdlib, third-party, local (separated by blank lines). Use `goimports` for formatting.
+- **Error Handling**: Use custom `errors` package (`errors.Wrap`, `errors.New`, `errors.Join`). Always wrap errors with context. Return `nil` for nil errors in Wrap.
+- **Types**: Prefer explicit types. Use generics where appropriate. Document exported types with comments.
+- **Naming**: Use camelCase for unexported, PascalCase for exported. Acronyms stay uppercase (e.g., `URI`, `HTTP`).
+- **Comments**: Document all exported functions/types with godoc format. Start with the function/type name.
+- **Linting**: Follow golangci-lint v2 with most linters enabled (see `.golangci.yml`). Use `//nolint:lintername` sparingly with justification.
+- **Context**: Pass `context.Context` as first parameter. Use `util.CtxWithTimeout` for timeout operations.
+- **Formatting**: Use `gofmt` and `gofumpt`. Max line length flexible but keep readable. Use tabs for indentation.
+- **Testing**: Use `testify` for assertions. Add `-race` flag. Python tests use `pytest` with `pymongo`.

--- a/hack/change_stream.py
+++ b/hack/change_stream.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# poetry run python3 .dev/change_stream.py mongodb://adm:pass@rs00:30000
+# poetry run python3 .dev/change_stream.py mongodb://rs00:30000
 
 import sys
 from signal import SIG_DFL, SIGINT, signal
@@ -7,7 +7,7 @@ from signal import SIG_DFL, SIGINT, signal
 import bson.json_util as json
 import pymongo
 
-MONGODB_URI = "mongodb://adm:pass@rs00:30000"
+MONGODB_URI = "mongodb://rs00:30000"
 
 ignoreCheckpoints = True  # set to False to see all changes, including checkpoints
 
@@ -26,7 +26,7 @@ if __name__ == "__main__":
         del change["wallTime"]
 
         ns = change["ns"]["db"]
-        
+
         if ignoreCheckpoints and ns == "percona_link_mongodb":
             continue
 

--- a/hack/compare-all.py
+++ b/hack/compare-all.py
@@ -7,11 +7,11 @@ import pymongo
 from pymongo import ASCENDING, MongoClient
 from pymongo.collection import Collection
 
-SRC_URI = "mongodb://adm:pass@rs00:30000"
-TGT_URI = "mongodb://adm:pass@rs10:30100"
+SRC_URI = "mongodb://rs00:30000"
+TGT_URI = "mongodb://rs10:30100"
 
-SRC_SH_URI = "mongodb://adm:pass@src-mongos:27017"
-TGT_SH_URI = "mongodb://adm:pass@tgt-mongos:29017"
+SRC_SH_URI = "mongodb://src-mongos:27017"
+TGT_SH_URI = "mongodb://tgt-mongos:29017"
 
 src = pymongo.MongoClient(SRC_SH_URI)
 tgt = pymongo.MongoClient(TGT_SH_URI)

--- a/hack/drop-all.py
+++ b/hack/drop-all.py
@@ -2,11 +2,11 @@
 
 import pymongo
 
-SRC_URI = "mongodb://adm:pass@rs00:30000"
-TGT_URI = "mongodb://adm:pass@rs10:30100"
+SRC_URI = "mongodb://rs00:30000"
+TGT_URI = "mongodb://rs10:30100"
 
-SRC_SH_URI = "mongodb://adm:pass@src-mongos:27017"
-TGT_SH_URI = "mongodb://adm:pass@tgt-mongos:29017"
+SRC_SH_URI = "mongodb://src-mongos:27017"
+TGT_SH_URI = "mongodb://tgt-mongos:29017"
 
 src = pymongo.MongoClient(SRC_SH_URI)
 tgt = pymongo.MongoClient(TGT_SH_URI)

--- a/hack/oplog_stream.py
+++ b/hack/oplog_stream.py
@@ -4,7 +4,7 @@ import bson.json_util as json
 import pymongo
 
 if __name__ == "__main__":
-    MONGODB_URI = "mongodb://adm:pass@rs10:30100,rs11:30101,rs12:30102"
+    MONGODB_URI = "mongodb://rs10:30100,rs11:30101,rs12:30102"
     m = pymongo.MongoClient(MONGODB_URI, readPreference="primary")
     for change in m.local["oplog.rs"].find():
         del change["_id"]

--- a/hack/reference.md
+++ b/hack/reference.md
@@ -10,7 +10,7 @@ host.docker.internal:2242/metrics
 ## MongoLink CLI
 
 ```shell
-go install . && pml --source="mongodb://rs00:30000" --target="mongodb://rs10:30100" --reset-state --log-level="debug"
+go install . && pcsm --source="mongodb://rs00:30000" --target="mongodb://rs10:30100" --reset-state --log-level="debug"
 ```
 
 

--- a/hack/reference.md
+++ b/hack/reference.md
@@ -10,7 +10,7 @@ host.docker.internal:2242/metrics
 ## MongoLink CLI
 
 ```shell
-go install . && pml --source="mongodb://adm:pass@rs00:30000" --target="mongodb://adm:pass@rs10:30100" --reset-state --log-level="debug"
+go install . && pml --source="mongodb://rs00:30000" --target="mongodb://rs10:30100" --reset-state --log-level="debug"
 ```
 
 

--- a/hack/rs/generate-data.py
+++ b/hack/rs/generate-data.py
@@ -4,7 +4,7 @@ from bson.decimal128 import Decimal128
 import pymongo
 from pymongo import MongoClient
 
-MONGODB_URI = "mongodb://adm:pass@rs00:30000"
+MONGODB_URI = "mongodb://rs00:30000"
 client = MongoClient(MONGODB_URI)
 db = client["stress_test_db"]
 

--- a/hack/rs/generate-replication-data.py
+++ b/hack/rs/generate-replication-data.py
@@ -7,7 +7,7 @@ import time
 from bson import ObjectId, BSON
 from datetime import datetime
 
-uri = "mongodb://adm:pass@rs00:30000"
+uri = "mongodb://rs00:30000"
 # uri="mongodb://inel:m0sl1RoYDXkSLEse@cluster0.vrfly.mongodb.net/"
 
 

--- a/hack/rs/generate-replication-txn.py
+++ b/hack/rs/generate-replication-txn.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import threading
 
 # MongoDB connection
-uri = "mongodb://adm:pass@rs00:30000"
+uri = "mongodb://rs00:30000"
 client = MongoClient(uri)  # Ensure you have a replica set
 
 # Databases and collections

--- a/hack/rs/load.py
+++ b/hack/rs/load.py
@@ -7,7 +7,7 @@ import time
 from bson import ObjectId, BSON
 from datetime import datetime
 
-uri="mongodb://adm:pass@rs00:30000"
+uri="mongodb://rs00:30000"
 # uri="mongodb://inel:m0sl1RoYDXkSLEse@cluster0.vrfly.mongodb.net/"
 
 def log(msg):

--- a/hack/sh/scripts/drop-all.py
+++ b/hack/sh/scripts/drop-all.py
@@ -2,8 +2,8 @@
 
 import pymongo
 
-SRC_URI = "mongodb://adm:pass@src-mongos:27017"
-TGT_URI = "mongodb://adm:pass@tgt-mongos:29017"
+SRC_URI = "mongodb://src-mongos:27017"
+TGT_URI = "mongodb://tgt-mongos:29017"
 
 src = pymongo.MongoClient(SRC_URI)
 tgt = pymongo.MongoClient(TGT_URI)

--- a/hack/sh/scripts/load-hashed.py
+++ b/hack/sh/scripts/load-hashed.py
@@ -7,7 +7,7 @@ import time
 from bson import ObjectId, BSON
 from datetime import datetime
 
-uri="mongodb://adm:pass@src-mongos:27017"
+uri="mongodb://src-mongos:27017"
 # uri="mongodb://inel:m0sl1RoYDXkSLEse@cluster0.vrfly.mongodb.net/"
 
 def create_sharded_collection(db, collection_name, shard_key):

--- a/hack/sh/scripts/load-ranged.py
+++ b/hack/sh/scripts/load-ranged.py
@@ -7,7 +7,7 @@ import time
 from bson import ObjectId, BSON
 from datetime import datetime
 
-uri = "mongodb://adm:pass@src-mongos:27017"
+uri = "mongodb://src-mongos:27017"
 # uri="mongodb://inel:m0sl1RoYDXkSLEse@cluster0.vrfly.mongodb.net/"
 
 

--- a/pcsm/clone.go
+++ b/pcsm/clone.go
@@ -618,6 +618,8 @@ func (c *Clone) collectSizeMap(ctx context.Context) error {
 					continue
 				}
 
+				lg.With(log.NS(db, spec.Name)).Infof("Namespace %q included", db+"."+spec.Name)
+
 				collGrp.Go(func() error {
 					ns := db + "." + spec.Name
 					if spec.Type == topo.TypeView {

--- a/sel/sel.go
+++ b/sel/sel.go
@@ -3,6 +3,8 @@ package sel
 import (
 	"slices"
 	"strings"
+
+	"github.com/percona/percona-clustersync-mongodb/log"
 )
 
 // NSFilter returns true if a namespace is allowed.
@@ -13,12 +15,17 @@ func AllowAllFilter(string, string) bool {
 }
 
 func MakeFilter(include, exclude []string) NSFilter {
+	lg := log.New("filter")
+
 	if len(include) == 0 && len(exclude) == 0 {
 		return AllowAllFilter
 	}
 
 	includeFilter := doMakeFitler(include)
 	excludeFilter := doMakeFitler(exclude)
+
+	lg.Infof("Include filter: %v", strings.Join(include, ", "))
+	lg.Infof("Exclude filter: %v", strings.Join(exclude, ", "))
 
 	return func(db, coll string) bool {
 		_, dbIncluded := includeFilter[db]

--- a/sel/sel.go
+++ b/sel/sel.go
@@ -21,8 +21,8 @@ func MakeFilter(include, exclude []string) NSFilter {
 		return AllowAllFilter
 	}
 
-	includeFilter := doMakeFitler(include)
-	excludeFilter := doMakeFitler(exclude)
+	includeFilter := doMakeFilter(include)
+	excludeFilter := doMakeFilter(exclude)
 
 	lg.Infof("Include filter: %v", strings.Join(include, ", "))
 	lg.Infof("Exclude filter: %v", strings.Join(exclude, ", "))
@@ -74,7 +74,7 @@ func (f filterMap) Has(db, coll string) bool {
 	return slices.Contains(list, coll) // only if explcitly listed
 }
 
-func doMakeFitler(filter []string) filterMap {
+func doMakeFilter(filter []string) filterMap {
 	// keys are database names. values are list collections that belong to the db.
 	// if a key contains empty/nil, whole db is included (all its collections).
 	filterMap := make(map[string][]string)

--- a/sel/sel.go
+++ b/sel/sel.go
@@ -22,38 +22,32 @@ func MakeFilter(include, exclude []string) NSFilter {
 
 	return func(db, coll string) bool {
 		_, dbIncluded := includeFilter[db]
-		_, dbExcluded := excludeFilter[db]
 
 		nsIncluded := len(includeFilter) > 0 && includeFilter.Has(db, coll)
 		nsExcluded := len(excludeFilter) > 0 && excludeFilter.Has(db, coll)
 
-		if nsIncluded && dbIncluded && !nsExcluded {
-			// If the namespace is included, it is allowed.
-			// Also make sure that the namespace is not excluded,
-			// because exclusion takes precedence.
-			return true
-		}
-
-		if dbIncluded && !nsExcluded {
-			// If the database is included in the filter,
-			// but the namespace is not included, it is not allowed.
-			// Also make sure that the namespace is not excluded,
-			// because exclusion takes precedence.
+		// Exclusion takes precedence - if explicitly excluded, deny immediately.
+		if nsExcluded {
 			return false
 		}
 
-		if nsExcluded && dbExcluded {
-			// If the namespace is excluded, it is not allowed.
+		// If include filter exists, use whitelist logic (deny by default).
+		if len(includeFilter) > 0 {
+			// Allow if namespace is explicitly included.
+			if nsIncluded {
+				return true
+			}
+			// DB is in include filter but collection is not - deny.
+			if dbIncluded {
+				return false
+			}
+			// DB not in include filter at all - deny.
 			return false
 		}
 
-		if dbExcluded {
-			// If the database is included in the filter,
-			// but the namespace is not excluded, it is allowed.
-			return true
-		}
+		// No include filter (exclude-only or no filters).
+		// Allow by default since exclusions are already handled above.
 
-		// If the namespace is not present in either filter, it is allowed by default.
 		return true
 	}
 }

--- a/sel/sel_test.go
+++ b/sel/sel_test.go
@@ -6,6 +6,172 @@ import (
 	"github.com/percona/percona-clustersync-mongodb/sel"
 )
 
+func TestFilterNew(t *testing.T) {
+	t.Parallel()
+
+	// Base namespaces present in source - 3 DBs with 2 collections each
+	baseNamespaces := map[string]map[string]bool{
+		"test_db1": {
+			"test_collection1": false,
+			"test_collection2": false,
+		},
+		"test_db2": {
+			"test_collection1": false,
+			"test_collection2": false,
+		},
+		"test_db3": {
+			"test_collection1": false,
+			"test_collection2": false,
+		},
+	}
+
+	// prepareNamespaces sets expected inclusion results for all base namespaces,
+	// based on the provided expected map.
+	prepareNamespaces := func(expected map[string]map[string]bool) map[string]map[string]bool {
+		result := make(map[string]map[string]bool)
+
+		for db, colls := range baseNamespaces {
+			result[db] = make(map[string]bool)
+
+			for coll := range colls {
+				if expColls, ok := expected[db]; ok {
+					result[db][coll] = expColls[coll]
+				} else {
+					result[db][coll] = false
+				}
+			}
+		}
+
+		return result
+	}
+
+	t.Run("case 1: include one DB, no exclusions", func(t *testing.T) {
+		t.Parallel()
+
+		includeFilter := []string{"test_db1.*"}
+
+		namespaces := prepareNamespaces(map[string]map[string]bool{
+			"test_db1": {
+				"test_collection1": true,
+				"test_collection2": true,
+			},
+		})
+
+		isIncluded := sel.MakeFilter(includeFilter, nil)
+
+		for db, colls := range namespaces {
+			for coll, expected := range colls {
+				if got := isIncluded(db, coll); got != expected {
+					t.Errorf("%s.%s: expected %v, got %v", db, coll, expected, got)
+				}
+			}
+		}
+	})
+
+	t.Run("case 2: include one collection, no exclusions", func(t *testing.T) {
+		t.Parallel()
+
+		includeFilter := []string{"test_db1.test_collection1"}
+
+		namespaces := prepareNamespaces(map[string]map[string]bool{
+			"test_db1": {
+				"test_collection1": true,
+				"test_collection2": false,
+			},
+		})
+
+		isIncluded := sel.MakeFilter(includeFilter, nil)
+
+		for db, colls := range namespaces {
+			for coll, expected := range colls {
+				if got := isIncluded(db, coll); got != expected {
+					t.Errorf("%s.%s: expected %v, got %v", db, coll, expected, got)
+				}
+			}
+		}
+	})
+
+	t.Run("case 3a: include and exclude same DB", func(t *testing.T) {
+		t.Parallel()
+
+		includeFilter := []string{"test_db1.*"}
+		excludeFilter := []string{"test_db1.*"}
+
+		namespaces := prepareNamespaces(map[string]map[string]bool{})
+
+		isIncluded := sel.MakeFilter(includeFilter, excludeFilter)
+
+		for db, colls := range namespaces {
+			for coll, expected := range colls {
+				if got := isIncluded(db, coll); got != expected {
+					t.Errorf("%s.%s: expected %v, got %v", db, coll, expected, got)
+				}
+			}
+		}
+	})
+
+	t.Run("case 3b: include and exclude same collection", func(t *testing.T) {
+		t.Parallel()
+
+		includeFilter := []string{"test_db1.test_collection1"}
+		excludeFilter := []string{"test_db1.test_collection1"}
+
+		namespaces := prepareNamespaces(map[string]map[string]bool{})
+
+		isIncluded := sel.MakeFilter(includeFilter, excludeFilter)
+
+		for db, colls := range namespaces {
+			for coll, expected := range colls {
+				if got := isIncluded(db, coll); got != expected {
+					t.Errorf("%s.%s: expected %v, got %v", db, coll, expected, got)
+				}
+			}
+		}
+	})
+
+	t.Run("case 4: include collection with mistake in name", func(t *testing.T) {
+		t.Parallel()
+
+		includeFilter := []string{"test_db1.mistake_in_collection_name"}
+
+		namespaces := prepareNamespaces(map[string]map[string]bool{})
+
+		isIncluded := sel.MakeFilter(includeFilter, nil)
+
+		for db, colls := range namespaces {
+			for coll, expected := range colls {
+				if got := isIncluded(db, coll); got != expected {
+					t.Errorf("%s.%s: expected %v, got %v", db, coll, expected, got)
+				}
+			}
+		}
+	})
+
+	t.Run("case 5: include DB and exclude one collection from it", func(t *testing.T) {
+		t.Parallel()
+
+		includeFilter := []string{"test_db1.*"}
+		excludeFilter := []string{"test_db1.test_collection1"}
+
+		namespaces := prepareNamespaces(map[string]map[string]bool{
+			"test_db1": {
+				"test_collection1": false,
+				"test_collection2": true,
+			},
+		})
+
+		isIncluded := sel.MakeFilter(includeFilter, excludeFilter)
+
+		for db, colls := range namespaces {
+			for coll, expected := range colls {
+				if got := isIncluded(db, coll); got != expected {
+					t.Errorf("%s.%s: expected %v, got %v", db, coll, expected, got)
+				}
+			}
+		}
+	})
+}
+
 func TestFilter(t *testing.T) {
 	t.Parallel()
 
@@ -30,9 +196,9 @@ func TestFilter(t *testing.T) {
 				"coll_2": false,
 			},
 			"db_2": {
-				"coll_0": true,
-				"coll_1": true,
-				"coll_2": true,
+				"coll_0": false,
+				"coll_1": false,
+				"coll_2": false,
 			},
 		}
 

--- a/sel/sel_test.go
+++ b/sel/sel_test.go
@@ -6,299 +6,236 @@ import (
 	"github.com/percona/percona-clustersync-mongodb/sel"
 )
 
-func TestFilterNew(t *testing.T) {
-	t.Parallel()
-
-	// Base namespaces present in source - 3 DBs with 2 collections each
-	baseNamespaces := map[string]map[string]bool{
-		"test_db1": {
-			"test_collection1": false,
-			"test_collection2": false,
-		},
-		"test_db2": {
-			"test_collection1": false,
-			"test_collection2": false,
-		},
-		"test_db3": {
-			"test_collection1": false,
-			"test_collection2": false,
-		},
-	}
-
-	// prepareNamespaces sets expected inclusion results for all base namespaces,
-	// based on the provided expected map.
-	prepareNamespaces := func(expected map[string]map[string]bool) map[string]map[string]bool {
-		result := make(map[string]map[string]bool)
-
-		for db, colls := range baseNamespaces {
-			result[db] = make(map[string]bool)
-
-			for coll := range colls {
-				if expColls, ok := expected[db]; ok {
-					result[db][coll] = expColls[coll]
-				} else {
-					result[db][coll] = false
-				}
-			}
-		}
-
-		return result
-	}
-
-	t.Run("case 1: include one DB, no exclusions", func(t *testing.T) {
-		t.Parallel()
-
-		includeFilter := []string{"test_db1.*"}
-
-		namespaces := prepareNamespaces(map[string]map[string]bool{
-			"test_db1": {
-				"test_collection1": true,
-				"test_collection2": true,
-			},
-		})
-
-		isIncluded := sel.MakeFilter(includeFilter, nil)
-
-		for db, colls := range namespaces {
-			for coll, expected := range colls {
-				if got := isIncluded(db, coll); got != expected {
-					t.Errorf("%s.%s: expected %v, got %v", db, coll, expected, got)
-				}
-			}
-		}
-	})
-
-	t.Run("case 2: include one collection, no exclusions", func(t *testing.T) {
-		t.Parallel()
-
-		includeFilter := []string{"test_db1.test_collection1"}
-
-		namespaces := prepareNamespaces(map[string]map[string]bool{
-			"test_db1": {
-				"test_collection1": true,
-				"test_collection2": false,
-			},
-		})
-
-		isIncluded := sel.MakeFilter(includeFilter, nil)
-
-		for db, colls := range namespaces {
-			for coll, expected := range colls {
-				if got := isIncluded(db, coll); got != expected {
-					t.Errorf("%s.%s: expected %v, got %v", db, coll, expected, got)
-				}
-			}
-		}
-	})
-
-	t.Run("case 3a: include and exclude same DB", func(t *testing.T) {
-		t.Parallel()
-
-		includeFilter := []string{"test_db1.*"}
-		excludeFilter := []string{"test_db1.*"}
-
-		namespaces := prepareNamespaces(map[string]map[string]bool{})
-
-		isIncluded := sel.MakeFilter(includeFilter, excludeFilter)
-
-		for db, colls := range namespaces {
-			for coll, expected := range colls {
-				if got := isIncluded(db, coll); got != expected {
-					t.Errorf("%s.%s: expected %v, got %v", db, coll, expected, got)
-				}
-			}
-		}
-	})
-
-	t.Run("case 3b: include and exclude same collection", func(t *testing.T) {
-		t.Parallel()
-
-		includeFilter := []string{"test_db1.test_collection1"}
-		excludeFilter := []string{"test_db1.test_collection1"}
-
-		namespaces := prepareNamespaces(map[string]map[string]bool{})
-
-		isIncluded := sel.MakeFilter(includeFilter, excludeFilter)
-
-		for db, colls := range namespaces {
-			for coll, expected := range colls {
-				if got := isIncluded(db, coll); got != expected {
-					t.Errorf("%s.%s: expected %v, got %v", db, coll, expected, got)
-				}
-			}
-		}
-	})
-
-	t.Run("case 4: include collection with mistake in name", func(t *testing.T) {
-		t.Parallel()
-
-		includeFilter := []string{"test_db1.mistake_in_collection_name"}
-
-		namespaces := prepareNamespaces(map[string]map[string]bool{})
-
-		isIncluded := sel.MakeFilter(includeFilter, nil)
-
-		for db, colls := range namespaces {
-			for coll, expected := range colls {
-				if got := isIncluded(db, coll); got != expected {
-					t.Errorf("%s.%s: expected %v, got %v", db, coll, expected, got)
-				}
-			}
-		}
-	})
-
-	t.Run("case 5: include DB and exclude one collection from it", func(t *testing.T) {
-		t.Parallel()
-
-		includeFilter := []string{"test_db1.*"}
-		excludeFilter := []string{"test_db1.test_collection1"}
-
-		namespaces := prepareNamespaces(map[string]map[string]bool{
-			"test_db1": {
-				"test_collection1": false,
-				"test_collection2": true,
-			},
-		})
-
-		isIncluded := sel.MakeFilter(includeFilter, excludeFilter)
-
-		for db, colls := range namespaces {
-			for coll, expected := range colls {
-				if got := isIncluded(db, coll); got != expected {
-					t.Errorf("%s.%s: expected %v, got %v", db, coll, expected, got)
-				}
-			}
-		}
-	})
-}
-
 func TestFilter(t *testing.T) {
 	t.Parallel()
 
-	t.Run("include", func(t *testing.T) {
-		t.Parallel()
-
-		includeFilter := []string{
-			"db_0.*",
-			"db_1.coll_0",
-			"db_1.coll_1",
-		}
-
-		namespaces := map[string]map[string]bool{
-			"db_0": {
-				"coll_0": true,
-				"coll_1": true,
-				"coll_2": true,
+	tests := []struct {
+		name           string
+		includeFilter  []string
+		excludeFilter  []string
+		testNamespaces map[string]map[string]bool
+	}{
+		// Core filter modes
+		{
+			name: "include only",
+			includeFilter: []string{
+				"db_0.*",
+				"db_1.coll_0",
+				"db_1.coll_1",
 			},
-			"db_1": {
-				"coll_0": true,
-				"coll_1": true,
-				"coll_2": false,
+			excludeFilter: nil,
+			testNamespaces: map[string]map[string]bool{
+				"db_0": {
+					"coll_0": true,
+					"coll_1": true,
+					"coll_2": true,
+				},
+				"db_1": {
+					"coll_0": true,
+					"coll_1": true,
+					"coll_2": false,
+				},
+				"db_2": {
+					"coll_0": false,
+					"coll_1": false,
+					"coll_2": false,
+				},
 			},
-			"db_2": {
-				"coll_0": false,
-				"coll_1": false,
-				"coll_2": false,
+		},
+		{
+			name:          "exclude only",
+			includeFilter: nil,
+			excludeFilter: []string{
+				"db_0.*",
+				"db_1.coll_0",
+				"db_1.coll_1",
 			},
-		}
+			testNamespaces: map[string]map[string]bool{
+				"db_0": {
+					"coll_0": false,
+					"coll_1": false,
+					"coll_2": false,
+				},
+				"db_1": {
+					"coll_0": false,
+					"coll_1": false,
+					"coll_2": true,
+				},
+				"db_2": {
+					"coll_0": true,
+					"coll_1": true,
+					"coll_2": true,
+				},
+			},
+		},
+		{
+			name: "include with exclude",
+			includeFilter: []string{
+				"db_0.*",
+				"db_1.coll_0",
+				"db_1.coll_1",
+				"db_2.coll_0",
+				"db_2.coll_1",
+			},
+			excludeFilter: []string{
+				"db_0.*",
+				"db_1.coll_0",
+				"db_3.coll_1",
+			},
+			testNamespaces: map[string]map[string]bool{
+				"db_0": {
+					"coll_0": false,
+					"coll_1": false,
+					"coll_2": false,
+				},
+				"db_1": {
+					"coll_0": false,
+					"coll_1": true,
+					"coll_2": false,
+				},
+				"db_2": {
+					"coll_0": true,
+					"coll_1": true,
+					"coll_2": false,
+				},
+				"db_3": {
+					"coll_0": false,
+					"coll_1": false,
+					"coll_2": false,
+				},
+			},
+		},
 
-		isIncluded := sel.MakeFilter(includeFilter, nil)
+		// More advanced inclusion/exclusion scenarios
+		{
+			name:          "include one DB, no exclusions",
+			includeFilter: []string{"test_db1.*"},
+			excludeFilter: nil,
+			testNamespaces: map[string]map[string]bool{
+				"test_db1": {
+					"test_collection1": true,
+					"test_collection2": true,
+				},
+				"test_db2": {
+					"test_collection1": false,
+					"test_collection2": false,
+				},
+				"test_db3": {
+					"test_collection1": false,
+					"test_collection2": false,
+				},
+			},
+		},
+		{
+			name:          "include one collection, no exclusions",
+			includeFilter: []string{"test_db1.test_collection1"},
+			excludeFilter: nil,
+			testNamespaces: map[string]map[string]bool{
+				"test_db1": {
+					"test_collection1": true,
+					"test_collection2": false,
+				},
+				"test_db2": {
+					"test_collection1": false,
+					"test_collection2": false,
+				},
+				"test_db3": {
+					"test_collection1": false,
+					"test_collection2": false,
+				},
+			},
+		},
+		{
+			name:          "include and exclude same DB",
+			includeFilter: []string{"test_db1.*"},
+			excludeFilter: []string{"test_db1.*"},
+			testNamespaces: map[string]map[string]bool{
+				"test_db1": {
+					"test_collection1": false,
+					"test_collection2": false,
+				},
+				"test_db2": {
+					"test_collection1": false,
+					"test_collection2": false,
+				},
+				"test_db3": {
+					"test_collection1": false,
+					"test_collection2": false,
+				},
+			},
+		},
+		{
+			name:          "include and exclude same collection",
+			includeFilter: []string{"test_db1.test_collection1"},
+			excludeFilter: []string{"test_db1.test_collection1"},
+			testNamespaces: map[string]map[string]bool{
+				"test_db1": {
+					"test_collection1": false,
+					"test_collection2": false,
+				},
+				"test_db2": {
+					"test_collection1": false,
+					"test_collection2": false,
+				},
+				"test_db3": {
+					"test_collection1": false,
+					"test_collection2": false,
+				},
+			},
+		},
+		{
+			name:          "include collection with mistake in name",
+			includeFilter: []string{"test_db1.mistake_in_collection_name"},
+			excludeFilter: nil,
+			testNamespaces: map[string]map[string]bool{
+				"test_db1": {
+					"test_collection1": false,
+					"test_collection2": false,
+				},
+				"test_db2": {
+					"test_collection1": false,
+					"test_collection2": false,
+				},
+				"test_db3": {
+					"test_collection1": false,
+					"test_collection2": false,
+				},
+			},
+		},
+		{
+			name:          "include DB and exclude one collection from it",
+			includeFilter: []string{"test_db1.*"},
+			excludeFilter: []string{"test_db1.test_collection1"},
+			testNamespaces: map[string]map[string]bool{
+				"test_db1": {
+					"test_collection1": false,
+					"test_collection2": true,
+				},
+				"test_db2": {
+					"test_collection1": false,
+					"test_collection2": false,
+				},
+				"test_db3": {
+					"test_collection1": false,
+					"test_collection2": false,
+				},
+			},
+		},
+	}
 
-		for db, colls := range namespaces {
-			for coll, expected := range colls {
-				if got := isIncluded(db, coll); got != expected {
-					t.Errorf("%s.%s: expected %v, got %v", db, coll, expected, got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			filter := sel.MakeFilter(tt.includeFilter, tt.excludeFilter)
+
+			for db, colls := range tt.testNamespaces {
+				for coll, expected := range colls {
+					if got := filter(db, coll); got != expected {
+						t.Errorf("%s.%s: expected %v, got %v", db, coll, expected, got)
+					}
 				}
 			}
-		}
-	})
-
-	t.Run("exclude", func(t *testing.T) {
-		t.Parallel()
-
-		excludedFilter := []string{
-			"db_0.*",
-			"db_1.coll_0",
-			"db_1.coll_1",
-		}
-
-		namespaces := map[string]map[string]bool{
-			"db_0": {
-				"coll_0": false,
-				"coll_1": false,
-				"coll_2": false,
-			},
-			"db_1": {
-				"coll_0": false,
-				"coll_1": false,
-				"coll_2": true,
-			},
-			"db_2": {
-				"coll_0": true,
-				"coll_1": true,
-				"coll_2": true,
-			},
-		}
-
-		isIncluded := sel.MakeFilter(nil, excludedFilter)
-
-		for db, colls := range namespaces {
-			for coll, expected := range colls {
-				if got := isIncluded(db, coll); got != expected {
-					t.Errorf("%s.%s: expected %v, got %v", db, coll, expected, got)
-				}
-			}
-		}
-	})
-
-	t.Run("include with exclude", func(t *testing.T) {
-		t.Parallel()
-
-		includedFilter := []string{
-			"db_0.*",
-			"db_1.coll_0",
-			"db_1.coll_1",
-			"db_2.coll_0",
-			"db_2.coll_1",
-		}
-
-		excludedFilter := []string{
-			"db_0.*",
-			"db_1.coll_0",
-			"db_3.coll_1",
-		}
-
-		namespaces := map[string]map[string]bool{
-			"db_0": {
-				"coll_0": false,
-				"coll_1": false,
-				"coll_2": false,
-			},
-			"db_1": {
-				"coll_0": false,
-				"coll_1": true,
-				"coll_2": false,
-			},
-			"db_2": {
-				"coll_0": true,
-				"coll_1": true,
-				"coll_2": false,
-			},
-			"db_3": {
-				"coll_0": false,
-				"coll_1": false,
-				"coll_2": false,
-			},
-		}
-
-		isIncluded := sel.MakeFilter(includedFilter, excludedFilter)
-
-		for db, colls := range namespaces {
-			for coll, expected := range colls {
-				if got := isIncluded(db, coll); got != expected {
-					t.Errorf("%s.%s: expected %v, got %v", db, coll, expected, got)
-				}
-			}
-		}
-	})
+		})
+	}
 }

--- a/sel/sel_test.go
+++ b/sel/sel_test.go
@@ -285,9 +285,9 @@ func TestFilter(t *testing.T) {
 				"coll_2": false,
 			},
 			"db_3": {
-				"coll_0": true,
+				"coll_0": false,
 				"coll_1": false,
-				"coll_2": true,
+				"coll_2": false,
 			},
 		}
 

--- a/tests/test_selective.py
+++ b/tests/test_selective.py
@@ -90,7 +90,7 @@ def test_create_collection_with_exclude_only(t: testing.Testing, phase: Runner.P
 
 
 @pytest.mark.parametrize("phase", [Runner.Phase.APPLY, Runner.Phase.CLONE])
-def test_create_collection(t: testing.Testing, phase: Runner.Phase):
+def test_create_collection_with_both_include_exclude(t: testing.Testing, phase: Runner.Phase):
     with perform_with_options(
         t.source,
         t.target,
@@ -114,9 +114,9 @@ def test_create_collection(t: testing.Testing, phase: Runner.Phase):
         "db_2.coll_0",
         "db_2.coll_1",
         # "db_2.coll_2",
-        "db_3.coll_0",
+        # "db_3.coll_0",
         # "db_3.coll_1",
-        "db_3.coll_2",
+        # "db_3.coll_2",
     }
 
     assert expected == set(testing.list_all_namespaces(t.target))

--- a/tests/test_selective_sharded.py
+++ b/tests/test_selective_sharded.py
@@ -92,7 +92,7 @@ def test_create_collection_with_exclude_only(t: testing.Testing, phase: Runner.P
 
 
 @pytest.mark.parametrize("phase", [Runner.Phase.APPLY, Runner.Phase.CLONE])
-def test_create_collection(t: testing.Testing, phase: Runner.Phase):
+def test_create_collection_with_both_include_exclude(t: testing.Testing, phase: Runner.Phase):
     with perform_with_options(
         t.source,
         t.target,
@@ -117,9 +117,9 @@ def test_create_collection(t: testing.Testing, phase: Runner.Phase):
         "db_2.coll_0",
         "db_2.coll_1",
         # "db_2.coll_2",
-        "db_3.coll_0",
+        # "db_3.coll_0",
         # "db_3.coll_1",
-        "db_3.coll_2",
+        # "db_3.coll_2",
     }
 
     assert expected == set(testing.list_all_namespaces(t.target))


### PR DESCRIPTION
[![PCSM-230](https://img.shields.io/badge/JIRA-PCSM--230-green?logo=)](https://jira.percona.com/browse/PCSM-230) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

### Problem

Filter logic was incorrect - namespaces not in the include filter were being allowed when both include and exclude filters were specified. The intended behavior is that when an include filter is present, only those namespaces explicitly included should be allowed (like a whitelist behavior), while exclusions should always take precedence.

### Solution

Fixed `MakeFilter` function to correctly implement whitelist behavior when include filters are specified.

Filter Semantics
- Include only → Behaves like a whitelist: only sync explicitly included namespaces
- Exclude only → Behaves like a blacklist: sync everything except excluded namespaces  
- Include + Exclude → Exclusion wins, then whitelist applies. Essentially excludes everything from a whitelist (include filter)
- No filters → Sync everything

Example: Include db1 entirely, exclude one collection from it
`--include-namespaces="db1.*" --exclude-namespaces="db1.logs"`
**Result**: Syncs db1.users, db1.orders, etc. but NOT db1.logs or any other databases

Besides this, logging was added to print the include and exclude filters at filter creation time for easier debugging.
This handles task https://perconadev.atlassian.net/browse/PCSM-179

Also:
- Added `AGENTS.md` to help agents with the project.
- Fixed `hack` scripts not to use auth for dev clusters.

[PCSM-230]: https://perconadev.atlassian.net/browse/PCSM-230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ