### PR TITLE
PCSM-258: Test cross topo replication

### DIFF
--- a/.github/workflows/e2etests.yml
+++ b/.github/workflows/e2etests.yml
@@ -57,8 +57,8 @@ jobs:
 
       - name: Run tests (pytest)
         run: |
-          export TEST_SOURCE_URI=mongodb://rs00:30000
-          export TEST_TARGET_URI=mongodb://rs10:30100
+          export TEST_SOURCE_URI=mongodb://rs00:50000
+          export TEST_TARGET_URI=mongodb://rs10:50100
           export TEST_PCSM_URL=http://127.0.0.1:2242
           export TEST_PCSM_BIN=./bin/pcsm_test
 

--- a/hack/change_stream.py
+++ b/hack/change_stream.py
@@ -7,7 +7,7 @@ Useful for debugging and monitoring replication.
 
 Usage:
     python hack/change_stream.py -u "mongodb://localhost:27017"
-    python hack/change_stream.py --uri "mongodb://rs00:30000" --show-checkpoints
+    python hack/change_stream.py --uri "mongodb://rs00:50000" --show-checkpoints
 
 Options:
     -u, --uri               MongoDB connection string (required)
@@ -28,7 +28,7 @@ def parse_args():
         epilog="""
 Examples:
     python hack/change_stream.py -u "mongodb://localhost:27017"
-    python hack/change_stream.py --uri "mongodb://rs00:30000" --show-checkpoints
+    python hack/change_stream.py --uri "mongodb://rs00:50000" --show-checkpoints
         """,
     )
     parser.add_argument("-u", "--uri", type=str, required=True, help="MongoDB connection string")

--- a/hack/oplog_stream.py
+++ b/hack/oplog_stream.py
@@ -4,7 +4,7 @@ import bson.json_util as json
 import pymongo
 
 if __name__ == "__main__":
-    MONGODB_URI = "mongodb://rs10:30100,rs11:30101,rs12:30102"
+    MONGODB_URI = "mongodb://rs10:50100,rs11:50101,rs12:50102"
     m = pymongo.MongoClient(MONGODB_URI, readPreference="primary")
     for change in m.local["oplog.rs"].find():
         del change["_id"]

--- a/hack/reference.md
+++ b/hack/reference.md
@@ -1,18 +1,16 @@
-
 ## PMM External Sources
 
 Metrics Endpoint for PMM in a docker and PCSM on a local host:
+
 ```
 host.docker.internal:2242/metrics
 ```
 
-
 ## PCSM CLI
 
 ```shell
-go install . && pcsm --source="mongodb://rs00:30000" --target="mongodb://rs10:30100" --reset-state --log-level="debug"
+go install . && pcsm --source="mongodb://rs00:50000" --target="mongodb://rs10:50100" --reset-state --log-level="debug"
 ```
-
 
 ## PCSM Server
 
@@ -30,7 +28,6 @@ curl -H 'Content-Type: application/json' \
 curl localhost:2242/status
 ```
 
-
 ## Poetry
 
 ```shell
@@ -41,9 +38,8 @@ poetry run pytest -v -s tests/test_collections.py
 poetry run pytest -v -s tests/test_collections.py::test_rename
 ```
 
-
 ## oplog operations
 
 ```javascript
