### PR TITLE
 PCSM-294: Fix BufBuilder overflow

### DIFF
--- a/.github/workflows/e2etests.yml
+++ b/.github/workflows/e2etests.yml
@@ -62,7 +62,7 @@ jobs:
           export TEST_PCSM_URL=http://127.0.0.1:2242
           export TEST_PCSM_BIN=./bin/pcsm_test
 
-          poetry run pytest tests/test_collections.py tests/test_documents.py tests/test_indexes.py tests/test_selective.py tests/test_transactions.py
+          poetry run pytest tests/test_collections.py tests/test_documents.py tests/test_indexes.py tests/test_selective.py tests/test_transactions.py tests/test_pipeline_updates.py
 
       - name: Teardown Docker Compose
         if: always()
@@ -78,9 +78,9 @@ jobs:
         include:
           # 6.0/7.0: sharded-specific tests only (full suite blocked by PCSM-255)
           - mongo_version: "6.0"
-            test_scope: tests/test_collections_sharded.py tests/test_documents_sharded.py
+            test_scope: tests/test_collections_sharded.py tests/test_documents_sharded.py tests/test_pipeline_updates.py
           - mongo_version: "7.0"
-            test_scope: tests/test_collections_sharded.py tests/test_documents_sharded.py
+            test_scope: tests/test_collections_sharded.py tests/test_documents_sharded.py tests/test_pipeline_updates.py
           - mongo_version: "8.0"
             test_scope: ""
 

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,7 @@
+# CVE-2026-34040: docker/docker AuthZ plugin bypass (HIGH)
+# Transitive test-only dependency via testcontainers-go v0.41.0.
+# Docker v29.3.1 (which contains the fix) uses a new Go module structure
+# and is not available under the old +incompatible import path.
+# Tracked upstream: https://github.com/testcontainers/testcontainers-go/issues/3614
+# Remove this entry once testcontainers-go releases a version with docker v29.
+CVE-2026-34040

