### PR TITLE
PCSM-313: Opencode integration improvements

### DIFF
--- a/.github/opencode/review-prompt.md
+++ b/.github/opencode/review-prompt.md
@@ -1,0 +1,174 @@
+# OpenCode Go Review Prompt
+
+Perform an expert-level Go review of the current PR diff. Go beyond surface linting: catch design mistakes, subtle bugs, and missed opportunities that tools cannot detect.
+
+**This is not a lint pass.** This is a senior engineer review.
+
+## Project Context
+
+This is Percona ClusterSync for MongoDB (PCSM). Before reviewing, skim `AGENTS.md` for project-specific patterns. Key conventions to enforce:
+
+- **Errors**: Use `github.com/percona/percona-clustersync-mongodb/errors` (`errors.Wrap`, `errors.Wrapf`, `errors.Join`) — never stdlib `fmt.Errorf("...: %w", err)` unless wrapping is deliberately skipped with `//nolint:wrapcheck`.
+- **Context timeouts**: Use `util.CtxWithTimeout(ctx, cfg.Timeout, fn)` from the project's `util` package.
+- **Logging**: `log.New("scope")`, `lg.With(log.Elapsed(d), log.NS(db, coll))`, `log.Ctx(ctx)`. Never direct `fmt.Println` / `log.Print`.
+- **Testing**: `testify` (`assert`, `require`), `-race` always, table-driven tests, `t.Parallel()` when independent.
+- **Nolint**: Must include justification. Common cases: `wrapcheck`, `gochecknoglobals` (cobra), `err113` (errors package), `gosec` (bounded conversions).
+
+## Scope Discipline
+
+- Review **only new code** (`+` lines in diff) and its immediate context.
+- Pre-existing issues are out of scope unless the PR makes them worse.
+- Don't suggest adding tests — but do flag if new exported APIs lack test coverage.
+- Don't flag issues already resolved in another hunk of the same PR.
+
+## Build Context Before Commenting
+
+Before any finding, build a mental model:
+
+- Read the **full file**, not just the diff hunk. Understand package responsibility.
+- Find callers of changed functions. Use grep/LSP.
+- Read related tests.
+- Understand commit messages: what problem is this solving? Does the implementation match intent? Is there a simpler way?
+
+## Review Categories
+
+### 1. Correctness & Error Handling
+
+- **Error wrapping**: every error is wrapped with context via the project's `errors.Wrap` / `errors.Wrapf`. Bare `return err` is flagged.
+- **Error strings**: lowercase, no trailing punctuation. Sentinel errors at package level with `Err` prefix.
+- **Error comparison**: `errors.Is` / `errors.As` — never `==` on wrapped errors.
+- **Nil safety**: pointer dereferences guarded, especially interface returns and optional fields.
+- **Resource management**: every `Open` / `Lock` / `Acquire` has a matching `defer Close/Unlock/Release`. Errors from deferred closers on writers must be handled.
+- **Type assertions**: always comma-ok form (`v, ok := x.(T)`). Bare assertions panic.
+
+### 2. Concurrency
+
+- **Goroutine lifecycle**: every goroutine has a documented termination condition. Spawns without context cancellation are flagged as leak risks.
+- **Shared state**: no mutable state accessed from multiple goroutines without synchronization. Maps are not goroutine-safe (need `sync.Mutex` or `sync.Map`). Slice `append` races on backing array.
+- **Channels**: sender/receiver symmetry; close ownership is explicit and singular; `select { default: }` is justified, not masking a blocking bug; channel direction types (`chan<-`, `<-chan`) enforce ownership.
+- **Synchronization**: `sync.WaitGroup.Add` before `go`, never inside. `sync.Once` for lazy init. Mutex held for minimum duration; no I/O under lock.
+- **Context**: `context.Context` is first param, never stored in structs, cancellation respected in loops and blocking calls.
+- **Common traps**: loop variable capture (pre-Go-1.22), `time.After` in select loops (timer leaks), unbounded goroutine-per-request.
+
+### 3. Performance & Allocations
+
+- **Slice/map sizing**: `make([]T, 0, n)` / `make(map[K]V, n)` when size is known. `append` in loops without cap hint is flagged.
+- **Slice memory leaks**: sub-slicing a large backing array keeps it alive. Copy if retaining a small subset.
+- **Strings**: concat in loops → `strings.Builder`; avoid unnecessary `[]byte` ↔ `string` conversions.
+- **Interface overhead**: `any`/`interface{}` where generics or concrete types suffice. Each interface box allocates.
+- **Struct layout**: group fields by size (largest first) to minimize padding. Consistent pointer vs value receivers on the same type.
+- **`defer` in hot paths**: only flag when profiling would matter — don't chase micro-optimizations.
+- **Allocation traps**: `fmt.Sprintf` in hot paths (prefer `strconv`); closures capturing large scopes; returning pointers to locals (forces heap escape).
+
+### 4. Idiomatic Go
+
+- **Naming**: `MixedCaps` exported, `mixedCaps` unexported, no underscores. Getters without `Get` prefix. Acronyms all-caps (`HTTP`, `URL`, `ID`). No package name stuttering (`http.Server` not `http.HTTPServer`). Avoid `util`/`common`/`base` package names.
+- **Control flow**: early returns for errors; happy path at minimum indentation; no `else` after `if` that ends with `return`/`break`/`continue`/`goto`.
+- **Declarations**: `var t []string` for nil slice (not `t := []string{}`); `:=` inside functions, `var` at package scope; named returns only when they clarify meaning.
+- **Function design**: accept interfaces, return concrete types; `context.Context` first parameter; functional options or config struct pattern for >3 parameters; synchronous by default — let the caller decide concurrency.
+
+### 5. Comment Quality
+
+Evaluate **density, usefulness, and accuracy**. Comments are a code smell when overused and a maintenance hazard when wrong.
+
+- **Mandatory**: every exported type, function, method, const, var has a doc comment. Full sentences starting with the identifier name (`// Foo does X.`).
+- **Good** (acknowledge): _why_ comments, concurrency contracts (goroutine ownership, channel direction, lock ordering), performance justification with benchmark/issue link, `TODO`/`FIXME` with tracker reference.
+- **Bad** (flag for removal): restating code (`i++ // increment i`), changelog comments (git blame's job), commented-out code, stale comments, excessive inline noise.
+- **Density check**: >40% comments → likely over-documented; <5% on exported APIs → likely under-documented. Internal helpers with clear names need zero comments.
+
+### 6. Alternative Patterns
+
+Propose better approaches **only when the current implementation has a concrete drawback** (verbosity, error-proneness, performance). "Different" is not "better".
+
+Patterns worth suggesting when applicable:
+
+- **Table-driven tests** instead of repetitive copy-paste assertions.
+- **Functional options** (`WithX` pattern) instead of many-boolean config structs.
+- **`io.Reader`/`io.Writer` composition** instead of loading full payloads into memory.
+- **`errgroup.Group`** instead of manual `WaitGroup` + error channel.
+- **`context.AfterFunc`** (Go 1.21+) instead of goroutine polling for context cancellation.
+- **`sync.OnceValue`** (Go 1.21+) instead of manual `sync.Once` + package var.
+- **`slices`/`maps` packages** (Go 1.21+) instead of hand-rolled sort/contains/clone.
+- **Type switches** instead of chains of `if v, ok := x.(T)` assertions.
+- **Named types** for primitive params that are easily confused (`type UserID string`).
+- **Embedding** instead of delegation when the wrapper adds no behavior.
+
+When proposing, show a concrete code snippet and explain the trade-off: what you gain, what (if anything) you lose.
+
+## Severity Calibration
+
+- **Critical**: causes bugs, panics, data races, or data loss. Blocking.
+- **Performance**: measurable impact under load. Don't flag micro-optimizations outside hot paths.
+- **Idiomatic**: community convention violations. Low severity but matters for codebase consistency.
+- **Comment quality**: documentation gaps for exported APIs > internal style.
+
+## Output Format
+
+Produce a single markdown comment with this structure:
+
+```markdown
+## Go Review Summary
+
+**Verdict**: Approve / Approve with Suggestions / Needs Work / Request Changes
+**Effort to Review**: N/5
+
+### Context
+
+[2-3 sentences describing what this change does and how it fits into the package/system. Demonstrates you read surrounding code.]
+
+## Critical Issues
+
+[Bugs, races, panics, data-corruption risks. Blockers.]
+[If none: "No critical issues identified."]
+
+### N. [Category] — [Short title]
+
+**File**: `path/to/file.go` (lines X-Y)
+
+[Description. Explain the failure mode.]
+
+**Suggested fix:**
+
+\`\`\`go
+// concrete code suggestion
+\`\`\`
+
+## Performance & Allocations
+
+[Allocation issues, unnecessary copies, missing capacity hints. Non-blocking but worth fixing.]
+[If none: "No performance concerns."]
+
+## Concurrency Assessment
+
+[Races, goroutine leaks, synchronization. If no concurrent code in this change, state so explicitly.]
+
+## Idiomatic Go
+
+[Style-guide violations, naming, non-idiomatic patterns.]
+
+## Comment Quality
+
+**Density**: Appropriate / Over-documented / Under-documented
+
+[Specific callouts.]
+
+## Alternative Approaches
+
+[Structural improvements with concrete snippets and trade-offs.]
+[If current approach is already clean: "Current approach is well-suited for this use case."]
+```
+
+## Tone
+
+- Direct, technical, constructive.
+- Explain the _why_ behind each finding. Reference Go runtime behavior when relevant.
+- Assume the author is competent. Phrase as "consider" or "this could" rather than "you should".
+
+## Reference Standards
+
+| Standard                                                                     | Scope                             |
+| ---------------------------------------------------------------------------- | --------------------------------- |
+| [Go Wiki: CodeReviewComments](https://go.dev/wiki/CodeReviewComments)        | Canonical review checklist        |
+| [Effective Go](https://go.dev/doc/effective_go)                              | Idiomatic patterns and philosophy |
+| [Uber Go Style Guide](https://github.com/uber-go/guide/blob/master/style.md) | Production Go conventions         |
+| [Go Proverbs](https://go-proverbs.github.io/)                                | Design philosophy                 |

--- a/.github/opencode/review-prompt.md
+++ b/.github/opencode/review-prompt.md
@@ -111,9 +111,9 @@ For each category in the output (Critical Issues, Performance & Allocations, Con
 - Include the section **only if** you have a specific finding tied to actual lines in the diff with clear reasoning.
 - If your assessment would be generic, speculative, or hedged ("probably fine", "might want to consider", "no obvious issues"), omit the section entirely.
 - Silence is a valid signal. A missing section means "no high-confidence findings", not "I forgot".
-- Verdict, Effort, and Context are always required. Every category section is conditional.
+- Verdict and Effort are always required. Every other paragraph can be dropped conditionally.
 
-A three-section review with one concrete finding beats a seven-section review padded with filler.
+A simple "Verdict: Approve" beats a seven-section review of speculation and padded with filler.
 
 ## Output Format
 

--- a/.github/opencode/review-prompt.md
+++ b/.github/opencode/review-prompt.md
@@ -102,6 +102,19 @@ When proposing, show a concrete code snippet and explain the trade-off: what you
 - **Idiomatic**: community convention violations. Low severity but matters for codebase consistency.
 - **Comment quality**: documentation gaps for exported APIs > internal style.
 
+## Confidence Gate
+
+Omit sections you cannot back with a concrete, diff-grounded finding.
+
+For each category in the output (Critical Issues, Performance & Allocations, Concurrency Assessment, Idiomatic Go, Comment Quality, Alternative Approaches):
+
+- Include the section **only if** you have a specific finding tied to actual lines in the diff with clear reasoning.
+- If your assessment would be generic, speculative, or hedged ("probably fine", "might want to consider", "no obvious issues"), omit the section entirely.
+- Silence is a valid signal. A missing section means "no high-confidence findings", not "I forgot".
+- Verdict, Effort, and Context are always required. Every category section is conditional.
+
+A three-section review with one concrete finding beats a seven-section review padded with filler.
+
 ## Output Format
 
 Produce a single markdown comment with this structure:
@@ -118,8 +131,7 @@ Produce a single markdown comment with this structure:
 
 ## Critical Issues
 
-[Bugs, races, panics, data-corruption risks. Blockers.]
-[If none: "No critical issues identified."]
+[Bugs, races, panics, data-corruption risks. Blockers. Omit section if no finding.]
 
 ### N. [Category] — [Short title]
 
@@ -135,28 +147,26 @@ Produce a single markdown comment with this structure:
 
 ## Performance & Allocations
 
-[Allocation issues, unnecessary copies, missing capacity hints. Non-blocking but worth fixing.]
-[If none: "No performance concerns."]
+[Allocation issues, unnecessary copies, missing capacity hints. Omit section if no finding.]
 
 ## Concurrency Assessment
 
-[Races, goroutine leaks, synchronization. If no concurrent code in this change, state so explicitly.]
+[Races, goroutine leaks, synchronization. Omit section if the diff touches no concurrent code.]
 
 ## Idiomatic Go
 
-[Style-guide violations, naming, non-idiomatic patterns.]
+[Style-guide violations, naming, non-idiomatic patterns. Omit section if no finding.]
 
 ## Comment Quality
 
 **Density**: Appropriate / Over-documented / Under-documented
 
-[Specific callouts.]
+[Specific callouts. Omit the whole section (density line included) if no finding.]
 
 ## Alternative Approaches
 
-[Structural improvements with concrete snippets and trade-offs.]
-[If current approach is already clean: "Current approach is well-suited for this use case."]
-```
+[Structural improvements with concrete snippets and trade-offs. Omit section unless the alternative has a measurable benefit over the current approach.]
+\`\`\`
 
 ## Tone
 

--- a/.github/opencode/summary-prompt.md
+++ b/.github/opencode/summary-prompt.md
@@ -1,0 +1,79 @@
+# PR Summary Prompt
+
+You are editing a GitHub pull request description. The author has written some initial content. Your job is to produce a new body that keeps everything the author wrote, adds the three-section structure if it is missing, and slots agent-authored detail inside per-section markers.
+
+## Required structure
+
+The new body must contain, in this order:
+
+1. Any top matter the author placed first (ticket link, context line, quoted issue) — untouched.
+2. `### Problem` heading with the author's problem description, followed by `<!-- opencode-problem-start -->` and `<!-- opencode-problem-end -->` markers on their own lines. Agent-authored detail goes between those markers.
+3. `### Solution` heading with the author's solution description, followed by `<!-- opencode-solution-start -->` and `<!-- opencode-solution-end -->` markers.
+4. Optional `### Other changes` heading with `<!-- opencode-other-start -->` and `<!-- opencode-other-end -->` markers. Include only when the diff contains work that is NOT strictly required by the primary ticket (linter cleanup, `AGENTS.md` edits, unrelated refactors, dependency bumps, README tweaks, formatting fixups). Omit the whole section when the PR is tightly scoped.
+5. Any other section the author added (for example `### Testing`, `### Screenshots`, `### Notes`) — untouched and in its original position.
+
+If `### Problem` or `### Solution` is missing, create the heading and place the markers beneath it. If the markers already exist in an unusual place (for example mid-paragraph), leave them where they are and update only the content between them.
+
+## Hard rules
+
+1. **Never modify author-authored content.** Text that sits outside the agent markers stays exactly as the author wrote it, character-for-character, including whitespace, typos, and formatting quirks.
+2. **Never modify sections that are not Problem, Solution, or Other changes.** `### Testing`, `### Screenshots`, custom sections — all untouched.
+3. **Strip legacy markers.** If the body contains a `<!-- opencode-summary-start -->` ... `<!-- opencode-summary-end -->` block, remove the block and its contents entirely. The content was agent-generated and is superseded by the new per-section markers.
+4. **Do not wrap the response in a code fence.** Return the body as raw markdown. The body may contain code fences internally for diffs or examples — those stay. Do not wrap the whole response.
+
+## What goes inside each marker pair
+
+- `opencode-problem-*` — additional problem context the author did not provide. Specific functions, packages, root causes, missing behavior grounded in the diff. Empty if the author's text is already thorough.
+- `opencode-solution-*` — additional implementation detail. Key design decisions and why. No file-by-file walkthroughs. Empty if already covered.
+- `opencode-other-*` — bullet list of out-of-scope changes. Omit the entire `### Other changes` section when there are none.
+
+## Core content rules
+
+- Ground every agent sentence in the provided diff. If you cannot cite a specific code change, do not write the sentence.
+- Prefer empty markers over padded content. An empty marker block beats filler.
+- No internal discussions, team decisions, or people's names. This is an open-source repo.
+- No file-by-file walkthroughs. The diff speaks for itself.
+- Do not repeat what the author already wrote. Add complementary detail only.
+
+## Tone
+
+Engineer talking to another engineer. Direct, specific, no hand-waving. Match the author's voice where they have set one.
+
+## Banned words and phrases
+
+These mark AI-generated text. Avoid them.
+
+Words: comprehensive, robust, seamless, holistic, leverage, synergy, transformative, groundbreaking, empower, foster, harness, unlock, realm, landscape, ecosystem, embark, journey, pivotal, crucial, meticulous, cornerstone, beacon, unwavering, indelible, myriad, paramount, utilize, facilitate, endeavor, commence, elucidate, actionable, impactful, learnings, spearheaded.
+
+Phrases: "It's worth noting", "Let me dive in", "At the end of the day", "Additionally," as an opener.
+
+Prefer plain verbs: use over utilize, help over facilitate, start over commence, show over demonstrate, try over endeavor.
+
+## Example marker shapes
+
+Author had content, agent added complementary detail:
+
+```
+### Problem
+
+Sharded writes during movePrimary race with clone readers and produce duplicate keys on target.
+
+<!-- opencode-problem-start -->
+The race window is inside `pcsm/clone.applyChunk`, where the session token is cached before the chunk cursor observes the post-movePrimary shard topology.
+<!-- opencode-problem-end -->
+```
+
+Author already covered it, agent has nothing to add:
+
+```
+### Solution
+
+Switch to a fresh session per chunk and re-derive the shard key before each apply.
+
+<!-- opencode-solution-start -->
+<!-- opencode-solution-end -->
+```
+
+## Output
+
+Return ONLY the complete new PR body as markdown. No commentary before or after. No code fences wrapping the whole response.

--- a/.github/workflows/jira-comment-sync.yml
+++ b/.github/workflows/jira-comment-sync.yml
@@ -15,7 +15,10 @@ concurrency:
 
 jobs:
   sync-comment:
-    if: github.event.comment.user.type != 'Bot'
+    # Runs only on issue comments (not PR comments)
+    if: |
+      github.event.comment.user.type != 'Bot' &&
+      github.event.issue.pull_request == null
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -37,7 +40,7 @@ jobs:
         id: filter-commands
         shell: bash
         run: |
-          if [[ "$COMMENT_BODY" == /jira* || "$COMMENT_BODY" == /oc* || "$COMMENT_BODY" == /opencode* ]]; then
+          if [[ "$COMMENT_BODY" == /jira* || "$COMMENT_BODY" == /oc* || "$COMMENT_BODY" == /opencode* || "$COMMENT_BODY" == /review* || "$COMMENT_BODY" == /summary* ]]; then
             echo "SKIP=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -48,7 +51,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          COMMENTS=$(gh api "repos/$REPO_FULL/issues/$ISSUE_NUMBER/comments" --jq '.[].body')
+          COMMENTS=$(gh api --paginate "repos/$REPO_FULL/issues/$ISSUE_NUMBER/comments" --jq '.[].body')
           TICKET_KEY=$(printf '%s\n' "$COMMENTS" | grep -oP '(?<=<!-- jira:)PCSM-\d+' | head -1 || true)
 
           if [[ -z "$TICKET_KEY" ]]; then

--- a/.github/workflows/jira-create.yml
+++ b/.github/workflows/jira-create.yml
@@ -10,7 +10,12 @@ concurrency:
 
 jobs:
   create-jira:
-    if: github.event.comment.body == '/jira' || startsWith(github.event.comment.body, '/jira ')
+    # Runs only on /jira or "/jira ..." comments on issues (not PRs).
+    # PR-side flow uses .github/workflows/opencode-pr-summary.yml + opencode-review.yml;
+    # a separate Jira ticket from a PR comment would create a duplicate tracker.
+    if: |
+      (github.event.comment.body == '/jira' || startsWith(github.event.comment.body, '/jira ')) &&
+      github.event.issue.pull_request == null
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -46,7 +51,7 @@ jobs:
         if: env.SKIP != 'true'
         run: |
           set -euo pipefail
-          COMMENTS=$(gh api "repos/$REPO_FULL/issues/$ISSUE_NUMBER/comments" --jq '.[].body')
+          COMMENTS=$(gh api --paginate "repos/$REPO_FULL/issues/$ISSUE_NUMBER/comments" --jq '.[].body')
           if echo "$COMMENTS" | grep -q "<!-- jira:PCSM-"; then
             TICKET=$(printf '%s\n' "$COMMENTS" | grep -oE '<!-- jira:PCSM-[0-9]+ -->' | head -1 | sed -E 's/<!-- jira:([^ ]+) -->/\1/')
             gh api "repos/$REPO_FULL/issues/$ISSUE_NUMBER/comments" \
@@ -61,6 +66,45 @@ jobs:
           AUTH=$(printf '%s' "$JIRA_USER_EMAIL:$JIRA_API_TOKEN" | base64 | tr -d '\n')
           echo "::add-mask::$AUTH"
           echo "JIRA_AUTH=$AUTH" >> "$GITHUB_ENV"
+
+      - name: Verify Jira access
+        if: env.SKIP != 'true'
+        run: |
+          set -euo pipefail
+          # Preflight diagnostic. Without this, the Create Jira ticket step below
+          # reports a terse HTTP 400 `{"errors":{"project":"valid project is required"}}`
+          # when the service account can't see PCSM, which wastes reviewer time.
+          MYSELF_CODE=$(curl --silent --show-error -o myself.json -w '%{http_code}' \
+            "$JIRA_BASE_URL/rest/api/3/myself" \
+            -H "Authorization: Basic $JIRA_AUTH" \
+            -H "Accept: application/json")
+          if [[ "$MYSELF_CODE" -ge 400 ]]; then
+            echo "::error::Jira authentication failed (HTTP $MYSELF_CODE). Check JIRA_USER_EMAIL and JIRA_API_TOKEN secrets."
+            cat myself.json
+            exit 1
+          fi
+          JIRA_USER=$(jq -r '.emailAddress // .displayName // "unknown"' myself.json)
+          echo "Authenticated to Jira as: $JIRA_USER"
+
+          PROJECT_CODE=$(curl --silent --show-error -o project.json -w '%{http_code}' \
+            "$JIRA_BASE_URL/rest/api/3/project/PCSM" \
+            -H "Authorization: Basic $JIRA_AUTH" \
+            -H "Accept: application/json")
+          if [[ "$PROJECT_CODE" -eq 404 ]]; then
+            echo "::error::Jira account '$JIRA_USER' cannot see project PCSM. Grant Browse Projects and Create Issues permission to this account on the PCSM project in Jira."
+            exit 1
+          fi
+          if [[ "$PROJECT_CODE" -ge 400 ]]; then
+            echo "::error::Jira /project/PCSM returned HTTP $PROJECT_CODE."
+            cat project.json
+            exit 1
+          fi
+          if ! jq -e '.issueTypes[] | select(.name == "Task")' project.json >/dev/null; then
+            echo "::error::PCSM project visible but 'Task' issue type is not in its scheme. Available types:"
+            jq -r '.issueTypes[].name' project.json
+            exit 1
+          fi
+          echo "PCSM project accessible, 'Task' issue type available."
 
       - name: Get issue content
         id: get-issue

--- a/.github/workflows/jira-create.yml
+++ b/.github/workflows/jira-create.yml
@@ -73,25 +73,19 @@ jobs:
           set -euo pipefail
           # Preflight diagnostic. Without this, the Create Jira ticket step below
           # reports a terse HTTP 400 `{"errors":{"project":"valid project is required"}}`
-          # when the service account can't see PCSM, which wastes reviewer time.
-          MYSELF_CODE=$(curl --silent --show-error -o myself.json -w '%{http_code}' \
-            "$JIRA_BASE_URL/rest/api/3/myself" \
-            -H "Authorization: Basic $JIRA_AUTH" \
-            -H "Accept: application/json")
-          if [[ "$MYSELF_CODE" -ge 400 ]]; then
-            echo "::error::Jira authentication failed (HTTP $MYSELF_CODE). Check JIRA_USER_EMAIL and JIRA_API_TOKEN secrets."
-            cat myself.json
-            exit 1
-          fi
-          JIRA_USER=$(jq -r '.emailAddress // .displayName // "unknown"' myself.json)
-          echo "Authenticated to Jira as: $JIRA_USER"
-
+          # for two different underlying causes: token can't see PCSM, or the
+          # configured issue type isn't in PCSM's scheme. This step distinguishes them.
           PROJECT_CODE=$(curl --silent --show-error -o project.json -w '%{http_code}' \
             "$JIRA_BASE_URL/rest/api/3/project/PCSM" \
             -H "Authorization: Basic $JIRA_AUTH" \
             -H "Accept: application/json")
+          if [[ "$PROJECT_CODE" -eq 401 || "$PROJECT_CODE" -eq 403 ]]; then
+            echo "::error::Jira authentication failed (HTTP $PROJECT_CODE). Check JIRA_USER_EMAIL and JIRA_API_TOKEN secrets and their scopes."
+            cat project.json
+            exit 1
+          fi
           if [[ "$PROJECT_CODE" -eq 404 ]]; then
-            echo "::error::Jira account '$JIRA_USER' cannot see project PCSM. Grant Browse Projects and Create Issues permission to this account on the PCSM project in Jira."
+            echo "::error::Jira token cannot see project PCSM. Grant Browse Projects and Create Issues permission to this account on the PCSM project in Jira."
             exit 1
           fi
           if [[ "$PROJECT_CODE" -ge 400 ]]; then
@@ -99,12 +93,12 @@ jobs:
             cat project.json
             exit 1
           fi
-          if ! jq -e '.issueTypes[] | select(.name == "Task")' project.json >/dev/null; then
-            echo "::error::PCSM project visible but 'Task' issue type is not in its scheme. Available types:"
+          if ! jq -e '.issueTypes[] | select(.name == "Admin & Maintenance Task")' project.json >/dev/null; then
+            echo "::error::PCSM project visible but 'Admin & Maintenance Task' issue type is not in its scheme. Available types:"
             jq -r '.issueTypes[].name' project.json
             exit 1
           fi
-          echo "PCSM project accessible, 'Task' issue type available."
+          echo "PCSM project accessible, 'Admin & Maintenance Task' issue type available."
 
       - name: Get issue content
         id: get-issue
@@ -224,7 +218,7 @@ jobs:
                 project: {key: "PCSM"},
                 summary: $summary,
                 description: $description,
-                issuetype: {name: "Task"},
+                issuetype: {name: "Admin & Maintenance Task"},
                 labels: ["github-issue"]
               }
             }')

--- a/.github/workflows/opencode-pr-summary.yml
+++ b/.github/workflows/opencode-pr-summary.yml
@@ -11,8 +11,6 @@ concurrency:
 jobs:
   sync-summary:
     # Runs only on exact '/summary' PR comments from repo members or higher.
-    # Contrast with .github/workflows/opencode.yml which uses startsWith() for /oc
-    # and /opencode prefix commands; this one is intentionally strict.
     if: |
       github.event.issue.pull_request != null &&
       github.event.comment.body == '/summary' &&
@@ -23,86 +21,51 @@ jobs:
       )
     runs-on: ubuntu-latest
     permissions:
+      id-token: write       # opencode action uses OIDC for app-token exchange
       contents: read
       pull-requests: write
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      ANTHROPIC_MODEL: claude-sonnet-4-20250514
-      REPO_OWNER: ${{ github.repository_owner }}
-      REPO_NAME: ${{ github.event.repository.name }}
-      PR_NUM: ${{ github.event.issue.number }}
-      TMP_DIR: ./tmp/opencode-pr-summary
+      issues: read
     steps:
       # Checkout trusted default-branch contents to load the summary prompt.
-      # Using the PR head here would put author-controlled content into a
-      # privileged (pull-requests: write) issue_comment workflow, which CodeQL
-      # flags under actions/untrusted-checkout. Prompt edits land on main first.
       - name: Checkout default branch
         uses: actions/checkout@v6
         with:
           persist-credentials: false
 
-      - name: Fetch PR data
-        run: |
-          set -euo pipefail
-          mkdir -p "$TMP_DIR"
-          gh api "repos/$REPO_OWNER/$REPO_NAME/pulls/$PR_NUM" > "$TMP_DIR/pull-request.json"
-          gh api "repos/$REPO_OWNER/$REPO_NAME/pulls/$PR_NUM/commits" > "$TMP_DIR/commits.json"
-          gh api --paginate "repos/$REPO_OWNER/$REPO_NAME/pulls/$PR_NUM/files" > "$TMP_DIR/files.json"
-
-      - name: Build Anthropic request
+      - name: Load summary prompt
+        id: prompt
         run: |
           set -euo pipefail
           {
+            echo 'content<<PROMPT_EOF'
             cat .github/opencode/summary-prompt.md
-            printf '\n\n## Current PR body\n\n'
-            jq -r '.body // ""' "$TMP_DIR/pull-request.json"
-            printf '\n\n## Commits\n\n'
-            jq -r '.[] | "- " + (.commit.message | split("\n")[0])' "$TMP_DIR/commits.json"
-            printf '\n\n## File patches\n\n'
-            jq -r '.[] | "### " + .filename + " (" + .status + ", +" + (.additions|tostring) + "/-" + (.deletions|tostring) + ")\n\n```diff\n" + (.patch // "[binary or omitted]") + "\n```\n"' "$TMP_DIR/files.json"
-          } > "$TMP_DIR/prompt.txt"
+            echo ''
+            echo '---'
+            echo ''
+            echo '## Operating instructions'
+            echo ''
+            echo 'You are handling the `/summary` command on PR #${{ github.event.issue.number }} in the `${{ github.repository }}` repository.'
+            echo ''
+            echo 'Workflow:'
+            echo '1. Read the current PR body with `gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }}` and parse `.body`.'
+            echo '2. Read the commits with `gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }}/commits`.'
+            echo '3. Read the file patches with `gh api --paginate repos/${{ github.repository }}/pulls/${{ github.event.issue.number }}/files`.'
+            echo '4. Produce the new PR body per the rules at the top of this prompt.'
+            echo '5. Update the PR body with `gh api --method PATCH repos/${{ github.repository }}/pulls/${{ github.event.issue.number }} -f body=@path/to/new-body.md`.'
+            echo ''
+            echo 'Hard constraints:'
+            echo '- The only write operation allowed is the PATCH that updates the PR body.'
+            echo '- Do not post any comment on the PR or its commits.'
+            echo '- Do not push commits or modify any branch (including the PR branch).'
+            echo '- Do not open new PRs, issues, or discussions.'
+            echo '- Do not edit any file in the checked-out workspace. Work in `$RUNNER_TEMP` if you need scratch space.'
+            echo PROMPT_EOF
+          } >> "$GITHUB_OUTPUT"
 
-          jq -n \
-            --arg model "$ANTHROPIC_MODEL" \
-            --rawfile prompt "$TMP_DIR/prompt.txt" \
-            '{model: $model, max_tokens: 4000, messages: [{role: "user", content: $prompt}]}' \
-            > "$TMP_DIR/anthropic-request.json"
-
-      - name: Call Anthropic Messages API
-        run: |
-          set -euo pipefail
-          curl --fail --silent --show-error https://api.anthropic.com/v1/messages \
-            -H "content-type: application/json" \
-            -H "x-api-key: $ANTHROPIC_API_KEY" \
-            -H "anthropic-version: 2023-06-01" \
-            --data @"$TMP_DIR/anthropic-request.json" \
-            > "$TMP_DIR/anthropic-response.json"
-          if jq -e '.error' "$TMP_DIR/anthropic-response.json" >/dev/null 2>&1; then
-            echo "Anthropic API error: $(jq -r '.error.message' "$TMP_DIR/anthropic-response.json")"
-            exit 1
-          fi
-          jq -r '.content[] | select(.type == "text") | .text' "$TMP_DIR/anthropic-response.json" > "$TMP_DIR/summary.md"
-          test -s "$TMP_DIR/summary.md"
-
-      - name: Update PR description
-        run: |
-          set -euo pipefail
-          # Strip an outer code-fence wrapper if the model added one despite the
-          # instruction not to. Inner fences used for diff or code blocks inside
-          # the body survive because we only touch the first and last lines.
-          python3 - <<'PY'
-          import json, os, pathlib, re
-          tmp = pathlib.Path(os.environ["TMP_DIR"])
-          body = (tmp / "summary.md").read_text().strip()
-          m = re.match(r"^```(?:\w+)?\s*\n(.*?)\n```\s*$", body, re.DOTALL)
-          if m:
-              body = m.group(1)
-          (tmp / "pull-request-update.json").write_text(json.dumps({"body": body}))
-          PY
-          gh api --method PATCH "repos/$REPO_OWNER/$REPO_NAME/pulls/$PR_NUM" --input "$TMP_DIR/pull-request-update.json"
-
-      - name: Cleanup tmp directory
-        if: always()
-        run: rm -rf "$TMP_DIR"
+      - name: OpenCode PR summary
+        uses: anomalyco/opencode/github@latest
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        with:
+          model: anthropic/claude-opus-4-7
+          prompt: ${{ steps.prompt.outputs.content }}

--- a/.github/workflows/opencode-pr-summary.yml
+++ b/.github/workflows/opencode-pr-summary.yml
@@ -34,12 +34,13 @@ jobs:
       PR_NUM: ${{ github.event.issue.number }}
       TMP_DIR: ./tmp/opencode-pr-summary
     steps:
-      # issue_comment defaults to base (main); checking out the PR head lets
-      # prompt edits inside a PR take effect on that same PR.
-      - name: Checkout PR head
+      # Checkout trusted default-branch contents to load the summary prompt.
+      # Using the PR head here would put author-controlled content into a
+      # privileged (pull-requests: write) issue_comment workflow, which CodeQL
+      # flags under actions/untrusted-checkout. Prompt edits land on main first.
+      - name: Checkout default branch
         uses: actions/checkout@v6
         with:
-          ref: refs/pull/${{ github.event.issue.number }}/head
           persist-credentials: false
 
       - name: Fetch PR data

--- a/.github/workflows/opencode-pr-summary.yml
+++ b/.github/workflows/opencode-pr-summary.yml
@@ -1,18 +1,26 @@
 name: OpenCode PR Summary
 
 "on":
-  pull_request:
-    types:
-      - opened
-      - synchronize
+  issue_comment:
+    types: [created]
 
 concurrency:
-  group: pr-summary-${{ github.event.pull_request.number }}
+  group: pr-summary-${{ github.event.issue.number }}
   cancel-in-progress: true
 
 jobs:
   sync-summary:
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]' }}
+    # Runs only on exact '/summary' PR comments from repo members or higher.
+    # Contrast with .github/workflows/opencode.yml which uses startsWith() for /oc
+    # and /opencode prefix commands; this one is intentionally strict.
+    if: |
+      github.event.issue.pull_request != null &&
+      github.event.comment.body == '/summary' &&
+      (
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -23,73 +31,47 @@ jobs:
       ANTHROPIC_MODEL: claude-sonnet-4-20250514
       REPO_OWNER: ${{ github.repository_owner }}
       REPO_NAME: ${{ github.event.repository.name }}
-      PR_NUM: ${{ github.event.pull_request.number }}
+      PR_NUM: ${{ github.event.issue.number }}
       TMP_DIR: ./tmp/opencode-pr-summary
     steps:
-      - uses: actions/checkout@v6
+      # issue_comment defaults to base (main); checking out the PR head lets
+      # prompt edits inside a PR take effect on that same PR.
+      - name: Checkout PR head
+        uses: actions/checkout@v6
         with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
           persist-credentials: false
 
-      - name: Get PR commits
+      - name: Fetch PR data
         run: |
           set -euo pipefail
           mkdir -p "$TMP_DIR"
-          gh api "repos/$REPO_OWNER/$REPO_NAME/pulls/$PR_NUM/commits" > "$TMP_DIR/commits.json"
-
-      - name: Get current PR description
-        run: |
-          set -euo pipefail
           gh api "repos/$REPO_OWNER/$REPO_NAME/pulls/$PR_NUM" > "$TMP_DIR/pull-request.json"
+          gh api "repos/$REPO_OWNER/$REPO_NAME/pulls/$PR_NUM/commits" > "$TMP_DIR/commits.json"
+          gh api --paginate "repos/$REPO_OWNER/$REPO_NAME/pulls/$PR_NUM/files" > "$TMP_DIR/files.json"
 
-      - name: Generate PR summary
+      - name: Build Anthropic request
         run: |
           set -euo pipefail
-          python3 <<'PY'
-          import json
-          import os
-          import pathlib
-          import re
+          {
+            cat .github/opencode/summary-prompt.md
+            printf '\n\n## Current PR body\n\n'
+            jq -r '.body // ""' "$TMP_DIR/pull-request.json"
+            printf '\n\n## Commits\n\n'
+            jq -r '.[] | "- " + (.commit.message | split("\n")[0])' "$TMP_DIR/commits.json"
+            printf '\n\n## File patches\n\n'
+            jq -r '.[] | "### " + .filename + " (" + .status + ", +" + (.additions|tostring) + "/-" + (.deletions|tostring) + ")\n\n```diff\n" + (.patch // "[binary or omitted]") + "\n```\n"' "$TMP_DIR/files.json"
+          } > "$TMP_DIR/prompt.txt"
 
-          tmp_dir = pathlib.Path(os.environ["TMP_DIR"])
-          commits = json.loads((tmp_dir / "commits.json").read_text())
-          pr = json.loads((tmp_dir / "pull-request.json").read_text())
+          jq -n \
+            --arg model "$ANTHROPIC_MODEL" \
+            --rawfile prompt "$TMP_DIR/prompt.txt" \
+            '{model: $model, max_tokens: 4000, messages: [{role: "user", content: $prompt}]}' \
+            > "$TMP_DIR/anthropic-request.json"
 
-          start_marker = "<!-- opencode-summary-start -->"
-          end_marker = "<!-- opencode-summary-end -->"
-          body = pr.get("body") or ""
-          outside = re.sub(
-              re.escape(start_marker) + r".*?" + re.escape(end_marker),
-              "",
-              body,
-              flags=re.S,
-          ).strip()
-
-          commit_messages = []
-          for commit in commits:
-              message = (commit.get("commit") or {}).get("message", "").strip()
-              if message:
-                  commit_messages.append(f"- {message}")
-
-          prompt = "\n".join(
-              [
-                  "Generate a concise PR summary from these commit messages. Use Problem/Solution format if commits suggest a bug fix. Otherwise use a descriptive format. Keep it professional and terse. If the PR already has content outside the markers, match its tone.",
-                  "Return markdown only. No code fences. No commentary outside summary.",
-                  "",
-                  "Existing PR description outside summary markers:",
-                  outside or "(empty)",
-                  "",
-                  "Commit messages:",
-                  "\n".join(commit_messages) or "- No commit messages available",
-              ]
-          )
-
-          payload = {
-              "model": os.environ["ANTHROPIC_MODEL"],
-              "max_tokens": 400,
-              "messages": [{"role": "user", "content": prompt}],
-          }
-          (tmp_dir / "anthropic-request.json").write_text(json.dumps(payload))
-          PY
+      - name: Call Anthropic Messages API
+        run: |
+          set -euo pipefail
           curl --fail --silent --show-error https://api.anthropic.com/v1/messages \
             -H "content-type: application/json" \
             -H "x-api-key: $ANTHROPIC_API_KEY" \
@@ -106,32 +88,17 @@ jobs:
       - name: Update PR description
         run: |
           set -euo pipefail
-          python3 <<'PY'
-          import json
-          import os
-          import pathlib
-
-          tmp_dir = pathlib.Path(os.environ["TMP_DIR"])
-          pr = json.loads((tmp_dir / "pull-request.json").read_text())
-          summary = (tmp_dir / "summary.md").read_text().strip()
-          body = pr.get("body") or ""
-
-          start_marker = "<!-- opencode-summary-start -->"
-          end_marker = "<!-- opencode-summary-end -->"
-          block = f"{start_marker}\n{summary}\n{end_marker}"
-
-          if not body.strip():
-              updated = block
-          else:
-              start = body.find(start_marker)
-              end = body.find(end_marker)
-              if start != -1 and end != -1 and start < end:
-                  end += len(end_marker)
-                  updated = body[:start] + block + body[end:]
-              else:
-                  updated = f"{block}\n\n{body}"
-
-          (tmp_dir / "pull-request-update.json").write_text(json.dumps({"body": updated}))
+          # Strip an outer code-fence wrapper if the model added one despite the
+          # instruction not to. Inner fences used for diff or code blocks inside
+          # the body survive because we only touch the first and last lines.
+          python3 - <<'PY'
+          import json, os, pathlib, re
+          tmp = pathlib.Path(os.environ["TMP_DIR"])
+          body = (tmp / "summary.md").read_text().strip()
+          m = re.match(r"^```(?:\w+)?\s*\n(.*?)\n```\s*$", body, re.DOTALL)
+          if m:
+              body = m.group(1)
+          (tmp / "pull-request-update.json").write_text(json.dumps({"body": body}))
           PY
           gh api --method PATCH "repos/$REPO_OWNER/$REPO_NAME/pulls/$PR_NUM" --input "$TMP_DIR/pull-request-update.json"
 

--- a/.github/workflows/opencode-pr-summary.yml
+++ b/.github/workflows/opencode-pr-summary.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   sync-summary:
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -28,12 +28,13 @@ jobs:
       pull-requests: read
       issues: read
     steps:
-      # Check out the PR head so prompt edits made inside the PR take effect
-      # on that same PR when `/review` is run.
-      - name: Checkout PR head
+      # Checkout trusted default-branch contents to load the review prompt.
+      # Using the PR head here would put author-controlled content into a
+      # privileged (write-capable) issue_comment workflow, which CodeQL flags
+      # under actions/untrusted-checkout. Prompt edits land on main first.
+      - name: Checkout default branch
         uses: actions/checkout@v6
         with:
-          ref: refs/pull/${{ github.event.issue.number }}/head
           persist-credentials: false
 
       - name: Load review prompt

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   review:
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !github.event.pull_request.draft }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !github.event.pull_request.draft && github.event.pull_request.user.login != 'dependabot[bot]' }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -11,8 +11,6 @@ concurrency:
 jobs:
   review:
     # Trigger only on exact `/review` comments from privileged PR actors.