-db.oplog.rs.find({ op: "c" }).sort({ wall: 1 }).limit(10) //find 10 op:c operations logs sorted by wall field
+db.oplog.rs.find({ op: "c" }).sort({ wall: 1 }).limit(10); //find 10 op:c operations logs sorted by wall field
 ```

--- a/hack/rs/compose.yml
+++ b/hack/rs/compose.yml
@@ -5,14 +5,14 @@ services:
     hostname: rs00
     mem_limit: 2g
     memswap_limit: 2g
-    ports: ["30000:30000"]
+    ports: ["50000:50000"]
     volumes: ["rs00:/data/db", "./mongo/:/cfg:ro"]
     command:
       [
         "-f",
         "/cfg/mongod.conf",
         "--replSet=rs0",
-        "--port=30000",
+        "--port=50000",
       ]
 
   rs01:
@@ -21,14 +21,14 @@ services:
     hostname: rs01
     mem_limit: 2g
     memswap_limit: 2g
-    ports: ["30001:30001"]
+    ports: ["50001:50001"]
     volumes: ["rs01:/data/db", "./mongo/:/cfg:ro"]
     command:
       [
         "-f",
         "/cfg/mongod.conf",
         "--replSet=rs0",
-        "--port=30001",
+        "--port=50001",
       ]
 
   rs02:
@@ -37,14 +37,14 @@ services:
     hostname: rs02
     mem_limit: 2g
     memswap_limit: 2g
-    ports: ["30002:30002"]
+    ports: ["50002:50002"]
     volumes: ["rs02:/data/db", "./mongo/:/cfg:ro"]
     command:
       [
         "-f",
         "/cfg/mongod.conf",
         "--replSet=rs0",
-        "--port=30002",
+        "--port=50002",
       ]
 
   rs10:
@@ -53,14 +53,14 @@ services:
     hostname: rs10
     mem_limit: 2g
     memswap_limit: 2g
-    ports: ["30100:30100"]
+    ports: ["50100:50100"]
     volumes: ["rs10:/data/db", "./mongo/:/cfg:ro"]
     command:
       [
         "-f",
         "/cfg/mongod.conf",
         "--replSet=rs1",
-        "--port=30100",
+        "--port=50100",
       ]
 
   rs11:
@@ -69,14 +69,14 @@ services:
     hostname: rs11
     mem_limit: 2g
     memswap_limit: 2g
-    ports: ["30101:30101"]
+    ports: ["50101:50101"]
     volumes: ["rs11:/data/db", "./mongo/:/cfg:ro"]
     command:
       [
         "-f",
         "/cfg/mongod.conf",
         "--replSet=rs1",
-        "--port=30101",
+        "--port=50101",
       ]
 
   rs12:
@@ -85,14 +85,14 @@ services:
     hostname: rs12
     mem_limit: 2g
     memswap_limit: 2g
-    ports: ["30102:30102"]
+    ports: ["50102:50102"]
     volumes: ["rs12:/data/db", "./mongo/:/cfg:ro"]
     command:
       [
         "-f",
         "/cfg/mongod.conf",
         "--replSet=rs1",
-        "--port=30102",
+        "--port=50102",
       ]
 
 volumes:

--- a/hack/rs/mongo/scripts/rs0.js
+++ b/hack/rs/mongo/scripts/rs0.js
@@ -1,8 +1,8 @@
 rs.initiate({
   _id: "rs0",
   members: [
-    { _id: 0, host: "rs00:30000", priority: 2 },
-    { _id: 1, host: "rs01:30001" },
-    { _id: 2, host: "rs02:30002" },
+    { _id: 0, host: "rs00:50000", priority: 2 },
+    { _id: 1, host: "rs01:50001" },
+    { _id: 2, host: "rs02:50002" },
   ],
 });

--- a/hack/rs/mongo/scripts/rs1.js
+++ b/hack/rs/mongo/scripts/rs1.js
@@ -1,8 +1,8 @@
 rs.initiate({
   _id: "rs1",
   members: [
-    { _id: 0, host: "rs10:30100", priority: 2 },
-    { _id: 1, host: "rs11:30101" },
-    { _id: 2, host: "rs12:30102" },
+    { _id: 0, host: "rs10:50100", priority: 2 },
+    { _id: 1, host: "rs11:50101" },
+    { _id: 2, host: "rs12:50102" },
   ],
 });

--- a/hack/rs/recreate-cluster.sh
+++ b/hack/rs/recreate-cluster.sh
@@ -64,7 +64,7 @@ if $SOURCE; then
     echo "  Waiting for MongoDB..."
     sleep 3
     echo "  Initializing replica set..."
-    docker exec rs00 mongosh --port 30000 --quiet /cfg/scripts/rs0.js
+    docker exec rs00 mongosh --port 50000 --quiet /cfg/scripts/rs0.js
 fi
 
 if $TARGET; then
@@ -88,7 +88,7 @@ if $TARGET; then
     echo "  Waiting for MongoDB..."
     sleep 3
     echo "  Initializing replica set..."
-    docker exec rs10 mongosh --port 30100 --quiet /cfg/scripts/rs1.js
+    docker exec rs10 mongosh --port 50100 --quiet /cfg/scripts/rs1.js
 fi
 
 echo "Done."

--- a/hack/rs/run.sh
+++ b/hack/rs/run.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+# Start MongoDB replica set clusters for source and/or target
+#
+# Usage:
+#   ./run.sh                # Start both source and target
+#   ./run.sh --source       # Start source only (rs0: rs00, rs01, rs02)
+#   ./run.sh --target       # Start target only (rs1: rs10, rs11, rs12)
+#   ./run.sh -s -t          # Start both (explicit)
+
+set -euo pipefail
 
 BASE=$(dirname "$(dirname "$0")")
 
@@ -9,16 +18,45 @@ RDIR="$BASE/rs"
 
 export compose="$RDIR/compose.yml"
 
-dcf up -d rs00 rs01 rs02 rs10 rs11 rs12
+SOURCE=false
+TARGET=false
 
-mwait "rs00:30000"
-mwait "rs01:30001"
-mwait "rs02:30002"
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -s|--source) SOURCE=true; shift ;;
+        -t|--target) TARGET=true; shift ;;
+        -h|--help)
+            echo "Usage: $0 [--source|-s] [--target|-t]"
+            echo "  No flags: start both source and target"
+            echo "  -s, --source  Start source cluster only (rs0: rs00, rs01, rs02)"
+            echo "  -t, --target  Start target cluster only (rs1: rs10, rs11, rs12)"
+            exit 0 ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
 
-rsinit "scripts/rs0" "rs00:30000"
+# Default: start both
+if ! $SOURCE && ! $TARGET; then
+    SOURCE=true
+    TARGET=true
+fi
 
-mwait "rs10:30100"
-mwait "rs11:30101"
-mwait "rs12:30102"
+if $SOURCE; then
+    dcf up -d rs00 rs01 rs02
 
-rsinit "scripts/rs1" "rs10:30100"
+    mwait "rs00:50000"
+    mwait "rs01:50001"
+    mwait "rs02:50002"
+
+    rsinit "scripts/rs0" "rs00:50000"
+fi
+
+if $TARGET; then
+    dcf up -d rs10 rs11 rs12
+
+    mwait "rs10:50100"
+    mwait "rs11:50101"
+    mwait "rs12:50102"
+
+    rsinit "scripts/rs1" "rs10:50100"
+fi

--- a/hack/sh/run.sh
+++ b/hack/sh/run.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
-# Start MongoDB sharded clusters for source and target
+# Start MongoDB sharded clusters for source and/or target
 #
 # Usage:
-#   ./run.sh                      # Default: 2 source shards, 2 target shards
+#   ./run.sh                      # Start both source and target (default)
+#   ./run.sh --source             # Start source cluster only
+#   ./run.sh --target             # Start target cluster only
+#   ./run.sh -s -t                # Start both (explicit)
 #   SRC_SHARDS=1 ./run.sh         # Custom source shards, default target
 #   TGT_SHARDS=3 ./run.sh         # Default source, custom target shards
 #   SRC_SHARDS=3 TGT_SHARDS=1 ./run.sh  # Custom both
@@ -23,10 +26,27 @@ SDIR="$BASE/sh"
 
 export compose=$SDIR/compose.yml
 
-# Configuration: Number of shards for source and target clusters
-# Can be overridden with environment variables: SRC_SHARDS=2 TGT_SHARDS=1 ./run.sh
-SRC_SHARDS="${SRC_SHARDS:-2}"
-TGT_SHARDS="${TGT_SHARDS:-2}"
+SOURCE=false
+TARGET=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -s|--source) SOURCE=true; shift ;;
+        -t|--target) TARGET=true; shift ;;
+        -h|--help)
+            echo "Usage: $0 [--source|-s] [--target|-t]"
+            echo "  No flags: start both source and target"
+            echo "  -s, --source  Start source cluster only"
+            echo "  -t, --target  Start target cluster only"
+            exit 0 ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+if ! $SOURCE && ! $TARGET; then
+    SOURCE=true
+    TARGET=true
+fi
 
 # Port mappings for each shard (must match compose.yml)
 # Source shards: rs0=30000, rs1=30100, rs2=30200
@@ -34,86 +54,82 @@ TGT_SHARDS="${TGT_SHARDS:-2}"
 SRC_SHARD_PORTS=(30000 30100 30200)
 TGT_SHARD_PORTS=(40000 40100 40200)
 
+SRC_SHARDS="${SRC_SHARDS:-2}"
+TGT_SHARDS="${TGT_SHARDS:-2}"
+
 MAX_SRC_SHARDS=${#SRC_SHARD_PORTS[@]}
 MAX_TGT_SHARDS=${#TGT_SHARD_PORTS[@]}
 
-if [ "$SRC_SHARDS" -gt "$MAX_SRC_SHARDS" ]; then
+if $SOURCE && [ "$SRC_SHARDS" -gt "$MAX_SRC_SHARDS" ]; then
     echo "ERROR: SRC_SHARDS=$SRC_SHARDS exceeds maximum $MAX_SRC_SHARDS"
     echo "Available init scripts: $SDIR/mongo/src/rs{0..$((MAX_SRC_SHARDS-1))}.js"
     exit 1
 fi
 
-if [ "$TGT_SHARDS" -gt "$MAX_TGT_SHARDS" ]; then
+if $TARGET && [ "$TGT_SHARDS" -gt "$MAX_TGT_SHARDS" ]; then
     echo "ERROR: TGT_SHARDS=$TGT_SHARDS exceeds maximum $MAX_TGT_SHARDS"
     echo "Available init scripts: $SDIR/mongo/tgt/rs{0..$((MAX_TGT_SHARDS-1))}.js"
     exit 1
 fi
 
-echo "Starting source cluster with $SRC_SHARDS shards (max: $MAX_SRC_SHARDS)"
-echo "Starting target cluster with $TGT_SHARDS shards (max: $MAX_TGT_SHARDS)"
+if $SOURCE; then
+    echo "Starting source cluster with $SRC_SHARDS shards (max: $MAX_SRC_SHARDS)"
 
-# Build list of source shard services to start
-SRC_SERVICES="src-cfg0"
-for i in $(seq 0 $((SRC_SHARDS - 1))); do
-    SRC_SERVICES="$SRC_SERVICES src-rs${i}0"
-done
+    SRC_SERVICES="src-cfg0"
+    for i in $(seq 0 $((SRC_SHARDS - 1))); do
+        SRC_SERVICES="$SRC_SERVICES src-rs${i}0"
+    done
 
-# Start source config server and shards
-dcf up -d $SRC_SERVICES
+    dcf up -d $SRC_SERVICES
 
-# Initialize source config server
-mwait "src-cfg0:27000" && rsinit "src/cfg" "src-cfg0:27000"
+    mwait "src-cfg0:27000" && rsinit "src/cfg" "src-cfg0:27000"
 
-# Initialize source shards
-for i in $(seq 0 $((SRC_SHARDS - 1))); do
-    PORT=${SRC_SHARD_PORTS[$i]}
-    mwait "src-rs${i}0:${PORT}" && rsinit "src/rs${i}" "src-rs${i}0:${PORT}"
-done
+    for i in $(seq 0 $((SRC_SHARDS - 1))); do
+        PORT=${SRC_SHARD_PORTS[$i]}
+        mwait "src-rs${i}0:${PORT}" && rsinit "src/rs${i}" "src-rs${i}0:${PORT}"
+    done
 
-# Start source mongos
-dcf up -d src-mongos && mwait "src-mongos:27017"
+    dcf up -d src-mongos && mwait "src-mongos:27017"
 
-# Add source shards to cluster
-ADD_SHARDS_CMD=""
-for i in $(seq 0 $((SRC_SHARDS - 1))); do
-    PORT=${SRC_SHARD_PORTS[$i]}
-    ADD_SHARDS_CMD="${ADD_SHARDS_CMD}sh.addShard('rs${i}/src-rs${i}0:${PORT}'); "
-done
-msh "src-mongos:27017" --eval "$ADD_SHARDS_CMD"
+    ADD_SHARDS_CMD=""
+    for i in $(seq 0 $((SRC_SHARDS - 1))); do
+        PORT=${SRC_SHARD_PORTS[$i]}
+        ADD_SHARDS_CMD="${ADD_SHARDS_CMD}sh.addShard('rs${i}/src-rs${i}0:${PORT}'); "
+    done
+    msh "src-mongos:27017" --eval "$ADD_SHARDS_CMD"
 
-if [[ "${MONGO_VERSION:-8.0}" == 8.* ]]; then
-    msh "src-mongos:27017" --eval "db.adminCommand('transitionFromDedicatedConfigServer');"
+    if [[ "${MONGO_VERSION:-8.0}" == 8.* ]]; then
+        msh "src-mongos:27017" --eval "db.adminCommand('transitionFromDedicatedConfigServer');"
+    fi
 fi
 
-# Build list of target shard services to start
-TGT_SERVICES="tgt-cfg0"
-for i in $(seq 0 $((TGT_SHARDS - 1))); do
-    TGT_SERVICES="$TGT_SERVICES tgt-rs${i}0"
-done
+if $TARGET; then
+    echo "Starting target cluster with $TGT_SHARDS shards (max: $MAX_TGT_SHARDS)"
 
-# Start target config server and shards
-dcf up -d $TGT_SERVICES
+    TGT_SERVICES="tgt-cfg0"
+    for i in $(seq 0 $((TGT_SHARDS - 1))); do
+        TGT_SERVICES="$TGT_SERVICES tgt-rs${i}0"
+    done
 
-# Initialize target config server
-mwait "tgt-cfg0:28000" && rsinit "tgt/cfg" "tgt-cfg0:28000"
+    dcf up -d $TGT_SERVICES
 
-# Initialize target shards
-for i in $(seq 0 $((TGT_SHARDS - 1))); do
-    PORT=${TGT_SHARD_PORTS[$i]}
-    mwait "tgt-rs${i}0:${PORT}" && rsinit "tgt/rs${i}" "tgt-rs${i}0:${PORT}"
-done
+    mwait "tgt-cfg0:28000" && rsinit "tgt/cfg" "tgt-cfg0:28000"
 
-# Start target mongos
-dcf up -d tgt-mongos && mwait "tgt-mongos:27017"
+    for i in $(seq 0 $((TGT_SHARDS - 1))); do
+        PORT=${TGT_SHARD_PORTS[$i]}
+        mwait "tgt-rs${i}0:${PORT}" && rsinit "tgt/rs${i}" "tgt-rs${i}0:${PORT}"
+    done
 
-# Add target shards to cluster
-ADD_SHARDS_CMD=""
-for i in $(seq 0 $((TGT_SHARDS - 1))); do
-    PORT=${TGT_SHARD_PORTS[$i]}
-    ADD_SHARDS_CMD="${ADD_SHARDS_CMD}sh.addShard('rs${i}/tgt-rs${i}0:${PORT}'); "
-done
-msh "tgt-mongos:27017" --eval "$ADD_SHARDS_CMD"
+    dcf up -d tgt-mongos && mwait "tgt-mongos:27017"
 
-if [[ "${MONGO_VERSION:-8.0}" == 8.* ]]; then
-    msh "tgt-mongos:27017" --eval "db.adminCommand('transitionFromDedicatedConfigServer');"
+    ADD_SHARDS_CMD=""
+    for i in $(seq 0 $((TGT_SHARDS - 1))); do
+        PORT=${TGT_SHARD_PORTS[$i]}
+        ADD_SHARDS_CMD="${ADD_SHARDS_CMD}sh.addShard('rs${i}/tgt-rs${i}0:${PORT}'); "
+    done
+    msh "tgt-mongos:27017" --eval "$ADD_SHARDS_CMD"
+
+    if [[ "${MONGO_VERSION:-8.0}" == 8.* ]]; then
+        msh "tgt-mongos:27017" --eval "db.adminCommand('transitionFromDedicatedConfigServer');"
+    fi
 fi


### PR DESCRIPTION
Remaps RS ports from 30xxx to 50xxx so sharded source and RS target clusters can run side by side. Adds `--source`/`--target` flags to both `hack/rs/run.sh` and `hack/sh/run.sh` for partial cluster startup.

This is the infrastructure needed to test cross-topology replication (sharded cluster → replica set), per PCSM-258. No Go code changes, no test changes.

### Changes

**Port remapping** (`hack/rs/`): RS source ports 30000→50000, target 30100→50100. Updates compose.yml, init scripts, recreate script.

**Selective startup** (`hack/rs/run.sh`, `hack/sh/run.sh`): Both scripts now accept `--source`/`-s` and `--target`/`-t` flags. No flags = start both (backward compatible). The sharded script was also refactored from hardcoded shard blocks to a loop over `SRC_SHARDS`/`TGT_SHARDS` env vars (1-3, default 2).

**CI** (`.github/workflows/e2etests.yml`): RS test URIs updated to match new ports.

**Tooling** (`hack/change_stream.py`, `hack/oplog_stream.py`, `hack/reference.md`): Default ports updated.