--- a/pcsm/repl/bulk.go
+++ b/pcsm/repl/bulk.go
@@ -613,6 +613,8 @@ func collectUpdateOpsWithPipeline(event *UpdateEvent) updateOps {
 	for _, field := range event.UpdateDescription.UpdatedFields {
 		if !isArrayPath(field.Key, dp, truncatedFields) {
 			nonArrayFields = append(nonArrayFields, bson.E{Key: field.Key, Value: field.Value})
+
+			continue
 		}
 
 		parts := strings.Split(field.Key, ".")

--- a/pcsm/repl/bulk.go
+++ b/pcsm/repl/bulk.go
@@ -694,7 +694,19 @@ func isArrayPath(field string, disambiguatedPaths map[string][]any, truncatedFie
 		}
 	}
 
-	// Case 2: disambiguatedPaths is nil (MongoDB <6.1) → use truncatedFields + depth heuristic
+	// Case 2: disambiguatedPaths is nil (MongoDB <6.1) → use truncatedFields only.
+	//
+	// Without disambiguatedPaths, a path like "arr.0.10" is ambiguous: "10" could be
+	// an array index (→ $concatArrays needed) or a document field name (→ standard $set).
+	// The previous depth heuristic (len > 2 → assume array index) caused data corruption
+	// for documents with numeric-string field names inside array elements.
+	//
+	// The only reliable indicator available without disambiguatedPaths is whether the
+	// direct parent path is in truncatedFields. $concatArrays is needed precisely when
+	// the truncated array is the direct parent of the updated index — e.g., "arr.5" when
+	// "arr" was truncated. For deeper paths like "arr.0.10", the parent "arr.0" was not
+	// truncated, so standard $set handles it correctly regardless of whether "10" is an
+	// index or a field name.
 	if disambiguatedPaths == nil {
 		parts := strings.Split(field, ".")
 		if len(parts) < 2 { //nolint:mnd
@@ -707,16 +719,11 @@ func isArrayPath(field string, disambiguatedPaths map[string][]any, truncatedFie
 			return false
 		}
 
-		// If parent is in truncatedFields, definitely an array path
+		// Only use $concatArrays when the direct parent was truncated.
 		parentPath := strings.Join(parts[:len(parts)-1], ".")
-		if _, ok := truncatedFields[parentPath]; ok {
-			return true
-		}
+		_, ok := truncatedFields[parentPath]
 
-		// Parent not in truncatedFields. Use depth heuristic:
-		// - Depth > 2 (e.g., b.0.1): likely nested array, return true
-		// - Depth == 2 (e.g., f2.1): ambiguous, could be object key, return false
-		return len(parts) > 2 //nolint:mnd
+		return ok
 	}
 
 	// Case 3: disambiguatedPaths non-nil but field not in it → Atoi fallback (unambiguous)

--- a/pcsm/repl/bulk.go
+++ b/pcsm/repl/bulk.go
@@ -37,9 +37,9 @@ var collectionBulkOptions = options.BulkWrite().
 // Pipeline $set operation limits to prevent MongoDB's BufBuilder overflow (error 13548).
 // MongoDB's BufBuilder accumulates across ALL stages within a single pipeline, so splitting
 // into multiple $set stages within one pipeline has no effect. Instead, when the batched $set
-// fields exceed these limits, they are emitted as separate pipeline updateOne operations
-// (each with its own BufBuilder). maxBytesPerSetOp is the primary guard; maxFieldsPerSetOp
-// is a secondary guard against degenerate cases with many tiny fields.
+// fields exceed these limits, they are emitted as separate standard (non-pipeline) updateOne
+// operations, each with its own BufBuilder. maxBytesPerSetOp is the primary guard;
+// maxFieldsPerSetOp is a secondary guard against degenerate cases with many tiny fields.
 const (
 	maxFieldsPerSetOp = 100        //nolint:mnd
 	maxBytesPerSetOp  = 512 * 1024 //nolint:mnd // 512KB
@@ -219,13 +219,13 @@ func (cbw *clientBulkWrite) Update(ns catalog.Namespace, event *UpdateEvent) {
 		Database: ns.Database, Collection: ns.Collection, Model: m,
 	})
 
-	// Follow-up pipeline operations for $set fields split out due to BufBuilder limits.
-	// Each follow-up is a separate pipeline (bson.A) to reset MongoDB's BufBuilder and
-	// preserve field ordering. Ordered bulk writes guarantee sequential execution.
-	for _, followUpPipeline := range ops.followUp {
+	// Follow-up standard $set operations for fields split out due to BufBuilder limits.
+	// Each is a separate updateOne (bson.D) so MongoDB resets its BufBuilder per operation.
+	// Ordered bulk writes guarantee sequential execution.
+	for _, followUp := range ops.followUp {
 		fm := &mongo.ClientUpdateOneModel{
 			Filter: event.DocumentKey,
-			Update: followUpPipeline,
+			Update: followUp,
 		}
 
 		if ns.Sharded && cbw.useSimpleCollation {
@@ -448,11 +448,11 @@ func (cbw *collectionBulkWrite) Update(ns catalog.Namespace, event *UpdateEvent)
 	cbw.writes[ns.String()] = append(cbw.writes[ns.String()], m)
 	cbw.count++
 
-	// Follow-up pipeline operations for $set fields split out due to BufBuilder limits.
-	for _, followUpPipeline := range ops.followUp {
+	// Follow-up standard $set operations for fields split out due to BufBuilder limits.
+	for _, followUp := range ops.followUp {
 		fm := &mongo.UpdateOneModel{
 			Filter: event.DocumentKey,
-			Update: followUpPipeline,
+			Update: followUp,
 		}
 
 		if ns.Sharded && cbw.useSimpleCollation {
@@ -608,34 +608,34 @@ func collectUpdateOpsWithPipeline(event *UpdateEvent) updateOps {
 	}
 
 	// Handle updated fields
-	var batchedSetFields bson.D
+	var nonArrayFields bson.D
 
 	for _, field := range event.UpdateDescription.UpdatedFields {
-		if isArrayPath(field.Key, dp, truncatedFields) {
-			parts := strings.Split(field.Key, ".")
-			fieldName := strings.Join(parts[:len(parts)-1], ".")
-			fieldIdx, _ := strconv.Atoi(parts[len(parts)-1])
-			fieldExpr := "$" + fieldName
+		if !isArrayPath(field.Key, dp, truncatedFields) {
+			nonArrayFields = append(nonArrayFields, bson.E{Key: field.Key, Value: field.Value})
+		}
 
-			stage := bson.D{{
-				"$set", bson.D{
-					{fieldName, bson.D{
-						{"$concatArrays", bson.A{
-							bson.D{{"$slice", bson.A{fieldExpr, fieldIdx}}},
-							bson.A{field.Value},
-							bson.D{{
-								"$slice",
-								bson.A{fieldExpr, fieldIdx + 1, bson.D{{"$max", bson.A{1, bson.D{{"$size", fieldExpr}}}}}},
-							}},
+		parts := strings.Split(field.Key, ".")
+		fieldName := strings.Join(parts[:len(parts)-1], ".")
+		fieldIdx, _ := strconv.Atoi(parts[len(parts)-1])
+		fieldExpr := "$" + fieldName
+
+		stage := bson.D{{
+			"$set", bson.D{
+				{fieldName, bson.D{
+					{"$concatArrays", bson.A{
+						bson.D{{"$slice", bson.A{fieldExpr, fieldIdx}}},
+						bson.A{field.Value},
+						bson.D{{
+							"$slice",
+							bson.A{fieldExpr, fieldIdx + 1, bson.D{{"$max", bson.A{1, bson.D{{"$size", fieldExpr}}}}}},
 						}},
 					}},
-				},
-			}}
+				}},
+			},
+		}}
 
-			pipeline = append(pipeline, stage)
-		} else {
-			batchedSetFields = append(batchedSetFields, bson.E{Key: field.Key, Value: field.Value})
-		}
+		pipeline = append(pipeline, stage)
 	}
 
 	// Emit non-array $set fields as separate standard (non-pipeline) $set operations.
@@ -651,19 +651,19 @@ func collectUpdateOpsWithPipeline(event *UpdateEvent) updateOps {
 	chunkStart := 0
 	chunkBytes := 0
 
-	for i := range batchedSetFields {
-		b, _ := bson.Marshal(bson.D{batchedSetFields[i]})
+	for i := range nonArrayFields {
+		b, _ := bson.Marshal(bson.D{nonArrayFields[i]})
 		chunkBytes += len(b)
 
 		if chunkBytes >= maxBytesPerSetOp || (i-chunkStart+1) >= maxFieldsPerSetOp {
-			followUp = append(followUp, bson.D{{Key: "$set", Value: batchedSetFields[chunkStart : i+1]}})
+			followUp = append(followUp, bson.D{{Key: "$set", Value: nonArrayFields[chunkStart : i+1]}})
 			chunkStart = i + 1
 			chunkBytes = 0
 		}
 	}
 
-	if chunkStart < len(batchedSetFields) {
-		followUp = append(followUp, bson.D{{Key: "$set", Value: batchedSetFields[chunkStart:]}})
+	if chunkStart < len(nonArrayFields) {
+		followUp = append(followUp, bson.D{{Key: "$set", Value: nonArrayFields[chunkStart:]}})
 	}
 
 	// Handle removed fields

--- a/pcsm/repl/bulk.go
+++ b/pcsm/repl/bulk.go
@@ -34,6 +34,11 @@ var collectionBulkOptions = options.BulkWrite().
 	SetOrdered(true).
 	SetBypassDocumentValidation(false)
 
+// maxFieldsPerSetStage limits the number of non-array fields per $set stage in a pipeline
+// update. This prevents MongoDB's BufBuilder overflow (error 13548) when many dotted-path
+// $set operations are applied to a large document within a single aggregation pipeline stage.
+const maxFieldsPerSetStage = 25 //nolint:mnd
+
 type bulkWriter interface {
 	Full() bool
 	Empty() bool
@@ -579,8 +584,14 @@ func collectUpdateOpsWithPipeline(event *UpdateEvent) bson.A {
 		}
 	}
 
-	if len(batchedSetFields) > 0 {
-		pipeline = append(pipeline, bson.D{{Key: "$set", Value: batchedSetFields}})
+	// Emit non-array $set fields in chunked stages to avoid MongoDB's BufBuilder overflow
+	// (error 13548). The pipeline executor accumulates ~1-2MB of intermediate BSON per
+	// dotted-path $set within a single stage. With many fields on a large document, a single
+	// $set stage can exceed the 125MB BufBuilder limit. Chunking to maxFieldsPerSetStage
+	// fields per stage keeps the peak at ~64MB even for maximum-size (16MB) documents.
+	for i := 0; i < len(batchedSetFields); i += maxFieldsPerSetStage {
+		end := min(i+maxFieldsPerSetStage, len(batchedSetFields))
+		pipeline = append(pipeline, bson.D{{Key: "$set", Value: batchedSetFields[i:end]}})
 	}
 
 	// Handle removed fields

--- a/pcsm/repl/bulk.go
+++ b/pcsm/repl/bulk.go
@@ -34,10 +34,32 @@ var collectionBulkOptions = options.BulkWrite().
 	SetOrdered(true).
 	SetBypassDocumentValidation(false)
 
-// maxFieldsPerSetStage limits the number of non-array fields per $set stage in a pipeline
-// update. This prevents MongoDB's BufBuilder overflow (error 13548) when many dotted-path
-// $set operations are applied to a large document within a single aggregation pipeline stage.
-const maxFieldsPerSetStage = 25 //nolint:mnd
+// Pipeline $set operation limits to prevent MongoDB's BufBuilder overflow (error 13548).
+// MongoDB's BufBuilder accumulates across ALL stages within a single pipeline, so splitting
+// into multiple $set stages within one pipeline has no effect. Instead, when the batched $set
+// fields exceed these limits, they are emitted as separate pipeline updateOne operations
+// (each with its own BufBuilder). maxBytesPerSetOp is the primary guard; maxFieldsPerSetOp
+// is a secondary guard against degenerate cases with many tiny fields.
+const (
+	maxFieldsPerSetOp = 100        //nolint:mnd
+	maxBytesPerSetOp  = 512 * 1024 //nolint:mnd // 512KB
+)
+
+// updateOps holds the result of building update operations from a change stream event.
+// When pipeline $set fields exceed size limits, they are split into follow-up standard
+// (non-pipeline) $set operations to prevent MongoDB's BufBuilder overflow (error 13548).
+// Follow-ups use standard $set (bson.D) because pipeline $set treats numeric path
+// components as document field names rather than array indices (e.g. "arr.0.d" in a
+// pipeline creates field "0" in each element instead of navigating to arr[0].d).
+// Standard $set correctly navigates array indices via dotted paths.
+type updateOps struct {
+	// primary is the main update: either bson.D (simple update) or bson.A (pipeline).
+	primary any
+	// followUp contains additional standard $set operations for fields that were split
+	// out of the primary pipeline to avoid BufBuilder overflow. Each element is a
+	// standard update document (bson.D) with a single $set operator. nil when not needed.
+	followUp []bson.D
+}
 
 type bulkWriter interface {
 	Full() bool
@@ -182,22 +204,38 @@ func (cbw *clientBulkWrite) Insert(ns catalog.Namespace, event *InsertEvent) {
 }
 
 func (cbw *clientBulkWrite) Update(ns catalog.Namespace, event *UpdateEvent) {
+	ops := collectUpdateOps(event)
+
 	m := &mongo.ClientUpdateOneModel{
 		Filter: event.DocumentKey,
-		Update: collectUpdateOps(event),
+		Update: ops.primary,
 	}
 
 	if ns.Sharded && cbw.useSimpleCollation {
 		m.Collation = simpleCollation
 	}
 
-	bw := mongo.ClientBulkWrite{
-		Database:   ns.Database,
-		Collection: ns.Collection,
-		Model:      m,
-	}
+	cbw.writes = append(cbw.writes, mongo.ClientBulkWrite{
+		Database: ns.Database, Collection: ns.Collection, Model: m,
+	})
 
-	cbw.writes = append(cbw.writes, bw)
+	// Follow-up pipeline operations for $set fields split out due to BufBuilder limits.
+	// Each follow-up is a separate pipeline (bson.A) to reset MongoDB's BufBuilder and
+	// preserve field ordering. Ordered bulk writes guarantee sequential execution.
+	for _, followUpPipeline := range ops.followUp {
+		fm := &mongo.ClientUpdateOneModel{
+			Filter: event.DocumentKey,
+			Update: followUpPipeline,
+		}
+
+		if ns.Sharded && cbw.useSimpleCollation {
+			fm.Collation = simpleCollation
+		}
+
+		cbw.writes = append(cbw.writes, mongo.ClientBulkWrite{
+			Database: ns.Database, Collection: ns.Collection, Model: fm,
+		})
+	}
 }
 
 func (cbw *clientBulkWrite) Replace(ns catalog.Namespace, event *ReplaceEvent) {
@@ -396,9 +434,11 @@ func (cbw *collectionBulkWrite) Insert(ns catalog.Namespace, event *InsertEvent)
 }
 
 func (cbw *collectionBulkWrite) Update(ns catalog.Namespace, event *UpdateEvent) {
+	ops := collectUpdateOps(event)
+
 	m := &mongo.UpdateOneModel{
 		Filter: event.DocumentKey,
-		Update: collectUpdateOps(event),
+		Update: ops.primary,
 	}
 
 	if ns.Sharded && cbw.useSimpleCollation {
@@ -406,8 +446,22 @@ func (cbw *collectionBulkWrite) Update(ns catalog.Namespace, event *UpdateEvent)
 	}
 
 	cbw.writes[ns.String()] = append(cbw.writes[ns.String()], m)
-
 	cbw.count++
+
+	// Follow-up pipeline operations for $set fields split out due to BufBuilder limits.
+	for _, followUpPipeline := range ops.followUp {
+		fm := &mongo.UpdateOneModel{
+			Filter: event.DocumentKey,
+			Update: followUpPipeline,
+		}
+
+		if ns.Sharded && cbw.useSimpleCollation {
+			fm.Collation = simpleCollation
+		}
+
+		cbw.writes[ns.String()] = append(cbw.writes[ns.String()], fm)
+		cbw.count++
+	}
 }
 
 func (cbw *collectionBulkWrite) Replace(ns catalog.Namespace, event *ReplaceEvent) {
@@ -484,7 +538,7 @@ func handleDuplicateKeyError(ctx context.Context, coll *mongo.Collection, replac
 	return nil
 }
 
-func collectUpdateOps(event *UpdateEvent) any {
+func collectUpdateOps(event *UpdateEvent) updateOps {
 	for _, trunc := range event.UpdateDescription.TruncatedArrays {
 		for _, update := range event.UpdateDescription.UpdatedFields {
 			if update.Key == trunc.Field || strings.HasPrefix(update.Key, trunc.Field+".") {
@@ -519,10 +573,10 @@ func collectUpdateOps(event *UpdateEvent) any {
 		ops = append(ops, bson.E{"$push", fields})
 	}
 
-	return ops
+	return updateOps{primary: ops}
 }
 
-func collectUpdateOpsWithPipeline(event *UpdateEvent) bson.A {
+func collectUpdateOpsWithPipeline(event *UpdateEvent) updateOps {
 	s := len(event.UpdateDescription.UpdatedFields) +
 		len(event.UpdateDescription.RemovedFields) +
 		len(event.UpdateDescription.TruncatedArrays)
@@ -584,14 +638,32 @@ func collectUpdateOpsWithPipeline(event *UpdateEvent) bson.A {
 		}
 	}
 
-	// Emit non-array $set fields in chunked stages to avoid MongoDB's BufBuilder overflow
-	// (error 13548). The pipeline executor accumulates ~1-2MB of intermediate BSON per
-	// dotted-path $set within a single stage. With many fields on a large document, a single
-	// $set stage can exceed the 125MB BufBuilder limit. Chunking to maxFieldsPerSetStage
-	// fields per stage keeps the peak at ~64MB even for maximum-size (16MB) documents.
-	for i := 0; i < len(batchedSetFields); i += maxFieldsPerSetStage {
-		end := min(i+maxFieldsPerSetStage, len(batchedSetFields))
-		pipeline = append(pipeline, bson.D{{Key: "$set", Value: batchedSetFields[i:end]}})
+	// Emit non-array $set fields as separate standard (non-pipeline) $set operations.
+	// They MUST NOT go into the primary pipeline for two reasons:
+	// 1. MongoDB's BufBuilder accumulates across ALL stages within a single pipeline,
+	//    so even a single $set stage with many large dotted-path values can overflow.
+	// 2. Pipeline $set treats numeric dotted-path components as document field names
+	//    rather than array indices (e.g. "arr.0.d" creates field "0" in each element
+	//    instead of navigating to arr[0].d). Standard $set handles this correctly.
+	// Fields are chunked by size/count to keep individual updates manageable.
+	var followUp []bson.D
+
+	chunkStart := 0
+	chunkBytes := 0
+
+	for i := range batchedSetFields {
+		b, _ := bson.Marshal(bson.D{batchedSetFields[i]})
+		chunkBytes += len(b)
+
+		if chunkBytes >= maxBytesPerSetOp || (i-chunkStart+1) >= maxFieldsPerSetOp {
+			followUp = append(followUp, bson.D{{Key: "$set", Value: batchedSetFields[chunkStart : i+1]}})
+			chunkStart = i + 1
+			chunkBytes = 0
+		}
+	}
+
+	if chunkStart < len(batchedSetFields) {
+		followUp = append(followUp, bson.D{{Key: "$set", Value: batchedSetFields[chunkStart:]}})
 	}
 
 	// Handle removed fields
@@ -602,7 +674,7 @@ func collectUpdateOpsWithPipeline(event *UpdateEvent) bson.A {
 		)
 	}
 
-	return pipeline
+	return updateOps{primary: pipeline, followUp: followUp}
 }
 
 // isArrayPath checks if the path is an path to an array index (e.g. "a.b.1").

--- a/pcsm/repl/bulk_test.go
+++ b/pcsm/repl/bulk_test.go
@@ -358,8 +358,7 @@ func TestCollectUpdateOpsWithPipeline_ChunksSmallFields(t *testing.T) {
 
 	// Many small fields should be chunked by field count (maxFieldsPerSetOp),
 	// since their total byte size is well under maxBytesPerSetOp.
-	// With 250 small fields: first 100 go into the primary pipeline, remaining 150
-	// are split into follow-up pipeline operations (100 + 50).
+	// All 250 non-array fields go to follow-up standard $set operations: 3 chunks of (100, 100, 50).
 	const numFields = 250
 
 	updatedFields := make(bson.D, 0, numFields+1)
@@ -411,7 +410,7 @@ func TestCollectUpdateOpsWithPipeline_ChunksLargeFields(t *testing.T) {
 	t.Parallel()
 
 	// Large fields (~20KB each) should be chunked by byte size (maxBytesPerSetOp),
-	// producing follow-up pipeline operations. This is the BufBuilder overflow scenario.
+	// producing follow-up standard $set operations. This is the BufBuilder overflow scenario.
 	const numFields = 100
 	largeValue := strings.Repeat("X", 20_000)
 

--- a/pcsm/repl/bulk_test.go
+++ b/pcsm/repl/bulk_test.go
@@ -2,8 +2,10 @@ package repl //nolint:testpackage
 
 import (
 	"strconv"
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
@@ -214,9 +216,9 @@ func TestCollectUpdateOps(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := collectUpdateOps(tt.event)
+			ops := collectUpdateOps(tt.event)
 
-			switch v := result.(type) {
+			switch v := ops.primary.(type) {
 			case bson.A:
 				if !tt.expectPipeline {
 					t.Errorf("Expected simple update doc (bson.D), got pipeline (bson.A)")
@@ -225,6 +227,20 @@ func TestCollectUpdateOps(t *testing.T) {
 				}
 
 				foundConcatArrays, foundSimpleSet := extractPipelineFields(t, v)
+
+				// Non-array fields may be in follow-up standard $set ops, collect those too.
+				for _, fu := range ops.followUp {
+					for _, elem := range fu {
+						if elem.Key == "$set" {
+							if setDoc, ok := elem.Value.(bson.D); ok {
+								for _, f := range setDoc {
+									foundSimpleSet[f.Key] = true
+								}
+							}
+						}
+					}
+				}
+
 				assertFieldsPresent(t, foundConcatArrays, tt.expectConcatArraysFor, "$concatArrays")
 				assertFieldsPresent(t, foundSimpleSet, tt.expectSimpleSetFor, "simple $set")
 
@@ -238,7 +254,7 @@ func TestCollectUpdateOps(t *testing.T) {
 				verifySimpleUpdateDoc(t, v, tt.expectSimpleSetFor)
 
 			default:
-				t.Errorf("Unexpected result type: %T", result)
+				t.Errorf("Unexpected result type: %T", ops.primary)
 			}
 		})
 	}
@@ -305,9 +321,9 @@ func TestCollectUpdateOps_NoFalsePositiveConflict(t *testing.T) {
 				},
 			}
 
-			result := collectUpdateOps(event)
+			ops := collectUpdateOps(event)
 
-			_, isPipeline := result.(bson.A)
+			_, isPipeline := ops.primary.(bson.A)
 			if isPipeline != tt.expectPipeline {
 				t.Errorf("collectUpdateOps() returned pipeline=%v, want pipeline=%v", isPipeline, tt.expectPipeline)
 			}
@@ -315,13 +331,14 @@ func TestCollectUpdateOps_NoFalsePositiveConflict(t *testing.T) {
 	}
 }
 
-func TestCollectUpdateOpsWithPipeline_ChunksSetStages(t *testing.T) {
+func TestCollectUpdateOpsWithPipeline_ChunksSmallFields(t *testing.T) {
 	t.Parallel()
 
-	// Many non-array fields should be chunked into multiple $set stages
-	// (maxFieldsPerSetStage fields each) to avoid BufBuilder overflow,
-	// not emitted as one giant $set stage.
-	const numFields = 2000
+	// Many small fields should be chunked by field count (maxFieldsPerSetOp),
+	// since their total byte size is well under maxBytesPerSetOp.
+	// With 250 small fields: first 100 go into the primary pipeline, remaining 150
+	// are split into follow-up pipeline operations (100 + 50).
+	const numFields = 250
 
 	updatedFields := make(bson.D, 0, numFields+1)
 	for i := range numFields {
@@ -331,7 +348,6 @@ func TestCollectUpdateOpsWithPipeline_ChunksSetStages(t *testing.T) {
 		})
 	}
 
-	// Add one real array path field to ensure array paths still get individual stages
 	updatedFields = append(updatedFields, bson.E{Key: "arr.2", Value: "arrval"})
 
 	event := &UpdateEvent{
@@ -346,16 +362,91 @@ func TestCollectUpdateOpsWithPipeline_ChunksSetStages(t *testing.T) {
 		},
 	}
 
-	result := collectUpdateOpsWithPipeline(event)
+	ops := collectUpdateOpsWithPipeline(event)
 
-	// Collect all $set stages, separating array ($concatArrays) from chunked non-array stages
-	var concatArraysStages int
+	pipeline, ok := ops.primary.(bson.A)
+	if !ok {
+		t.Fatalf("Expected pipeline (bson.A), got %T", ops.primary)
+	}
 
-	var chunkedStages []bson.D
+	concatArraysStages, truncationStages := classifySetStages(t, pipeline)
 
-	var truncationStages int
+	assert.Equal(t, 1, concatArraysStages, "$concatArrays stages")
+	assert.Equal(t, 1, truncationStages, "truncation stages")
 
-	for _, stage := range result {
+	// Count all $set fields across primary pipeline and follow-ups
+	totalFields := countAllSetFields(t, ops)
+
+	assert.Equal(t, numFields, totalFields, "total fields across primary + follow-ups")
+
+	// All batched fields go to follow-ups: 250 / 100 = 3 follow-ups (100, 100, 50)
+	expectedFollowUps := (numFields + maxFieldsPerSetOp - 1) / maxFieldsPerSetOp
+
+	assert.Len(t, ops.followUp, expectedFollowUps, "follow-up operations")
+}
+
+func TestCollectUpdateOpsWithPipeline_ChunksLargeFields(t *testing.T) {
+	t.Parallel()
+
+	// Large fields (~20KB each) should be chunked by byte size (maxBytesPerSetOp),
+	// producing follow-up pipeline operations. This is the BufBuilder overflow scenario.
+	const numFields = 100
+	largeValue := strings.Repeat("X", 20_000)
+
+	updatedFields := make(bson.D, 0, numFields+1)
+	for i := range numFields {
+		updatedFields = append(updatedFields, bson.E{
+			Key:   "arr." + strconv.Itoa(i) + ".d",
+			Value: largeValue,
+		})
+	}
+
+	updatedFields = append(updatedFields, bson.E{Key: "meta.updated", Value: true})
+
+	event := &UpdateEvent{
+		UpdateDescription: UpdateDescription{
+			TruncatedArrays: []struct {
+				Field   string `bson:"field"`
+				NewSize int32  `bson:"newSize"`
+			}{
+				{Field: "arr", NewSize: 250},
+			},
+			UpdatedFields: updatedFields,
+		},
+	}
+
+	ops := collectUpdateOpsWithPipeline(event)
+
+	pipeline, ok := ops.primary.(bson.A)
+	if !ok {
+		t.Fatalf("Expected pipeline (bson.A), got %T", ops.primary)
+	}
+
+	concatArraysStages, _ := classifySetStages(t, pipeline)
+
+	assert.Equal(t, 0, concatArraysStages, "$concatArrays stages (all fields should be batched)")
+
+	// Must have follow-ups since 100 × 20KB = 2MB >> 512KB limit
+	assert.NotEmpty(t, ops.followUp, "should have follow-up operations due to byte size")
+
+	// Each follow-up must be a standard update (bson.D) with a single $set operator
+	for i, fu := range ops.followUp {
+		assert.Len(t, fu, 1, "follow-up %d should have exactly 1 operator ($set)", i)
+		assert.Equal(t, "$set", fu[0].Key, "follow-up %d operator key", i)
+	}
+
+	// Count total fields across everything
+	totalFields := countAllSetFields(t, ops)
+	assert.Equal(t, numFields+1, totalFields, "total fields across primary + follow-ups (100 arr + 1 meta)")
+}
+
+// classifySetStages counts $concatArrays and truncation $set stages in a pipeline.
+func classifySetStages(t *testing.T, pipeline bson.A) (int, int) {
+	t.Helper()
+
+	var concatArrays, truncation int
+
+	for _, stage := range pipeline {
 		stageDoc, ok := stage.(bson.D)
 		if !ok {
 			continue
@@ -373,47 +464,81 @@ func TestCollectUpdateOpsWithPipeline_ChunksSetStages(t *testing.T) {
 
 			switch {
 			case len(setDoc) == 1 && hasConcatArrays(setDoc[0].Value):
-				concatArraysStages++
+				concatArrays++
 			case len(setDoc) == 1 && hasSlice(setDoc[0].Value):
-				truncationStages++
-			default:
-				chunkedStages = append(chunkedStages, setDoc)
+				truncation++
 			}
 		}
 	}
 
-	if concatArraysStages != 1 {
-		t.Errorf("Expected 1 $concatArrays stage, got %d", concatArraysStages)
-	}
+	return concatArrays, truncation
+}
 
-	if truncationStages != 1 {
-		t.Errorf("Expected 1 truncation stage, got %d", truncationStages)
-	}
+// extractSetFieldsFromPipeline collects non-array $set field keys from a pipeline in order.
+func extractSetFieldsFromPipeline(t *testing.T, pipeline bson.A) []string {
+	t.Helper()
 
-	// Each chunked stage must have at most maxFieldsPerSetStage fields
-	expectedChunks := (numFields + maxFieldsPerSetStage - 1) / maxFieldsPerSetStage
-	if len(chunkedStages) != expectedChunks {
-		t.Errorf("Expected %d chunked $set stages, got %d", expectedChunks, len(chunkedStages))
-	}
+	var keys []string
 
-	totalFields := 0
-
-	for i, chunk := range chunkedStages {
-		if len(chunk) > maxFieldsPerSetStage {
-			t.Errorf("Chunk %d has %d fields, exceeds max %d", i, len(chunk), maxFieldsPerSetStage)
+	for _, stage := range pipeline {
+		stageDoc, ok := stage.(bson.D)
+		if !ok {
+			continue
 		}
 
-		totalFields += len(chunk)
+		for _, elem := range stageDoc {
+			if elem.Key != setOp {
+				continue
+			}
+
+			setDoc, ok := elem.Value.(bson.D)
+			if !ok {
+				continue
+			}
+
+			for _, f := range setDoc {
+				if !hasConcatArrays(f.Value) && !hasSlice(f.Value) {
+					keys = append(keys, f.Key)
+				}
+			}
+		}
 	}
 
-	if totalFields != numFields {
-		t.Errorf("Expected %d total fields across chunks, got %d", numFields, totalFields)
+	return keys
+}
+
+// collectSetFieldKeys collects all non-array $set field keys from primary + follow-ups in order.
+func collectSetFieldKeys(t *testing.T, ops updateOps) []string {
+	t.Helper()
+
+	pipeline, ok := ops.primary.(bson.A)
+	if !ok {
+		t.Fatalf("Expected pipeline (bson.A), got %T", ops.primary)
 	}
 
-	// Total pipeline stages must be well under MongoDB's 1000-stage limit
-	if len(result) > 1000 {
-		t.Errorf("Pipeline has %d stages, exceeds MongoDB's 1000 stage limit", len(result))
+	keys := extractSetFieldsFromPipeline(t, pipeline)
+
+	// Follow-ups are standard $set (bson.D), not pipelines
+	for _, fu := range ops.followUp {
+		for _, elem := range fu {
+			if elem.Key == "$set" {
+				if setDoc, ok := elem.Value.(bson.D); ok {
+					for _, f := range setDoc {
+						keys = append(keys, f.Key)
+					}
+				}
+			}
+		}
 	}
+
+	return keys
+}
+
+// countAllSetFields counts all non-array $set fields across primary pipeline + follow-ups.
+func countAllSetFields(t *testing.T, ops updateOps) int {
+	t.Helper()
+
+	return len(collectSetFieldKeys(t, ops))
 }
 
 func TestCollectUpdateOpsWithPipeline_ChunkedSetPreservesOrder(t *testing.T) {
@@ -422,7 +547,7 @@ func TestCollectUpdateOpsWithPipeline_ChunkedSetPreservesOrder(t *testing.T) {
 	// Field ordering must be preserved across chunks to avoid breaking
 	// exact-match queries on embedded documents (MongoDB compares embedded
 	// documents by BSON byte order, so field reordering changes query semantics).
-	const numFields = 60 // spans 3 chunks of 25
+	const numFields = 250 // spans multiple chunks of maxFieldsPerSetStage
 
 	updatedFields := make(bson.D, 0, numFields)
 	expectedOrder := make([]string, 0, numFields)
@@ -445,34 +570,10 @@ func TestCollectUpdateOpsWithPipeline_ChunkedSetPreservesOrder(t *testing.T) {
 		},
 	}
 
-	result := collectUpdateOpsWithPipeline(event)
+	ops := collectUpdateOpsWithPipeline(event)
 
-	// Collect all non-array $set fields in pipeline order
-	var gotOrder []string
-
-	for _, stage := range result {
-		stageDoc, ok := stage.(bson.D)
-		if !ok {
-			continue
-		}
-
-		for _, elem := range stageDoc {
-			if elem.Key != setOp {
-				continue
-			}
-
-			setDoc, ok := elem.Value.(bson.D)
-			if !ok {
-				continue
-			}
-
-			for _, f := range setDoc {
-				if !hasConcatArrays(f.Value) && !hasSlice(f.Value) {
-					gotOrder = append(gotOrder, f.Key)
-				}
-			}
-		}
-	}
+	// Collect all non-array $set fields in order: primary pipeline first, then follow-ups
+	gotOrder := collectSetFieldKeys(t, ops)
 
 	if len(gotOrder) != len(expectedOrder) {
 		t.Fatalf("Expected %d fields, got %d", len(expectedOrder), len(gotOrder))
@@ -504,12 +605,17 @@ func TestCollectUpdateOpsWithPipeline_SliceUsesMaxForPositive(t *testing.T) {
 		},
 	}
 
-	result := collectUpdateOpsWithPipeline(event)
+	ops := collectUpdateOpsWithPipeline(event)
+
+	pipeline, ok := ops.primary.(bson.A)
+	if !ok {
+		t.Fatalf("Expected pipeline (bson.A), got %T", ops.primary)
+	}
 
 	// Find the $concatArrays stage for "arr"
 	found := false
 
-	for _, stage := range result {
+	for _, stage := range pipeline {
 		stageDoc, ok := stage.(bson.D)
 		if !ok {
 			continue

--- a/pcsm/repl/bulk_test.go
+++ b/pcsm/repl/bulk_test.go
@@ -106,11 +106,13 @@ func TestIsArrayPath(t *testing.T) {
 			want:  false,
 		},
 		{
-			name:  "dp nil, deeply nested: numeric path returns true",
+			// "a.2.b.3": last="3" numeric, direct parent="a.2.b" not in truncatedFields
+			// → standard $set (no $concatArrays needed; only direct parent matters)
+			name:  "dp nil, deeply nested: direct parent not truncated returns false",
 			field: "a.2.b.3",
 			dp:    nil,
 			tf:    map[string]struct{}{"a": {}},
-			want:  true,
+			want:  false,
 		},
 		{
 			name:  "dp nil, nested truncated parent: real array index",
@@ -125,6 +127,26 @@ func TestIsArrayPath(t *testing.T) {
 			dp:    nil,
 			tf:    map[string]struct{}{},
 			want:  false,
+		},
+		{
+			// "arr.0.10": last="10" numeric, direct parent="arr.0" not in truncatedFields
+			// ("arr" is truncated but "arr.0" is not) → standard $set to avoid data corruption
+			// from misidentifying "10" (a document field name) as an array index.
+			// This is the slice_zero scenario on MongoDB <6.1 without disambiguatedPaths.
+			name:  "dp nil, slice_zero scenario: numeric string field name not direct parent",
+			field: "arr.0.10",
+			dp:    nil,
+			tf:    map[string]struct{}{"arr": {}},
+			want:  false,
+		},
+		{
+			// "arr.0": last="0" numeric, direct parent="arr" IS in truncatedFields
+			// → $concatArrays needed (genuine array element replacement under truncated array)
+			name:  "dp nil, direct array element under truncated array returns true",
+			field: "arr.0",
+			dp:    nil,
+			tf:    map[string]struct{}{"arr": {}},
+			want:  true,
 		},
 	}
 

--- a/pcsm/repl/bulk_test.go
+++ b/pcsm/repl/bulk_test.go
@@ -315,13 +315,16 @@ func TestCollectUpdateOps_NoFalsePositiveConflict(t *testing.T) {
 	}
 }
 
-func TestCollectUpdateOpsWithPipeline_BatchesSetStages(t *testing.T) {
+func TestCollectUpdateOpsWithPipeline_ChunksSetStages(t *testing.T) {
 	t.Parallel()
 
-	// Many non-array fields should be batched into a single $set stage,
-	// not one $set stage per field.
-	updatedFields := make(bson.D, 0, 2000)
-	for i := range 2000 {
+	// Many non-array fields should be chunked into multiple $set stages
+	// (maxFieldsPerSetStage fields each) to avoid BufBuilder overflow,
+	// not emitted as one giant $set stage.
+	const numFields = 2000
+
+	updatedFields := make(bson.D, 0, numFields+1)
+	for i := range numFields {
 		updatedFields = append(updatedFields, bson.E{
 			Key:   "field_" + strconv.Itoa(i),
 			Value: "value",
@@ -345,9 +348,12 @@ func TestCollectUpdateOpsWithPipeline_BatchesSetStages(t *testing.T) {
 
 	result := collectUpdateOpsWithPipeline(event)
 
-	// Count $set stages
-	setStageCount := 0
-	var batchedSetStage bson.D
+	// Collect all $set stages, separating array ($concatArrays) from chunked non-array stages
+	var concatArraysStages int
+
+	var chunkedStages []bson.D
+
+	var truncationStages int
 
 	for _, stage := range result {
 		stageDoc, ok := stage.(bson.D)
@@ -356,36 +362,126 @@ func TestCollectUpdateOpsWithPipeline_BatchesSetStages(t *testing.T) {
 		}
 
 		for _, elem := range stageDoc {
-			if elem.Key == setOp {
-				setStageCount++
+			if elem.Key != setOp {
+				continue
+			}
 
-				setDoc, ok := elem.Value.(bson.D)
-				if !ok {
-					continue
-				}
+			setDoc, ok := elem.Value.(bson.D)
+			if !ok {
+				continue
+			}
 
-				// The batched stage will have many fields; the array stage has 1
-				if len(setDoc) > 1 {
-					batchedSetStage = setDoc
+			switch {
+			case len(setDoc) == 1 && hasConcatArrays(setDoc[0].Value):
+				concatArraysStages++
+			case len(setDoc) == 1 && hasSlice(setDoc[0].Value):
+				truncationStages++
+			default:
+				chunkedStages = append(chunkedStages, setDoc)
+			}
+		}
+	}
+
+	if concatArraysStages != 1 {
+		t.Errorf("Expected 1 $concatArrays stage, got %d", concatArraysStages)
+	}
+
+	if truncationStages != 1 {
+		t.Errorf("Expected 1 truncation stage, got %d", truncationStages)
+	}
+
+	// Each chunked stage must have at most maxFieldsPerSetStage fields
+	expectedChunks := (numFields + maxFieldsPerSetStage - 1) / maxFieldsPerSetStage
+	if len(chunkedStages) != expectedChunks {
+		t.Errorf("Expected %d chunked $set stages, got %d", expectedChunks, len(chunkedStages))
+	}
+
+	totalFields := 0
+
+	for i, chunk := range chunkedStages {
+		if len(chunk) > maxFieldsPerSetStage {
+			t.Errorf("Chunk %d has %d fields, exceeds max %d", i, len(chunk), maxFieldsPerSetStage)
+		}
+
+		totalFields += len(chunk)
+	}
+
+	if totalFields != numFields {
+		t.Errorf("Expected %d total fields across chunks, got %d", numFields, totalFields)
+	}
+
+	// Total pipeline stages must be well under MongoDB's 1000-stage limit
+	if len(result) > 1000 {
+		t.Errorf("Pipeline has %d stages, exceeds MongoDB's 1000 stage limit", len(result))
+	}
+}
+
+func TestCollectUpdateOpsWithPipeline_ChunkedSetPreservesOrder(t *testing.T) {
+	t.Parallel()
+
+	// Field ordering must be preserved across chunks to avoid breaking
+	// exact-match queries on embedded documents (MongoDB compares embedded
+	// documents by BSON byte order, so field reordering changes query semantics).
+	const numFields = 60 // spans 3 chunks of 25
+
+	updatedFields := make(bson.D, 0, numFields)
+	expectedOrder := make([]string, 0, numFields)
+
+	for i := range numFields {
+		key := "field_" + strconv.Itoa(i)
+		updatedFields = append(updatedFields, bson.E{Key: key, Value: i})
+		expectedOrder = append(expectedOrder, key)
+	}
+
+	event := &UpdateEvent{
+		UpdateDescription: UpdateDescription{
+			TruncatedArrays: []struct {
+				Field   string `bson:"field"`
+				NewSize int32  `bson:"newSize"`
+			}{
+				{Field: "arr", NewSize: 5},
+			},
+			UpdatedFields: updatedFields,
+		},
+	}
+
+	result := collectUpdateOpsWithPipeline(event)
+
+	// Collect all non-array $set fields in pipeline order
+	var gotOrder []string
+
+	for _, stage := range result {
+		stageDoc, ok := stage.(bson.D)
+		if !ok {
+			continue
+		}
+
+		for _, elem := range stageDoc {
+			if elem.Key != setOp {
+				continue
+			}
+
+			setDoc, ok := elem.Value.(bson.D)
+			if !ok {
+				continue
+			}
+
+			for _, f := range setDoc {
+				if !hasConcatArrays(f.Value) && !hasSlice(f.Value) {
+					gotOrder = append(gotOrder, f.Key)
 				}
 			}
 		}
 	}
 
-	// Should have: 1 truncation stage + 1 array $concatArrays stage + 1 batched $set stage = 3 $set stages total
-	expectedSetStages := 3
-	if setStageCount != expectedSetStages {
-		t.Errorf("Expected %d $set stages (truncation + array + batched), got %d", expectedSetStages, setStageCount)
+	if len(gotOrder) != len(expectedOrder) {
+		t.Fatalf("Expected %d fields, got %d", len(expectedOrder), len(gotOrder))
 	}
 
-	// The batched stage must contain all 2000 non-array fields
-	if len(batchedSetStage) != 2000 {
-		t.Errorf("Expected batched $set stage to contain 2000 fields, got %d", len(batchedSetStage))
-	}
-
-	// Total pipeline stages must be well under 1000
-	if len(result) > 1000 {
-		t.Errorf("Pipeline has %d stages, exceeds MongoDB's 1000 stage limit", len(result))
+	for i := range expectedOrder {
+		if gotOrder[i] != expectedOrder[i] {
+			t.Errorf("Field at position %d: got %q, want %q", i, gotOrder[i], expectedOrder[i])
+		}
 	}
 }
 
@@ -569,6 +665,21 @@ func hasConcatArrays(v any) bool {
 
 	for _, elem := range valueDoc {
 		if elem.Key == "$concatArrays" {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasSlice(v any) bool {
+	valueDoc, ok := v.(bson.D)
+	if !ok {
+		return false
+	}
+
+	for _, elem := range valueDoc {
+		if elem.Key == "$slice" {
 			return true
 		}
 	}

--- a/tests/test_pipeline_updates.py
+++ b/tests/test_pipeline_updates.py
@@ -111,20 +111,17 @@ def _assert_docs_equal(src_doc, dst_doc, ns):
     """Field-by-field comparison with detailed diagnostics on mismatch"""
     assert src_doc is not None, f"Source document missing in {ns}"
     assert dst_doc is not None, f"Target document missing in {ns}"
-    src_keys = list(src_doc.keys())
-    dst_keys = list(dst_doc.keys())
-    if src_keys != dst_keys:
+    if set(src_doc.keys()) != set(dst_doc.keys()):
         only_src = set(src_doc) - set(dst_doc)
         only_dst = set(dst_doc) - set(src_doc)
-        pytest.fail(
-            f"Document key mismatch in {ns}: only_src={only_src}, only_dst={only_dst}, "
-            f"src_order={src_keys}, dst_order={dst_keys}"
-        )
+        pytest.fail(f"Document key mismatch in {ns}: only_src={only_src}, only_dst={only_dst}")
     value_errors = []
     for k in src_doc:
         if not _bson_eq(src_doc[k], dst_doc[k]):
             value_errors.append(k)
     if not value_errors:
+        if list(src_doc.keys()) != list(dst_doc.keys()):
+            print(f"  WARNING: {ns}: top-level field order differs (data OK)")
         return
     lines = [f"Document mismatch in {ns}, fields: {value_errors[:10]}"]
     for k in value_errors[:5]:
@@ -159,4 +156,3 @@ def test_pipeline_update_regression(t: Testing, scenario_name: str):
     src_doc = t.source[db][coll_name].find_one({"_id": 1})
     dst_doc = t.target[db][coll_name].find_one({"_id": 1})
     _assert_docs_equal(src_doc, dst_doc, f"{db}.{coll_name}")
-    t.compare_all()

--- a/tests/test_pipeline_updates.py
+++ b/tests/test_pipeline_updates.py
@@ -16,7 +16,9 @@ def _build_pipeline_update_scenario(scenario_name):
     BUFBUILDER_LARGE_VAL = "X" * 20_000
     BUFBUILDER_PAD_VAL = "P" * 10_000
     BUFBUILDER_NEW_VAL = "Y" * 20_000
+
     embedded = {"author": "test", "version": 1, "status": "active"}
+
     if scenario_name == "stage_limit":
         doc = {
             "_id": 1,
@@ -25,14 +27,18 @@ def _build_pipeline_update_scenario(scenario_name):
             "metadata": "initial",
             "meta": embedded,
         }
+
         massive_set = {"items_count": STAGE_LIMIT_SLICE_TO, "meta.updated": True}
+
         for i in range(STAGE_LIMIT_EXTRAS):
             massive_set[f"extra_field_{i}"] = "value"
         update = [
             {"$set": {"items": {"$slice": ["$items", STAGE_LIMIT_SLICE_TO]}}},
             {"$set": massive_set},
         ]
+
         return {"doc": doc, "update": update}
+
     if scenario_name == "bufbuilder":
         doc = {
             "_id": 1,
@@ -47,6 +53,7 @@ def _build_pipeline_update_scenario(scenario_name):
                 for i in range(BUFBUILDER_NUM_ELEMENTS)
             ],
         }
+
         update = [
             {
                 "$set": {
@@ -77,21 +84,28 @@ def _build_pipeline_update_scenario(scenario_name):
             },
             {"$set": {"meta.updated": True}},
         ]
+
         return {"doc": doc, "update": update}
+
     if scenario_name == "slice_zero":
         num_elements = 20
         empty_idx = 10
         truncate_to = 15
+
         arr = []
         for i in range(num_elements):
             sub = [] if i == empty_idx else [i * 10, i * 10 + 1]
             arr.append({"items": sub, "n": f"e{i}", "v": i})
+
         doc = {"_id": 1, "meta": embedded, "arr": arr}
+
         update = [
             {"$set": {"arr": {"$slice": ["$arr", truncate_to]}}},
             {"$set": {f"arr.{empty_idx}.items.0": 99, "meta.updated": True}},
         ]
+
         return {"doc": doc, "update": update}
+
     raise ValueError(f"unknown scenario: {scenario_name}")
 
 
@@ -99,12 +113,15 @@ def _bson_eq(a, b):
     """Order-sensitive comparison (matches BSON/MongoDB field-order semantics)"""
     if type(a) is not type(b):
         return False
+
     if isinstance(a, dict):
         if list(a.keys()) != list(b.keys()):
             return False
         return all(_bson_eq(a[k], b[k]) for k in a)
+
     if isinstance(a, list):
         return len(a) == len(b) and all(_bson_eq(x, y) for x, y in zip(a, b, strict=False))
+
     return a == b
 
 
@@ -112,33 +129,41 @@ def _assert_docs_equal(src_doc, dst_doc, ns):
     """Field-by-field comparison with detailed diagnostics on mismatch"""
     assert src_doc is not None, f"Source document missing in {ns}"
     assert dst_doc is not None, f"Target document missing in {ns}"
+
     if set(src_doc.keys()) != set(dst_doc.keys()):
         only_src = set(src_doc) - set(dst_doc)
         only_dst = set(dst_doc) - set(src_doc)
         pytest.fail(f"Document key mismatch in {ns}: only_src={only_src}, only_dst={only_dst}")
+
     value_errors = []
+
     for k in src_doc:
         if not _bson_eq(src_doc[k], dst_doc[k]):
             value_errors.append(k)
+
     if not value_errors:
         if list(src_doc.keys()) != list(dst_doc.keys()):
             print(f"  WARNING: {ns}: top-level field order differs (data OK)")
         return
+
     lines = [f"Document mismatch in {ns}, fields: {value_errors[:10]}"]
     for k in value_errors[:5]:
         sv, dv = src_doc[k], dst_doc[k]
+
         if isinstance(sv, list) and isinstance(dv, list) and len(sv) == len(dv):
             diff_idx = [i for i in range(len(sv)) if not _bson_eq(sv[i], dv[i])]
             lines.append(
                 f"  key '{k}': {len(sv)} elems, {len(diff_idx)} differ"
                 f" at indices {diff_idx[:10]}{'...' if len(diff_idx) > 10 else ''}"
             )
+
             for i in diff_idx[:3]:
                 lines.append(f"    [{i}] src={repr(sv[i])[:200]}")
                 lines.append(f"    [{i}] dst={repr(dv[i])[:200]}")
         else:
             lines.append(f"  key '{k}': src={repr(sv)[:200]}")
             lines.append(f"  key '{k}': dst={repr(dv)[:200]}")
+
     pytest.fail("\n".join(lines))
 
 
@@ -152,9 +177,12 @@ def _wait_for_target_doc(target, db, coll_name, doc_id, timeout=30):
     """
     for _ in range(timeout * 2):
         doc = target[db][coll_name].find_one({"_id": doc_id})
+
         if doc is not None:
             return doc
+
         time.sleep(0.5)
+
     return None
 
 
@@ -167,6 +195,7 @@ def test_pipeline_update_regression(t: Testing, scenario_name: str):
     scenario = _build_pipeline_update_scenario(scenario_name)
     doc = scenario["doc"]
     update = scenario["update"]
+
     with t.run(Runner.Phase.APPLY, wait_timeout=60):
         t.source[db][coll_name].insert_one(doc)
         t.source[db][coll_name].update_one({"_id": 1}, update)
@@ -174,6 +203,7 @@ def test_pipeline_update_regression(t: Testing, scenario_name: str):
         # the events. On MongoDB 6.0 sharded clusters, the optime-based barrier in
         # wait_for_current_optime() may return before events are fully flushed.
         _wait_for_target_doc(t.target, db, coll_name, 1)
+
     src_doc = t.source[db][coll_name].find_one({"_id": 1})
     dst_doc = t.target[db][coll_name].find_one({"_id": 1})
     _assert_docs_equal(src_doc, dst_doc, f"{db}.{coll_name}")

--- a/tests/test_pipeline_updates.py
+++ b/tests/test_pipeline_updates.py
@@ -170,6 +170,10 @@ def test_pipeline_update_regression(t: Testing, scenario_name: str):
     with t.run(Runner.Phase.APPLY, wait_timeout=60):
         t.source[db][coll_name].insert_one(doc)
         t.source[db][coll_name].update_one({"_id": 1}, update)
+        # Poll target BEFORE finalization to ensure the change stream has delivered
+        # the events. On MongoDB 6.0 sharded clusters, the optime-based barrier in
+        # wait_for_current_optime() may return before events are fully flushed.
+        _wait_for_target_doc(t.target, db, coll_name, 1)
     src_doc = t.source[db][coll_name].find_one({"_id": 1})
-    dst_doc = _wait_for_target_doc(t.target, db, coll_name, 1)
+    dst_doc = t.target[db][coll_name].find_one({"_id": 1})
     _assert_docs_equal(src_doc, dst_doc, f"{db}.{coll_name}")

--- a/tests/test_pipeline_updates.py
+++ b/tests/test_pipeline_updates.py
@@ -1,0 +1,162 @@
+# pylint: disable=missing-docstring,redefined-outer-name
+import pytest
+from testing import Testing
+
+from pcsm import Runner
+
+
+def _build_pipeline_update_scenario(scenario_name):
+    STAGE_LIMIT_ITEMS_LEN = 2000
+    STAGE_LIMIT_SLICE_TO = 1000
+    STAGE_LIMIT_EXTRAS = 3000
+    BUFBUILDER_NUM_ELEMENTS = 300
+    BUFBUILDER_NUM_MODIFY = 100
+    BUFBUILDER_TRUNCATE_TO = 250
+    BUFBUILDER_LARGE_VAL = "X" * 20_000
+    BUFBUILDER_PAD_VAL = "P" * 10_000
+    BUFBUILDER_NEW_VAL = "Y" * 20_000
+    embedded = {"author": "test", "version": 1, "status": "active"}
+    if scenario_name == "stage_limit":
+        doc = {
+            "_id": 1,
+            "items": [f"old_val_{i}" for i in range(STAGE_LIMIT_ITEMS_LEN)],
+            "items_count": STAGE_LIMIT_ITEMS_LEN,
+            "metadata": "initial",
+            "meta": embedded,
+        }
+        massive_set = {"items_count": STAGE_LIMIT_SLICE_TO, "meta.updated": True}
+        for i in range(STAGE_LIMIT_EXTRAS):
+            massive_set[f"extra_field_{i}"] = "value"
+        update = [
+            {"$set": {"items": {"$slice": ["$items", STAGE_LIMIT_SLICE_TO]}}},
+            {"$set": massive_set},
+        ]
+        return {"doc": doc, "update": update}
+    if scenario_name == "bufbuilder":
+        doc = {
+            "_id": 1,
+            "meta": embedded,
+            "arr": [
+                {
+                    "d": BUFBUILDER_LARGE_VAL,
+                    "pad1": BUFBUILDER_PAD_VAL,
+                    "pad2": BUFBUILDER_PAD_VAL,
+                    "v": i + 1,
+                }
+                for i in range(BUFBUILDER_NUM_ELEMENTS)
+            ],
+        }
+        update = [
+            {
+                "$set": {
+                    "arr": {
+                        "$slice": [
+                            {
+                                "$map": {
+                                    "input": "$arr",
+                                    "as": "el",
+                                    "in": {
+                                        "$cond": {
+                                            "if": {"$lte": ["$$el.v", BUFBUILDER_NUM_MODIFY]},
+                                            "then": {
+                                                "$mergeObjects": [
+                                                    "$$el",
+                                                    {"d": BUFBUILDER_NEW_VAL},
+                                                ]
+                                            },
+                                            "else": "$$el",
+                                        }
+                                    },
+                                }
+                            },
+                            BUFBUILDER_TRUNCATE_TO,
+                        ]
+                    }
+                }
+            },
+            {"$set": {"meta.updated": True}},
+        ]
+        return {"doc": doc, "update": update}
+    if scenario_name == "slice_zero":
+        num_elements = 20
+        empty_idx = 10
+        truncate_to = 15
+        arr = []
+        for i in range(num_elements):
+            sub = [] if i == empty_idx else [i * 10, i * 10 + 1]
+            arr.append({"items": sub, "n": f"e{i}", "v": i})
+        doc = {"_id": 1, "meta": embedded, "arr": arr}
+        update = [
+            {"$set": {"arr": {"$slice": ["$arr", truncate_to]}}},
+            {"$set": {f"arr.{empty_idx}.items.0": 99, "meta.updated": True}},
+        ]
+        return {"doc": doc, "update": update}
+    raise ValueError(f"unknown scenario: {scenario_name}")
+
+
+def _bson_eq(a, b):
+    """Order-sensitive comparison (matches BSON/MongoDB field-order semantics)"""
+    if type(a) is not type(b):
+        return False
+    if isinstance(a, dict):
+        if list(a.keys()) != list(b.keys()):
+            return False
+        return all(_bson_eq(a[k], b[k]) for k in a)
+    if isinstance(a, list):
+        return len(a) == len(b) and all(_bson_eq(x, y) for x, y in zip(a, b, strict=False))
+    return a == b
+
+
+def _assert_docs_equal(src_doc, dst_doc, ns):
+    """Field-by-field comparison with detailed diagnostics on mismatch"""
+    assert src_doc is not None, f"Source document missing in {ns}"
+    assert dst_doc is not None, f"Target document missing in {ns}"
+    src_keys = list(src_doc.keys())
+    dst_keys = list(dst_doc.keys())
+    if src_keys != dst_keys:
+        only_src = set(src_doc) - set(dst_doc)
+        only_dst = set(dst_doc) - set(src_doc)
+        pytest.fail(
+            f"Document key mismatch in {ns}: only_src={only_src}, only_dst={only_dst}, "
+            f"src_order={src_keys}, dst_order={dst_keys}"
+        )
+    value_errors = []
+    for k in src_doc:
+        if not _bson_eq(src_doc[k], dst_doc[k]):
+            value_errors.append(k)
+    if not value_errors:
+        return
+    lines = [f"Document mismatch in {ns}, fields: {value_errors[:10]}"]
+    for k in value_errors[:5]:
+        sv, dv = src_doc[k], dst_doc[k]
+        if isinstance(sv, list) and isinstance(dv, list) and len(sv) == len(dv):
+            diff_idx = [i for i in range(len(sv)) if not _bson_eq(sv[i], dv[i])]
+            lines.append(
+                f"  key '{k}': {len(sv)} elems, {len(diff_idx)} differ"
+                f" at indices {diff_idx[:10]}{'...' if len(diff_idx) > 10 else ''}"
+            )
+            for i in diff_idx[:3]:
+                lines.append(f"    [{i}] src={repr(sv[i])[:200]}")
+                lines.append(f"    [{i}] dst={repr(dv[i])[:200]}")
+        else:
+            lines.append(f"  key '{k}': src={repr(sv)[:200]}")
+            lines.append(f"  key '{k}': dst={repr(dv)[:200]}")
+    pytest.fail("\n".join(lines))
+
+
+@pytest.mark.timeout(120)
+@pytest.mark.parametrize("scenario_name", ["stage_limit", "bufbuilder", "slice_zero"])
+def test_pipeline_update_regression(t: Testing, scenario_name: str):
+    """Pipeline update regression: stage-limit, bufbuilder overflow, and $slice-zero"""
+    db = "pipeline_test_db"
+    coll_name = f"pipeline_{scenario_name}"
+    scenario = _build_pipeline_update_scenario(scenario_name)
+    doc = scenario["doc"]
+    update = scenario["update"]
+    with t.run(Runner.Phase.APPLY, wait_timeout=60):
+        t.source[db][coll_name].insert_one(doc)
+        t.source[db][coll_name].update_one({"_id": 1}, update)
+    src_doc = t.source[db][coll_name].find_one({"_id": 1})
+    dst_doc = t.target[db][coll_name].find_one({"_id": 1})
+    _assert_docs_equal(src_doc, dst_doc, f"{db}.{coll_name}")
+    t.compare_all()

--- a/tests/test_pipeline_updates.py
+++ b/tests/test_pipeline_updates.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-docstring,redefined-outer-name
 import pytest
+import time
 from testing import Testing
 
 from pcsm import Runner
@@ -141,6 +142,22 @@ def _assert_docs_equal(src_doc, dst_doc, ns):
     pytest.fail("\n".join(lines))
 
 
+def _wait_for_target_doc(target, db, coll_name, doc_id, timeout=30):
+    """Poll target until the document appears or timeout.
+
+    On some MongoDB versions (notably 6.0 sharded clusters), the optime-based
+    synchronization barrier in wait_for_current_optime() may return before the
+    change stream events have been fully flushed to the target. This polling
+    loop provides a reliable data-level verification.
+    """
+    for _ in range(timeout * 2):
+        doc = target[db][coll_name].find_one({"_id": doc_id})
+        if doc is not None:
+            return doc
+        time.sleep(0.5)
+    return None
+
+
 @pytest.mark.timeout(120)
 @pytest.mark.parametrize("scenario_name", ["stage_limit", "bufbuilder", "slice_zero"])
 def test_pipeline_update_regression(t: Testing, scenario_name: str):
@@ -154,5 +171,5 @@ def test_pipeline_update_regression(t: Testing, scenario_name: str):
         t.source[db][coll_name].insert_one(doc)
         t.source[db][coll_name].update_one({"_id": 1}, update)
     src_doc = t.source[db][coll_name].find_one({"_id": 1})
-    dst_doc = t.target[db][coll_name].find_one({"_id": 1})
+    dst_doc = _wait_for_target_doc(t.target, db, coll_name, 1)
     _assert_docs_equal(src_doc, dst_doc, f"{db}.{coll_name}")

--- a/tests/test_pipeline_updates.py
+++ b/tests/test_pipeline_updates.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-docstring,redefined-outer-name
-import pytest
 import time
+
+import pytest
 from testing import Testing
 
 from pcsm import Runner


### PR DESCRIPTION
[PCSM-294](https://perconadev.atlassian.net/browse/PCSM-294)

### Problem

Replication fails for two distinct scenarios involving pipeline updates on large documents:
1. **BufBuilder overflow (error 13548)** — When a change stream event contains many large dotted-path field updates conflicting with a truncated array, the update pipeline sent to the target accumulates too much intermediate BSON state across stages, exceeding MongoDB's internal BufBuilder limit. This caused replication to enter a failed state.
2. **Data corruption on MongoDB <6.1** — Without `disambiguatedPaths` in the change stream, PCSM's `isArrayPath` heuristic incorrectly identified paths like `arr.0.10` (where `"10"` is a document field name) as array index paths. This caused incorrect `$concatArrays` pipeline stages to be generated, corrupting the target document with spurious numeric-keyed fields.


### Solution

**BufBuilder overflow:** When a change event requires a pipeline update (i.e. an updated field conflicts with a truncated array), PCSM now splits the work for that single event into multiple ordered `updateOne` operations in the bulk write:
- **Primary pipeline** (`bson.A`): contains only the stages that genuinely need pipeline sequencing — one `$slice` stage per truncated array and one `$concatArrays` stage per array-index updated field.
- **Follow-up standard updates** (`bson.D`): the remaining non-array fields are emitted as one or more separate standard `updateOne` operations, chunked by field count (max 100 per operation) and byte size (max 512KB per operation).

Standard `$set` is used for the follow-ups for two reasons: it correctly navigates dotted numeric paths as array indices (pipeline `$set` would treat them as field names), and each separate `updateOne` gets its own BufBuilder, avoiding the overflow. Correctness of the split is guaranteed by `SetOrdered(true)` on the bulk write, which ensures follow-ups always execute after the primary pipeline has applied.


**`isArrayPath` heuristic fix:** Removed the depth heuristic (`len(parts) > 2`) that caused false positives on MongoDB <6.1 (6.1+ is unaffected since `disambiguatedPaths` was introduced in that version). The heuristic is replaced with a single precise check: `$concatArrays` is only used when the direct parent path of the updated field is present in `truncatedFields`. This correctly handles ambiguous numeric-string paths without `disambiguatedPaths` available.

Without `disambiguatedPaths`, a path like `arr.0.10` is ambiguous — `"10"` could be an array index or a document field name. The old depth heuristic assumed depth > 2 means array index, which caused data corruption when `"10"` was actually a field name. The fix uses `truncatedFields` as the only reliable signal: `$concatArrays` is needed precisely when the direct parent of the updated path is a truncated array (e.g. `arr.5` when `arr` was truncated, parent `arr` is in `truncatedFields`). For deeper paths like `arr.0.10`, the parent `arr.0` is not in `truncatedFields`, so a standard `$set` is used — which handles both the array-index and field-name interpretations correctly.

[PCSM-294]: https://perconadev.atlassian.net/browse/PCSM-294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