-    # Exact-match is intentional: avoids accidental fires from comments that
-    # happen to start with `/review`.
     if: |
       github.event.issue.pull_request != null &&
       github.event.comment.body == '/review' &&
@@ -29,9 +27,6 @@ jobs:
       issues: read
     steps:
       # Checkout trusted default-branch contents to load the review prompt.
-      # Using the PR head here would put author-controlled content into a
-      # privileged (write-capable) issue_comment workflow, which CodeQL flags
-      # under actions/untrusted-checkout. Prompt edits land on main first.
       - name: Checkout default branch
         uses: actions/checkout@v6
         with:
@@ -52,5 +47,5 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
-          model: anthropic/claude-opus-4-6
+          model: anthropic/claude-opus-4-7
           prompt: ${{ steps.prompt.outputs.content }}

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -1,26 +1,50 @@
 name: OpenCode Review
 
 "on":
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+  issue_comment:
+    types: [created]
 
 concurrency:
-  group: opencode-review-${{ github.event.pull_request.number }}
+  group: opencode-review-${{ github.event.issue.number }}
   cancel-in-progress: true
 
 jobs:
   review:
+    # Trigger only on exact `/review` comments from privileged PR actors.
+    # Exact-match is intentional: avoids accidental fires from comments that
+    # happen to start with `/review`.
+    if: |
+      github.event.issue.pull_request != null &&
+      github.event.comment.body == '/review' &&
+      (
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      )
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !github.event.pull_request.draft && github.event.pull_request.user.login != 'dependabot[bot]' }}
     permissions:
       id-token: write
       contents: read
       pull-requests: read
       issues: read
     steps:
