### PR TITLE
PCSM-218: Clone refactor

### DIFF
--- a/hack/sh/compose.yml
+++ b/hack/sh/compose.yml
@@ -22,8 +22,8 @@ services:
     image: "percona/percona-server-mongodb:${MONGO_VERSION:-8.0}"
     container_name: src-cfg0
     hostname: src-cfg0
-    mem_limit: 1g
-    memswap_limit: 1g
+    mem_limit: 2g
+    memswap_limit: 2g
     ports: ["27000:27000"]
     volumes: ["src-cfg0:/data/db", "./mongo/:/cfg:ro"]
     command:
@@ -41,8 +41,8 @@ services:
     image: "percona/percona-server-mongodb:${MONGO_VERSION:-8.0}"
     container_name: src-rs00
     hostname: src-rs00
-    mem_limit: 1g
-    memswap_limit: 1g
+    mem_limit: 2g
+    memswap_limit: 2g
     ports: ["30000:30000"]
     volumes: ["src-rs00:/data/db", "./mongo/:/cfg:ro"]
     command:
@@ -60,8 +60,8 @@ services:
     image: "percona/percona-server-mongodb:${MONGO_VERSION:-8.0}"
     container_name: src-rs10
     hostname: src-rs10
-    mem_limit: 1g
-    memswap_limit: 1g
+    mem_limit: 2g
+    memswap_limit: 2g
     ports: ["30100:30100"]
     volumes: ["src-rs10:/data/db", "./mongo/:/cfg:ro"]
     command:
@@ -79,8 +79,8 @@ services:
     image: "percona/percona-server-mongodb:${MONGO_VERSION:-8.0}"
     container_name: src-rs20
     hostname: src-rs20
-    mem_limit: 1g
-    memswap_limit: 1g
+    mem_limit: 2g
+    memswap_limit: 2g
     ports: ["30200:30200"]
     volumes: ["src-rs20:/data/db", "./mongo/:/cfg:ro"]
     command:
@@ -116,8 +116,8 @@ services:
     image: "percona/percona-server-mongodb:${MONGO_VERSION:-8.0}"
     container_name: tgt-cfg0
     hostname: tgt-cfg0
-    mem_limit: 1g
-    memswap_limit: 1g
+    mem_limit: 2g
+    memswap_limit: 2g
     ports: ["28000:28000"]
     volumes: ["tgt-cfg0:/data/db", "./mongo/:/cfg:ro"]
     command:
@@ -135,8 +135,8 @@ services:
     image: "percona/percona-server-mongodb:${MONGO_VERSION:-8.0}"
     container_name: tgt-rs00
     hostname: tgt-rs00
-    mem_limit: 1g
-    memswap_limit: 1g
+    mem_limit: 2g
+    memswap_limit: 2g
     ports: ["40000:40000"]
     volumes: ["tgt-rs00:/data/db", "./mongo/:/cfg:ro"]
     command:
@@ -154,8 +154,8 @@ services:
     image: "percona/percona-server-mongodb:${MONGO_VERSION:-8.0}"
     container_name: tgt-rs10
     hostname: tgt-rs10
-    mem_limit: 1g
-    memswap_limit: 1g
+    mem_limit: 2g
+    memswap_limit: 2g
     ports: ["40100:40100"]
     volumes: ["tgt-rs10:/data/db", "./mongo/:/cfg:ro"]
     command:
@@ -173,8 +173,8 @@ services:
     image: "percona/percona-server-mongodb:${MONGO_VERSION:-8.0}"
     container_name: tgt-rs20
     hostname: tgt-rs20
-    mem_limit: 1g
-    memswap_limit: 1g
+    mem_limit: 2g
+    memswap_limit: 2g
     ports: ["40200:40200"]
     volumes: ["tgt-rs20:/data/db", "./mongo/:/cfg:ro"]
     command:

--- a/pcsm/clone.go
+++ b/pcsm/clone.go
@@ -52,7 +52,7 @@ type Clone struct {
 	lock sync.Mutex
 	err  error // Error encountered during the cloning process
 
-	doneSig chan struct{}
+	done chan struct{}
 
 	sizeMap    sizeMap
 	totalSize  uint64        // Estimated total bytes to be cloned
@@ -107,7 +107,7 @@ func NewClone(
 		catalog:  catalog,
 		nsFilter: nsFilter,
 		options:  opts,
-		doneSig:  make(chan struct{}),
+		done:     make(chan struct{}),
 	}
 }
 