-      - uses: actions/checkout@v6
+      # Check out the PR head so prompt edits made inside the PR take effect
+      # on that same PR when `/review` is run.
+      - name: Checkout PR head
+        uses: actions/checkout@v6
         with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
           persist-credentials: false
+
+      - name: Load review prompt
+        id: prompt
+        run: |
+          set -euo pipefail
+          {
+            echo 'content<<PROMPT_EOF'
+            cat .github/opencode/review-prompt.md
+            echo PROMPT_EOF
+          } >> "$GITHUB_OUTPUT"
 
       - name: OpenCode Go review
         uses: anomalyco/opencode/github@latest
@@ -28,25 +52,4 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
           model: anthropic/claude-opus-4-6
-          prompt: |
-            Review only new code ('+' lines in diff). Pre-existing issues are out of scope.
-            Read AGENTS.md for project-specific patterns: errors.Wrap/Wrapf, util.CtxWithTimeout, log.New("scope"), testify assertions, race flag.
-
-            Categories to evaluate:
-            1. CORRECTNESS & ERROR HANDLING: error wrapping (use errors.Wrap not fmt.Errorf), nil safety, resource leaks (defer close), type assertion guards, panic recovery
-            2. CONCURRENCY: goroutine lifecycle (leaks), race conditions, channel correctness, sync primitives (Mutex vs RWMutex), context cancellation propagation
-            3. PERFORMANCE: unnecessary allocations (slice capacity hints, string builder vs +), interface boxing overhead, struct layout (field alignment), map pre-sizing
-            4. IDIOMATIC GO: naming (receiver names, unexported fields, acronyms), control flow (early return, no else after return), declaration style (short var where possible), function design (small/focused)
-            5. COMMENT QUALITY: exported API docs (godoc format), why-comments (not what), flag: misleading/stale/obvious comments
-            6. ALTERNATIVE PATTERNS: table-driven tests, functional options, errgroup for parallel work, sync.Once for init
-
-            References: Go Wiki CodeReviewComments, Uber Go Style Guide, Effective Go
-
-            Output format:
-            ## Verdict: APPROVE | APPROVE WITH SUGGESTIONS | NEEDS WORK
-            ### Critical Issues (blocking)
-            ### Performance
-            ### Concurrency
-            ### Idiomatic
-            ### Comment Quality
-            ### Suggested Alternatives
+          prompt: ${{ steps.prompt.outputs.content }}