@@ -196,7 +196,7 @@ func (c *Clone) Done() <-chan struct{} {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	return c.doneSig
+	return c.done
 }
 
 // Start starts the cloning process.
@@ -233,9 +233,9 @@ func (c *Clone) Start(context.Context) error {
 		}
 
 		select {
-		case <-c.doneSig:
+		case <-c.done:
 		default:
-			close(c.doneSig)
+			close(c.done)
 		}
 
 		c.finishTime = time.Now()

--- a/pcsm/clone.go
+++ b/pcsm/clone.go
@@ -488,10 +488,10 @@ func (c *Clone) doCollectionClone(
 
 	lastLogAt = time.Now() // init
 
-	updateC := copyManager.Do(nsCtx, ns, spec)
+	progressUpdates := copyManager.Do(nsCtx, ns, spec)
 
-	for update := range updateC {
-		err := update.Err
+	for progressUpdate := range progressUpdates {
+		err := progressUpdate.Err
 		if err != nil {
 			switch {
 			case topo.IsCollectionDropped(err):
@@ -524,8 +524,8 @@ func (c *Clone) doCollectionClone(
 
 			default:
 				updateLog := lg.With(
-					log.Size(update.SizeBytes),
-					log.Count(int64(update.Count)),
+					log.Size(progressUpdate.SizeBytes),
+					log.Count(int64(progressUpdate.Count)),
 					log.Elapsed(time.Since(lastLogAt)))
 
 				if errors.Is(err, context.Canceled) {
@@ -538,12 +538,12 @@ func (c *Clone) doCollectionClone(
 			}
 		}
 
-		totalCopiedCount += int64(update.Count)
-		totalCopiedSizeBytes += update.SizeBytes
-		c.copiedSize.Add(update.SizeBytes)
+		totalCopiedCount += int64(progressUpdate.Count)
+		totalCopiedSizeBytes += progressUpdate.SizeBytes
+		c.copiedSize.Add(progressUpdate.SizeBytes)
 
-		copiedCountSinceLastLog += int64(update.Count)
-		copiedSizeBytesSinceLastLog += update.SizeBytes
+		copiedCountSinceLastLog += int64(progressUpdate.Count)
+		copiedSizeBytesSinceLastLog += progressUpdate.SizeBytes
 
 		if copiedSizeBytesSinceLastLog >= humanize.GByte {
 			now := time.Now()

--- a/pcsm/clone.go
+++ b/pcsm/clone.go
@@ -488,7 +488,7 @@ func (c *Clone) doCollectionClone(
 
 	lastLogAt = time.Now() // init
 
-	progressUpdateCh := copyManager.Do(nsCtx, ns, spec)
+	progressUpdateCh := copyManager.Start(nsCtx, ns, spec)
 
 	for progressUpdate := range progressUpdateCh {
 		err := progressUpdate.Err

--- a/pcsm/copy.go
+++ b/pcsm/copy.go
@@ -69,14 +69,14 @@ type CopyManagerOptions struct {
 	// min: 1; default: [runtime.NumCPU] * 4.
 	NumInsertWorkers int
 	// SegmentSizeBytes is the logical segment size in bytes for splitting collections.
-	// min: 192MB [config.MinCloneSegmentSizeBytes].
-	// min: 64GiB [config.MaxCloneSegmentSizeBytes].
+	// min: [config.MinCloneSegmentSizeBytes].
+	// min: [config.MaxCloneSegmentSizeBytes].
 	// default: auto (per collection) [config.AutoCloneSegmentSize].
 	SegmentSizeBytes int64
 	// ReadBatchSizeBytes is the maximum read batch size in bytes.
-	// min: 16MiB [config.MinCloneReadBatchSizeBytes].
-	// max: 2GiB [config.MaxCloneReadBatchSizeBytes].
-	// default: 96MB [config.DefaultCloneReadBatchSizeBytes].
+	// min: [config.MinCloneReadBatchSizeBytes].
+	// max: [config.MaxCloneReadBatchSizeBytes].
+	// default: config.DefaultCloneReadBatchSizeBytes].
 	ReadBatchSizeBytes int32
 }
 

--- a/pcsm/copy.go
+++ b/pcsm/copy.go
@@ -265,7 +265,7 @@ func (cm *CopyManager) copyCollection(
 		close(insertResults)       // exit
 	}()
 
-	// spawn readSegment in loop until the collection is exhausted or canceled.
+	// Dispatches read workers for each segment.
 	go func() {
 		var segmentID uint32
 
@@ -304,6 +304,7 @@ func (cm *CopyManager) copyCollection(
 
 			pendingSegments.Add(1)
 
+			// Launch a read worker for the segment.
 			go func() {
 				defer func() {
 					<-cm.readLimit

--- a/pcsm/repl.go
+++ b/pcsm/repl.go
@@ -57,8 +57,8 @@ type Repl struct {
 	pauseTime time.Time
 
 	pausing bool
-	pauseC  chan struct{}
-	done    chan struct{}
+	pauseCh chan struct{}
+	doneCh  chan struct{}
 
 	bulkWrite      bulkWrite
 	bulkToken      bson.Raw
@@ -106,8 +106,8 @@ func NewRepl(
 		nsFilter: nsFilter,
 		catalog:  catalog,
 		options:  opts,
-		pauseC:   make(chan struct{}),
-		done:     make(chan struct{}),
+		pauseCh:  make(chan struct{}),
+		doneCh:   make(chan struct{}),
 	}
 }
 
@@ -216,7 +216,7 @@ func (r *Repl) Done() <-chan struct{} {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	return r.done
+	return r.doneCh
 }
 
 // Start begins the replication process from the specified start timestamp.
@@ -279,13 +279,13 @@ func (r *Repl) Pause(context.Context) error {
 
 func (r *Repl) doPause() {
 	r.pausing = true
-	done := r.done
+	doneCh := r.doneCh
 
 	go func() {
 		log.New("repl").Debug("Change Replication is pausing")
 
-		r.pauseC <- struct{}{}
-		<-done
+		r.pauseCh <- struct{}{}
+		<-doneCh
 
 		r.lock.Lock()
 		r.pauseTime = time.Now()
@@ -333,7 +333,7 @@ func (r *Repl) Resume(context.Context) error {
 	}
 
 	r.pauseTime = time.Time{}
-	r.done = make(chan struct{})
+	r.doneCh = make(chan struct{})
 
 	go r.run(options.ChangeStream().SetStartAtOperationTime(&r.lastReplicatedOpTime))
 
@@ -346,7 +346,7 @@ func (r *Repl) Resume(context.Context) error {
 func (r *Repl) watchChangeEvents(
 	ctx context.Context,
 	streamOptions *options.ChangeStreamOptionsBuilder,
-	changeC chan<- *ChangeEvent,
+	changeCh chan<- *ChangeEvent,
 ) error {
 	cur, err := r.source.Watch(ctx, mongo.Pipeline{},
 		streamOptions.SetShowExpandedEvents(true).
@@ -386,7 +386,7 @@ func (r *Repl) watchChangeEvents(
 			}
 
 			if !change.IsTransaction() {
-				changeC <- change
+				changeCh <- change
 				lastEventTS = change.ClusterTime
 
 				continue
@@ -408,15 +408,15 @@ func (r *Repl) watchChangeEvents(
 					}
 
 					// send the entire transaction for replication
-					changeC <- txn0
+					changeCh <- txn0
 					for _, txn := range txnOps {
-						changeC <- txn
+						changeCh <- txn
 					}
 					clear(txnOps)
 					txnOps = txnOps[:0]
 
 					if !change.IsTransaction() {
-						changeC <- change
+						changeCh <- change
 						txn0 = nil // no more transaction
 
 						break // return to non-transactional processing
@@ -435,9 +435,9 @@ func (r *Repl) watchChangeEvents(
 				}
 
 				// no event available. the entire transaction is received
-				changeC <- txn0
+				changeCh <- txn0
 				for _, txn := range txnOps {
-					changeC <- txn
+					changeCh <- txn
 				}
 				clear(txnOps)
 				txnOps = txnOps[:0]
@@ -452,7 +452,7 @@ func (r *Repl) watchChangeEvents(
 
 		// no event available yet. progress pcsm time
 		if sourceTS.After(lastEventTS) {
-			changeC <- &ChangeEvent{
+			changeCh <- &ChangeEvent{
 				EventHeader: EventHeader{
 					OperationType: advanceTimePseudoEvent,
 					ClusterTime:   sourceTS,
@@ -463,23 +463,23 @@ func (r *Repl) watchChangeEvents(
 }
 
 func (r *Repl) run(opts *options.ChangeStreamOptionsBuilder) {
-	defer close(r.done)
+	defer close(r.doneCh)
 
 	ctx := context.Background()
-	changeC := make(chan *ChangeEvent, config.ReplQueueSize)
+	changeChh := make(chan *ChangeEvent, config.ReplQueueSize)
 
 	go func() {
-		defer close(changeC)
+		defer close(changeChh)
 
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 
 		go func() {
-			<-r.pauseC
+			<-r.pauseCh
 			cancel()
 		}()
 
-		err := r.watchChangeEvents(ctx, opts, changeC)
+		err := r.watchChangeEvents(ctx, opts, changeChh)
 		if err != nil && !errors.Is(err, context.Canceled) {
 			if topo.IsChangeStreamHistoryLost(err) || topo.IsCappedPositionLost(err) {
 				err = ErrOplogHistoryLost
@@ -494,7 +494,7 @@ func (r *Repl) run(opts *options.ChangeStreamOptionsBuilder) {
 
 	lg := log.New("repl")
 
-	for change := range changeC {
+	for change := range changeChh {
 		if time.Since(r.lastBulkDoneAt) >= config.BulkOpsInterval && !r.bulkWrite.Empty() {
 			if !r.doBulkOps(ctx) {
 				return

--- a/pcsm/state_test.go
+++ b/pcsm/state_test.go
@@ -110,8 +110,8 @@ func TestPause_StateValidation(t *testing.T) {
 
 			if tt.setupRepl {
 				p.repl = &Repl{
-					pauseC:  make(chan struct{}),
-					doneSig: make(chan struct{}),
+					pauseC: make(chan struct{}),
+					done:   make(chan struct{}),
 				}
 			}
 
@@ -182,8 +182,8 @@ func TestResume_StateValidation(t *testing.T) {
 
 			if tt.initialState == StatePaused || tt.initialState == StateFailed {
 				p.repl = &Repl{
-					pauseC:  make(chan struct{}),
-					doneSig: make(chan struct{}),
+					pauseC: make(chan struct{}),
+					done:   make(chan struct{}),
 				}
 			}
 
@@ -205,11 +205,11 @@ func TestFinalize_FailsFromFailedStateWithoutIgnoreHistoryLost(t *testing.T) {
 		onStateChanged: func(State) {},
 		err:            ErrOplogHistoryLost,
 		clone: &Clone{
-			doneSig: make(chan struct{}),
+			done: make(chan struct{}),
 		},
 		repl: &Repl{
-			pauseC:  make(chan struct{}),
-			doneSig: make(chan struct{}),
+			pauseC: make(chan struct{}),
+			done:   make(chan struct{}),
 		},
 	}
 
@@ -228,8 +228,8 @@ func TestResumeFromPaused_FailsWhenReplNotStarted(t *testing.T) {
 		state:          StatePaused,
 		onStateChanged: func(State) {},
 		repl: &Repl{
-			pauseC:  make(chan struct{}),
-			doneSig: make(chan struct{}),
+			pauseC: make(chan struct{}),
+			done:   make(chan struct{}),
 		},
 	}
 
@@ -249,7 +249,7 @@ func TestResumeFromFailed_FailsWhenReplNotPaused(t *testing.T) {
 		onStateChanged: func(State) {},
 		repl: &Repl{
 			pauseC:    make(chan struct{}),
-			doneSig:   make(chan struct{}),
+			done:      make(chan struct{}),
 			startTime: time.Now(),
 		},
 	}

--- a/pcsm/state_test.go
+++ b/pcsm/state_test.go
@@ -110,8 +110,8 @@ func TestPause_StateValidation(t *testing.T) {
 
 			if tt.setupRepl {
 				p.repl = &Repl{
-					pauseC: make(chan struct{}),
-					done:   make(chan struct{}),
+					pauseCh: make(chan struct{}),
+					doneCh:  make(chan struct{}),
 				}
 			}
 
@@ -182,8 +182,8 @@ func TestResume_StateValidation(t *testing.T) {
 
 			if tt.initialState == StatePaused || tt.initialState == StateFailed {
 				p.repl = &Repl{
-					pauseC: make(chan struct{}),
-					done:   make(chan struct{}),
+					pauseCh: make(chan struct{}),
+					doneCh:  make(chan struct{}),
 				}
 			}
 
@@ -205,11 +205,11 @@ func TestFinalize_FailsFromFailedStateWithoutIgnoreHistoryLost(t *testing.T) {
 		onStateChanged: func(State) {},
 		err:            ErrOplogHistoryLost,
 		clone: &Clone{
-			done: make(chan struct{}),
+			doneCh: make(chan struct{}),
 		},
 		repl: &Repl{
-			pauseC: make(chan struct{}),
-			done:   make(chan struct{}),
+			pauseCh: make(chan struct{}),
+			doneCh:  make(chan struct{}),
 		},
 	}
 
@@ -228,8 +228,8 @@ func TestResumeFromPaused_FailsWhenReplNotStarted(t *testing.T) {
 		state:          StatePaused,
 		onStateChanged: func(State) {},
 		repl: &Repl{
-			pauseC: make(chan struct{}),
-			done:   make(chan struct{}),
+			pauseCh: make(chan struct{}),
+			doneCh:  make(chan struct{}),
 		},
 	}
 
@@ -248,8 +248,8 @@ func TestResumeFromFailed_FailsWhenReplNotPaused(t *testing.T) {
 		state:          StateFailed,
 		onStateChanged: func(State) {},
 		repl: &Repl{
-			pauseC:    make(chan struct{}),
-			done:      make(chan struct{}),
+			pauseCh:   make(chan struct{}),
+			doneCh:    make(chan struct{}),
 			startTime: time.Now(),
 		},
 	}

--- a/tests/perf_test.go
+++ b/tests/perf_test.go
@@ -243,11 +243,11 @@ func copyDocuments(b *testing.B, source, target *mongo.Client, db, coll string) 
 	maxReadCount := maxWriteCount
 
 	totalCopiedBytes := int64(0)
-	documentC := make(chan bson.Raw, maxWriteCount)
-	done := make(chan error)
+	documentCh := make(chan bson.Raw, maxWriteCount)
+	doneCh := make(chan error)
 
 	go func() {
-		defer close(done)
+		defer close(doneCh)
 
 		// b.Logf("avg_doc_size=%d max_read_count=%d max_write_size=%d max_write_count=%d",
 		// 	averageDocumentSize, maxReadCount, maxWriteSize, maxWriteCount)
@@ -258,12 +258,12 @@ func copyDocuments(b *testing.B, source, target *mongo.Client, db, coll string) 
 		batch := make([]any, 0, maxReadCount)
 		batchSize := 0
 
-		for doc := range documentC {
+		for doc := range documentCh {
 			docSize := len(doc)
 			if len(batch)+1 > cap(batch) || batchSize+docSize > maxWriteSize {
 				_, err := targetCollection.InsertMany(ctx, batch, insertOptions)
 				if err != nil {
-					done <- err
+					doneCh <- err
 
 					return
 				}
@@ -285,7 +285,7 @@ func copyDocuments(b *testing.B, source, target *mongo.Client, db, coll string) 
 		if len(batch) != 0 {
 			_, err := targetCollection.InsertMany(ctx, batch, insertOptions)
 			if err != nil {
-				done <- err
+				doneCh <- err
 
 				return
 			}
@@ -304,17 +304,17 @@ func copyDocuments(b *testing.B, source, target *mongo.Client, db, coll string) 
 	defer cur.Close(ctx)
 
 	for cur.Next(ctx) {
-		documentC <- cur.Current
+		documentCh <- cur.Current
 	}
 
-	close(documentC)
+	close(documentCh)
 
 	err = cur.Err()
 	if err != nil {
 		return totalCopiedBytes, errors.Wrap(err, "cursor")
 	}
 
-	err = <-done
+	err = <-doneCh
 
 	return totalCopiedBytes, errors.Wrap(err, "insert documents")
 }

--- a/tests/test_slow.py
+++ b/tests/test_slow.py
@@ -36,9 +36,10 @@ def cleanup_numerous_databases(source: pymongo.MongoClient, target: pymongo.Mong
 def test_slow_clone_2gb(t: Testing):
     with t.run(phase=Runner.Phase.CLONE, wait_timeout=300):
         for _ in range(5):
-            t.source["db_0"]["coll_0"].insert_many(
-                ({"s": random.randbytes(1024)} for _ in range(420000)),
-            )
+            for _ in range(42):  # 42 batches x 10,000 = 420,000 docs
+                t.source["db_0"]["coll_0"].insert_many(
+                    [{"s": random.randbytes(1024)} for _ in range(10000)],
+                )
 
     try:
         t.compare_all(sort=[("_id", 1)])
@@ -53,12 +54,13 @@ def test_slow_clone_2gb(t: Testing):
 def test_slow_clone_2gb_two_namespace(t: Testing):
     with t.run(phase=Runner.Phase.CLONE, wait_timeout=300):
         for _ in range(5):
-            t.source["db_0"]["coll_0"].insert_many(
-                ({"s": random.randbytes(1024)} for _ in range(210000)),
-            )
-            t.source["db_0"]["coll_1"].insert_many(
-                ({"s": random.randbytes(1024)} for _ in range(210000)),
-            )
+            for _ in range(21):  # 21 batches x 10,000 = 210,000 docs
+                t.source["db_0"]["coll_0"].insert_many(
+                    [{"s": random.randbytes(1024)} for _ in range(10000)],
+                )
+                t.source["db_0"]["coll_1"].insert_many(
+                    [{"s": random.randbytes(1024)} for _ in range(10000)],
+                )
 
     try:
         t.compare_all(sort=[("_id", pymongo.ASCENDING)])
@@ -74,9 +76,10 @@ def test_slow_clone_2gb_vary_id(t: Testing):
     with t.run(phase=Runner.Phase.CLONE, wait_timeout=300):
         id_gen = vary_id_gen()
         for _ in range(5):
-            t.source["db_0"]["coll_0"].insert_many(
-                ({"_id": next(id_gen), "s": random.randbytes(1024)} for _ in range(420000)),
-            )
+            for _ in range(42):  # 42 batches x 10,000 = 420,000 docs
+                t.source["db_0"]["coll_0"].insert_many(
+                    [{"_id": next(id_gen), "s": random.randbytes(1024)} for _ in range(10000)],
+                )
 
     try:
         t.compare_all(sort=[("_id", pymongo.ASCENDING)])
@@ -93,9 +96,10 @@ def test_slow_clone_2gb_capped(t: Testing):
 
     with t.run(phase=Runner.Phase.CLONE, wait_timeout=300):
         for _ in range(5):
-            t.source["db_0"]["coll_0"].insert_many(
-                ({"s": random.randbytes(1024)} for _ in range(420000))
-            )
+            for _ in range(42):  # 42 batches x 10,000 = 420,000 docs
+                t.source["db_0"]["coll_0"].insert_many(
+                    [{"s": random.randbytes(1024)} for _ in range(10000)],
+                )
 
     try:
         t.compare_all(sort=[("$natural", pymongo.ASCENDING)])  # must keep source order
@@ -113,9 +117,10 @@ def test_slow_clone_2gb_capped_vary_id(t: Testing):
     with t.run(phase=Runner.Phase.CLONE, wait_timeout=300):
         id_gen = vary_id_gen()
         for _ in range(5):
-            t.source["db_0"]["coll_0"].insert_many(
-                ({"_id": next(id_gen), "s": random.randbytes(1024)} for _ in range(420000)),
-            )
+            for _ in range(42):  # 42 batches x 10,000 = 420,000 docs
+                t.source["db_0"]["coll_0"].insert_many(
+                    [{"_id": next(id_gen), "s": random.randbytes(1024)} for _ in range(10000)],
+                )
 
     try:
         t.compare_all(sort=[("$natural", pymongo.ASCENDING)])  # must keep source order


### PR DESCRIPTION
Due to the high volume of requests, we're unable to provide free service for this account. To continue using the service, please **[upgarde to a paid plan](https://pullrequestbadge.com/unlock/1683025?utm_medium=github&utm_source=percona&utm_campaign=unlock_text)**.

<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://perconadev.atlassian.net/browse/PCSM-218

**Problem**

The `CopyManager` code had complex, interleaved control flow mixing read/insert coordination, cleanup, and progress reporting in a single large function. Channel and variable naming was inconsistent, making the code harder to follow and maintain.

**Solution**

Refactored the collection copy logic by:
- Introduced `collectionCopySession` to encapsulate per-collection state and manage copy progress
- Extracted `runReadDispatcher` and `runInsertDispatcher` as dedicated methods on `CopyManager` for clearer separation of concerns
- Moved `readSegment` to the session for better cohesion with segment/batch ID tracking
- Replaced callback channels with a simpler `OnDone` callback pattern for insert results
- Renamed channels and types to idiomatic Go naming conventions (`Ch` suffix, `Wg` suffix, `Sem` for semaphores)
- Removed `insertResultCh`, now we send insert results directly to `progressUpdateCh`, no need for this indirection
- Made `progressUpdateCh` unbuffered instead of unnecessary it being buffered with `NumInsertWorkers` buffer


Besides these, PR fixes running `slow` tests.