### PR DESCRIPTION
### Problem

The opencode review and PR summary workflows ran on every PR push event. Every sync triggered a fresh review, wasting tokens. The PR summary got overwritten on every sync, clobbering author-added content. The review prompt was embedded in the workflow file so iterating on it required workflow edits. The summary workflow owned a single block of the PR body with no structured way for author-written Problem/Solution content to coexist with agent edits.

<!-- opencode-problem-start -->
<!-- opencode-problem-end -->

### Solution

Both workflows now trigger on `issue_comment` events with strict exact-match gates:

- `/review` runs the Go review workflow
- `/summary` runs the PR summary workflow

The gates also check `author_association in (OWNER|MEMBER|COLLABORATOR)`, so comments from non-maintainers never fire the workflows. The original dependabot guard from commit `5aca553` is removed since bots can't satisfy the new comment gate.

Prompts live in dedicated files:

- `.github/opencode/review-prompt.md` ports the `/go-review` command with PCSM-specific Go conventions
- `.github/opencode/summary-prompt.md` instructs the LLM to edit the PR body directly, managing three marker pairs:
  - `<!-- opencode-problem-start/end -->` inside `### Problem`
  - `<!-- opencode-solution-start/end -->` inside `### Solution`
  - `<!-- opencode-other-start/end -->` inside optional `### Other changes`

Both workflows check out the PR head (not the base branch) so prompt edits inside a PR take effect when the commands run on that same PR.

<!-- opencode-solution-start -->
<!-- opencode-solution-end -->

### Testing

- Once this PR merges, comment `/review` on a follow-up PR to confirm the Go review workflow triggers only on that exact comment body from a maintainer.
- Comment `/summary` on a PR to confirm the workflow rewrites the body with marker-bounded Problem/Solution blocks.
- Verify that non-maintainer comments saying `/review` or `/summary` leave the Actions tab quiet (no runs queued).
