### PR TITLE
PCSM-308: Webhook support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -33,10 +33,22 @@ type Config struct {
 	Repl  ReplConfig  `mapstructure:",squash"`
 	Clone CloneConfig `mapstructure:",squash"`
 
+	Webhook WebhookConfig `mapstructure:",squash"`
+
 	// hidden startup flags
 	Start              bool `mapstructure:"start"`
 	ResetState         bool `mapstructure:"reset-state"`
 	PauseOnInitialSync bool `mapstructure:"pause-on-initial-sync"`
+}
+
+// WebhookConfig holds webhook notification configuration.
+type WebhookConfig struct {
+	// URL is the webhook callback URL.
+	URL string `mapstructure:"webhook-url"`
+	// AuthToken is the Bearer token sent with webhook requests.
+	AuthToken string `mapstructure:"webhook-auth-token"`
+	// Events is a comma-separated list of events to send notifications for.
+	Events []string `mapstructure:"webhook-events"`
 }
 
 // LogConfig holds logging configuration.
@@ -188,6 +200,10 @@ func bindEnvVars() {
 	_ = viper.BindEnv("clone-num-insert-workers", "PCSM_CLONE_NUM_INSERT_WORKERS")
 	_ = viper.BindEnv("clone-segment-size", "PCSM_CLONE_SEGMENT_SIZE")
 	_ = viper.BindEnv("clone-read-batch-size", "PCSM_CLONE_READ_BATCH_SIZE")
+
+	_ = viper.BindEnv("webhook-url", "PCSM_WEBHOOK_URL")
+	_ = viper.BindEnv("webhook-auth-token", "PCSM_WEBHOOK_AUTH_TOKEN")
+	_ = viper.BindEnv("webhook-events", "PCSM_WEBHOOK_EVENTS")
 }
 
 //nolint:gochecknoglobals

--- a/config/config.go
+++ b/config/config.go
@@ -49,6 +49,8 @@ type WebhookConfig struct {
 	AuthToken string `mapstructure:"webhook-auth-token"`
 	// Events is a comma-separated list of events to send notifications for.
 	Events []string `mapstructure:"webhook-events"`
+	// Target is the webhook target format (e.g. "slack").
+	Target string `mapstructure:"webhook-target"`
 }
 
 // LogConfig holds logging configuration.
@@ -204,6 +206,7 @@ func bindEnvVars() {
 	_ = viper.BindEnv("webhook-url", "PCSM_WEBHOOK_URL")
 	_ = viper.BindEnv("webhook-auth-token", "PCSM_WEBHOOK_AUTH_TOKEN")
 	_ = viper.BindEnv("webhook-events", "PCSM_WEBHOOK_EVENTS")
+	_ = viper.BindEnv("webhook-target", "PCSM_WEBHOOK_TARGET")
 }
 
 //nolint:gochecknoglobals

--- a/config/validate.go
+++ b/config/validate.go
@@ -31,6 +31,35 @@ func Validate(cfg *Config) error {
 		return errors.New("source URI and target URI are identical")
 	}
 
+	err := validateWebhook(&cfg.Webhook)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validWebhookEvents is the set of accepted --webhook-events values.
+var validWebhookEvents = map[string]bool{ //nolint:gochecknoglobals
+	"all":     true,
+	"failure": true,
+}
+
+func validateWebhook(cfg *WebhookConfig) error {
+	if cfg.URL == "" && cfg.AuthToken == "" && len(cfg.Events) == 0 {
+		return nil
+	}
+
+	if cfg.URL == "" {
+		return errors.New("--webhook-url is required when --webhook-auth-token or --webhook-events is set")
+	}
+
+	for _, e := range cfg.Events {
+		if !validWebhookEvents[e] {
+			return errors.Errorf("invalid --webhook-events value %q: must be \"all\" or \"failure\"", e)
+		}
+	}
+
 	return nil
 }
 

--- a/config/validate.go
+++ b/config/validate.go
@@ -45,19 +45,28 @@ var validWebhookEvents = map[string]bool{ //nolint:gochecknoglobals
 	"failure": true,
 }
 
+// validWebhookTargets is the set of accepted --webhook-target values.
+var validWebhookTargets = map[string]bool{ //nolint:gochecknoglobals
+	"slack": true,
+}
+
 func validateWebhook(cfg *WebhookConfig) error {
-	if cfg.URL == "" && cfg.AuthToken == "" && len(cfg.Events) == 0 {
+	if cfg.URL == "" && cfg.AuthToken == "" && len(cfg.Events) == 0 && cfg.Target == "" {
 		return nil
 	}
 
 	if cfg.URL == "" {
-		return errors.New("--webhook-url is required when --webhook-auth-token or --webhook-events is set")
+		return errors.New("--webhook-url is required when other webhook options are set")
 	}
 
 	for _, e := range cfg.Events {
 		if !validWebhookEvents[e] {
 			return errors.Errorf("invalid --webhook-events value %q: must be \"all\" or \"failure\"", e)
 		}
+	}
+
+	if cfg.Target != "" && !validWebhookTargets[cfg.Target] {
+		return errors.Errorf("invalid --webhook-target value %q: must be \"slack\"", cfg.Target)
 	}
 
 	return nil

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -249,6 +249,29 @@ func TestValidate_Webhook(t *testing.T) {
 			}),
 			wantErr: "invalid --webhook-events value \"garbage\"",
 		},
+		{
+			name: "webhook target slack - valid",
+			cfg: validCfg(config.WebhookConfig{
+				URL:    "https://hooks.slack.com/services/xxx",
+				Target: "slack",
+			}),
+			wantErr: "",
+		},
+		{
+			name: "webhook target invalid",
+			cfg: validCfg(config.WebhookConfig{
+				URL:    "https://example.com/hook",
+				Target: "unknown",
+			}),
+			wantErr: "invalid --webhook-target value \"unknown\"",
+		},
+		{
+			name: "webhook target without url",
+			cfg: validCfg(config.WebhookConfig{
+				Target: "slack",
+			}),
+			wantErr: "--webhook-url is required",
+		},
 	}
 
 	for _, tt := range tests {

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -174,6 +174,99 @@ func TestValidate_PortBoundaries(t *testing.T) {
 	}
 }
 
+func TestValidate_Webhook(t *testing.T) {
+	t.Parallel()
+
+	validCfg := func(w config.WebhookConfig) *config.Config {
+		return &config.Config{
+			Port:    8080,
+			Source:  "mongodb://source:27017",
+			Target:  "mongodb://target:27017",
+			Webhook: w,
+		}
+	}
+
+	tests := []struct {
+		name    string
+		cfg     *config.Config
+		wantErr string
+	}{
+		{
+			name:    "no webhook options - valid",
+			cfg:     validCfg(config.WebhookConfig{}),
+			wantErr: "",
+		},
+		{
+			name: "url only - valid",
+			cfg: validCfg(config.WebhookConfig{
+				URL: "https://example.com/hook",
+			}),
+			wantErr: "",
+		},
+		{
+			name: "url with all events - valid",
+			cfg: validCfg(config.WebhookConfig{
+				URL:    "https://example.com/hook",
+				Events: []string{"all"},
+			}),
+			wantErr: "",
+		},
+		{
+			name: "url with failure events - valid",
+			cfg: validCfg(config.WebhookConfig{
+				URL:    "https://example.com/hook",
+				Events: []string{"failure"},
+			}),
+			wantErr: "",
+		},
+		{
+			name: "url with auth token - valid",
+			cfg: validCfg(config.WebhookConfig{
+				URL:       "https://example.com/hook",
+				AuthToken: "secret",
+			}),
+			wantErr: "",
+		},
+		{
+			name: "auth token without url",
+			cfg: validCfg(config.WebhookConfig{
+				AuthToken: "secret",
+			}),
+			wantErr: "--webhook-url is required",
+		},
+		{
+			name: "events without url",
+			cfg: validCfg(config.WebhookConfig{
+				Events: []string{"failure"},
+			}),
+			wantErr: "--webhook-url is required",
+		},
+		{
+			name: "invalid events value",
+			cfg: validCfg(config.WebhookConfig{
+				URL:    "https://example.com/hook",
+				Events: []string{"garbage"},
+			}),
+			wantErr: "invalid --webhook-events value \"garbage\"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := config.Validate(tt.cfg)
+
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestValidateCloneSegmentSize(t *testing.T) {
 	t.Parallel()
 

--- a/main.go
+++ b/main.go
@@ -158,6 +158,8 @@ func newRootCmd() *cobra.Command {
 	rootCmd.Flags().String("webhook-auth-token", "", "Bearer token sent with webhook requests")
 	rootCmd.Flags().StringSlice("webhook-events", nil,
 		"Webhook event filter: \"all\" for all events, \"failure\" for failure events only (default: all)")
+	rootCmd.Flags().String("webhook-target", "",
+		"Webhook payload format: \"slack\" for Slack incoming webhooks (default: generic JSON)")
 
 	rootCmd.AddCommand(
 		newVersionCmd(),
@@ -651,6 +653,7 @@ func createServer(ctx context.Context, cfg *config.Config) (*server, error) {
 		URL:       cfg.Webhook.URL,
 		AuthToken: cfg.Webhook.AuthToken,
 		Events:    webhookEvents,
+		Target:    webhook.Target(cfg.Webhook.Target),
 	}))
 
 	err = Restore(ctx, target, pcs)

--- a/main.go
+++ b/main.go
@@ -157,9 +157,7 @@ func newRootCmd() *cobra.Command {
 	rootCmd.Flags().String("webhook-url", "", "Webhook callback URL for lifecycle event notifications")
 	rootCmd.Flags().String("webhook-auth-token", "", "Bearer token sent with webhook requests")
 	rootCmd.Flags().StringSlice("webhook-events", nil,
-		"Webhook events to send (comma-separated: clone:completed,clone:failed,"+
-			"initial-sync:completed,finalization:started,finalization:finished,"+
-			"replication:started,replication:failed,replication:paused; default: all)")
+		"Webhook event filter: \"all\" for all events, \"failure\" for failure events only (default: all)")
 
 	rootCmd.AddCommand(
 		newVersionCmd(),
@@ -641,9 +639,10 @@ func createServer(ctx context.Context, cfg *config.Config) (*server, error) {
 
 	pcs := pcsm.New(ctx, source, target)
 
-	webhookEvents := make([]webhook.Event, 0, len(cfg.Webhook.Events))
-	for _, e := range cfg.Webhook.Events {
-		webhookEvents = append(webhookEvents, webhook.Event(e))
+	var webhookEvents []webhook.Event
+
+	if len(cfg.Webhook.Events) == 1 && cfg.Webhook.Events[0] == "failure" {
+		webhookEvents = webhook.FailureEvents()
 	}
 
 	pcs.SetWebhook(webhook.New(webhook.Config{

--- a/main.go
+++ b/main.go
@@ -643,6 +643,8 @@ func createServer(ctx context.Context, cfg *config.Config) (*server, error) {
 
 	if len(cfg.Webhook.Events) == 1 && cfg.Webhook.Events[0] == "failure" {
 		webhookEvents = webhook.FailureEvents()
+	} else {
+		webhookEvents = webhook.AllEvents()
 	}
 
 	pcs.SetWebhook(webhook.New(webhook.Config{

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/percona/percona-clustersync-mongodb/pcsm"
 	"github.com/percona/percona-clustersync-mongodb/pcsm/clone"
 	"github.com/percona/percona-clustersync-mongodb/pcsm/repl"
+	"github.com/percona/percona-clustersync-mongodb/pcsm/webhook"
 	"github.com/percona/percona-clustersync-mongodb/util"
 )
 
@@ -151,6 +152,14 @@ func newRootCmd() *cobra.Command {
 
 	rootCmd.Flags().Bool("pause-on-initial-sync", false, "")
 	rootCmd.Flags().MarkHidden("pause-on-initial-sync") //nolint:errcheck
+
+	// Webhook flags
+	rootCmd.Flags().String("webhook-url", "", "Webhook callback URL for lifecycle event notifications")
+	rootCmd.Flags().String("webhook-auth-token", "", "Bearer token sent with webhook requests")
+	rootCmd.Flags().StringSlice("webhook-events", nil,
+		"Webhook events to send (comma-separated: clone:completed,clone:failed,"+
+			"initial-sync:completed,finalization:started,finalization:finished,"+
+			"replication:started,replication:failed,replication:paused; default: all)")
 
 	rootCmd.AddCommand(
 		newVersionCmd(),
@@ -631,6 +640,17 @@ func createServer(ctx context.Context, cfg *config.Config) (*server, error) {
 	metrics.Init(promRegistry)
 
 	pcs := pcsm.New(ctx, source, target)
+
+	webhookEvents := make([]webhook.Event, 0, len(cfg.Webhook.Events))
+	for _, e := range cfg.Webhook.Events {
+		webhookEvents = append(webhookEvents, webhook.Event(e))
+	}
+
+	pcs.SetWebhook(webhook.New(webhook.Config{
+		URL:       cfg.Webhook.URL,
+		AuthToken: cfg.Webhook.AuthToken,
+		Events:    webhookEvents,
+	}))
 
 	err = Restore(ctx, target, pcs)
 	if err != nil {

--- a/pcsm/pcsm.go
+++ b/pcsm/pcsm.go
@@ -30,6 +30,7 @@ import (
 	"github.com/percona/percona-clustersync-mongodb/pcsm/catalog"
 	"github.com/percona/percona-clustersync-mongodb/pcsm/clone"
 	"github.com/percona/percona-clustersync-mongodb/pcsm/repl"
+	"github.com/percona/percona-clustersync-mongodb/pcsm/webhook"
 	"github.com/percona/percona-clustersync-mongodb/sel"
 )
 
@@ -107,6 +108,7 @@ type PCSM struct {
 	nsFilter  sel.NSFilter // Namespace filter
 
 	onStateChanged OnStateChangedFunc // onStateChanged is invoked on each state change
+	webhook        *webhook.Notifier  // webhook notifier for lifecycle events
 
 	pauseOnInitialSync bool
 
@@ -250,6 +252,11 @@ func (p *PCSM) SetOnStateChanged(f OnStateChangedFunc) {
 	p.lock.Unlock()
 }
 
+// SetWebhook sets the webhook notifier for lifecycle event notifications.
+func (p *PCSM) SetWebhook(n *webhook.Notifier) {
+	p.webhook = n
+}
+
 // Status returns the current status of the PCSM.
 func (p *PCSM) Status(ctx context.Context) *Status {
 	p.lock.Lock()
@@ -357,6 +364,8 @@ func (p *PCSM) Start(ctx context.Context, options *StartOptions) error {
 	p.repl = repl.NewRepl(p.source, p.target, p.catalog, p.nsFilter, &options.Repl)
 	p.state = StateRunning
 
+	p.webhook.Send(webhook.EventPCSMStarted, "PCSM started")
+
 	go p.run(p.lifecycleCtx)
 
 	return nil
@@ -395,10 +404,13 @@ func (p *PCSM) run(ctx context.Context) {
 
 		cloneStatus = p.clone.Status()
 		if cloneStatus.Err != nil {
+			p.webhook.Send(webhook.EventCloneFailed, cloneStatus.Err.Error())
 			p.setFailed(errors.Wrap(cloneStatus.Err, "clone"))
 
 			return
 		}
+
+		p.webhook.Send(webhook.EventCloneCompleted, "Data clone completed")
 	}
 
 	replStatus := p.repl.Status()
@@ -427,6 +439,7 @@ func (p *PCSM) run(ctx context.Context) {
 
 	replStatus = p.repl.Status()
 	if replStatus.Err != nil {
+		p.webhook.Send(webhook.EventReplicationFailed, replStatus.Err.Error())
 		p.setFailed(errors.Wrap(replStatus.Err, "change replication"))
 	}
 }
@@ -469,6 +482,8 @@ func (p *PCSM) monitorInitialSync(ctx context.Context) {
 			elapsed = time.Since(cloneStatus.StartTime)
 			lg.With(log.Elapsed(elapsed)).
 				Infof("Initial Sync completed in %s", elapsed.Round(time.Second))
+
+			p.webhook.Send(webhook.EventInitialSyncCompleted, "Initial sync completed")
 
 			p.lock.Lock()
 			pauseOnInitialSync := p.pauseOnInitialSync
@@ -575,6 +590,9 @@ func (p *PCSM) doPause(ctx context.Context) error {
 	}
 
 	p.state = StatePaused
+
+	p.webhook.Send(webhook.EventReplicationPaused, "Replication paused")
+
 	go p.onStateChanged(StatePaused)
 
 	return nil
@@ -688,10 +706,14 @@ func (p *PCSM) Finalize(ctx context.Context) error {
 		lg.With(log.Elapsed(time.Since(startedTime))).
 			Info("Finalization is completed")
 
+		p.webhook.Send(webhook.EventFinalizationFinished, "Finalization completed")
+
 		go p.onStateChanged(StateFinalized)
 	}()
 
 	lg.Info("Finalizing")
+
+	p.webhook.Send(webhook.EventFinalizationStarted, "Finalization started")
 
 	go p.onStateChanged(StateFinalizing)
 

--- a/pcsm/pcsm.go
+++ b/pcsm/pcsm.go
@@ -620,6 +620,8 @@ func (p *PCSM) Resume(ctx context.Context, options ResumeOptions) error {
 
 	log.New("pcsm").Info("Cluster Replication resumed")
 
+	p.webhook.Send(webhook.EventReplicationResumed, "Replication resumed")
+
 	return nil
 }
 

--- a/pcsm/webhook/webhook.go
+++ b/pcsm/webhook/webhook.go
@@ -32,6 +32,8 @@ const (
 	EventReplicationFailed Event = "replication:failed"
 	// EventReplicationPaused is emitted when replication is paused.
 	EventReplicationPaused Event = "replication:paused"
+	// EventReplicationResumed is emitted when replication is resumed.
+	EventReplicationResumed Event = "replication:resumed"
 )
 
 // AllEvents returns all available webhook events.

--- a/pcsm/webhook/webhook.go
+++ b/pcsm/webhook/webhook.go
@@ -159,7 +159,9 @@ func (n *Notifier) send(event Event, message string) {
 
 func (n *Notifier) marshalPayload(event Event, message string) ([]byte, error) {
 	if n.cfg.Target == TargetSlack {
-		text := "[" + string(event) + "] " + message
+		text := "*PCSM*\n*Event:* `" + string(event) +
+			"`\n*Message:* " + message +
+			"\n*Time:* " + time.Now().UTC().Format(time.RFC3339)
 
 		return json.Marshal(slackPayload{Text: text}) //nolint:wrapcheck
 	}

--- a/pcsm/webhook/webhook.go
+++ b/pcsm/webhook/webhook.go
@@ -36,6 +36,14 @@ const (
 	EventReplicationResumed Event = "replication:resumed"
 )
 
+// Target represents a webhook target format (e.g. "slack").
+type Target string
+
+const (
+	// TargetSlack indicates the payload should be formatted for Slack incoming webhooks.
+	TargetSlack Target = "slack"
+)
+
 // AllEvents returns all available webhook events.
 func AllEvents() []Event {
 	return []Event{
@@ -70,6 +78,12 @@ type Config struct {
 	URL       string
 	AuthToken string
 	Events    []Event
+	Target    Target // "slack" for Slack incoming webhooks, empty for generic JSON
+}
+
+// slackPayload is the JSON body sent to Slack incoming webhooks.
+type slackPayload struct {
+	Text string `json:"text"`
 }
 
 // Notifier sends HTTP POST requests to a configured webhook URL.
@@ -106,13 +120,7 @@ func (n *Notifier) Send(event Event, message string) {
 func (n *Notifier) send(event Event, message string) {
 	lg := log.New("webhook")
 
-	payload := Payload{
-		Event:     event,
-		Timestamp: time.Now().UTC().Format(time.RFC3339),
-		Message:   message,
-	}
-
-	body, err := json.Marshal(payload)
+	body, err := n.marshalPayload(event, message)
 	if err != nil {
 		lg.Error(err, "Marshal webhook payload")
 
@@ -128,7 +136,7 @@ func (n *Notifier) send(event Event, message string) {
 
 	req.Header.Set("Content-Type", "application/json")
 
-	if n.cfg.AuthToken != "" {
+	if n.cfg.AuthToken != "" && n.cfg.Target == "" {
 		req.Header.Set("Authorization", "Bearer "+n.cfg.AuthToken)
 	}
 
@@ -147,4 +155,18 @@ func (n *Notifier) send(event Event, message string) {
 	}
 
 	lg.Debugf("Webhook sent for event %q (status %d)", event, resp.StatusCode)
+}
+
+func (n *Notifier) marshalPayload(event Event, message string) ([]byte, error) {
+	if n.cfg.Target == TargetSlack {
+		text := "[" + string(event) + "] " + message
+
+		return json.Marshal(slackPayload{Text: text}) //nolint:wrapcheck
+	}
+
+	return json.Marshal(Payload{ //nolint:wrapcheck
+		Event:     event,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Message:   message,
+	})
 }

--- a/pcsm/webhook/webhook.go
+++ b/pcsm/webhook/webhook.go
@@ -48,6 +48,14 @@ func AllEvents() []Event {
 	}
 }
 
+// FailureEvents returns only failure-related webhook events.
+func FailureEvents() []Event {
+	return []Event{
+		EventCloneFailed,
+		EventReplicationFailed,
+	}
+}
+
 // Payload is the JSON body sent to the webhook URL.
 type Payload struct {
 	Event     Event  `json:"event"`

--- a/pcsm/webhook/webhook.go
+++ b/pcsm/webhook/webhook.go
@@ -1,0 +1,140 @@
+// Package webhook provides a simple HTTP webhook notifier for PCSM lifecycle events.
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"slices"
+	"time"
+
+	"github.com/percona/percona-clustersync-mongodb/log"
+)
+
+// Event represents a webhook event type.
+type Event string
+
+const (
+	// EventCloneCompleted is emitted when the data clone phase completes successfully.
+	EventCloneCompleted Event = "initial-sync:clone-completed"
+	// EventCloneFailed is emitted when the data clone phase fails.
+	EventCloneFailed Event = "initial-sync:clone-failed"
+	// EventInitialSyncCompleted is emitted when the initial sync (clone + change stream catch-up) completes.
+	EventInitialSyncCompleted Event = "initial-sync:completed"
+	// EventFinalizationStarted is emitted when finalization begins.
+	EventFinalizationStarted Event = "finalization:started"
+	// EventFinalizationFinished is emitted when finalization completes successfully.
+	EventFinalizationFinished Event = "finalization:finished"
+	// EventPCSMStarted is emitted when replication starts (pcsm start).
+	EventPCSMStarted Event = "pcsm:started"
+	// EventReplicationFailed is emitted when change replication fails.
+	EventReplicationFailed Event = "replication:failed"
+	// EventReplicationPaused is emitted when replication is paused.
+	EventReplicationPaused Event = "replication:paused"
+)
+
+// AllEvents returns all available webhook events.
+func AllEvents() []Event {
+	return []Event{
+		EventCloneCompleted,
+		EventCloneFailed,
+		EventInitialSyncCompleted,
+		EventFinalizationStarted,
+		EventFinalizationFinished,
+		EventPCSMStarted,
+		EventReplicationFailed,
+		EventReplicationPaused,
+	}
+}
+
+// Payload is the JSON body sent to the webhook URL.
+type Payload struct {
+	Event     Event  `json:"event"`
+	Timestamp string `json:"timestamp"`
+	Message   string `json:"message,omitempty"`
+}
+
+// Config holds the webhook configuration.
+type Config struct {
+	URL       string
+	AuthToken string
+	Events    []Event
+}
+
+// Notifier sends HTTP POST requests to a configured webhook URL.
+type Notifier struct {
+	cfg    Config
+	client *http.Client
+}
+
+// New creates a new Notifier. If cfg.URL is empty, Send is a no-op.
+func New(cfg Config) *Notifier {
+	return &Notifier{
+		cfg: cfg,
+		client: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+// Send sends a webhook notification for the given event.
+// It runs the HTTP request in a separate goroutine so it never blocks the caller.
+// It is safe to call on a nil Notifier.
+func (n *Notifier) Send(event Event, message string) {
+	if n == nil || n.cfg.URL == "" {
+		return
+	}
+
+	if len(n.cfg.Events) > 0 && !slices.Contains(n.cfg.Events, event) {
+		return
+	}
+
+	go n.send(event, message)
+}
+
+func (n *Notifier) send(event Event, message string) {
+	lg := log.New("webhook")
+
+	payload := Payload{
+		Event:     event,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Message:   message,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		lg.Error(err, "Marshal webhook payload")
+
+		return
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, n.cfg.URL, bytes.NewReader(body))
+	if err != nil {
+		lg.Error(err, "Create webhook request")
+
+		return
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	if n.cfg.AuthToken != "" {
+		req.Header.Set("Authorization", "Bearer "+n.cfg.AuthToken)
+	}
+
+	resp, err := n.client.Do(req)
+	if err != nil {
+		lg.Errorf(err, "Send webhook for event %q", event)
+
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		lg.Warnf("Webhook for event %q returned status %d", event, resp.StatusCode)
+
+		return
+	}
+
+	lg.Debugf("Webhook sent for event %q (status %d)", event, resp.StatusCode)
+}

--- a/pcsm/webhook/webhook_test.go
+++ b/pcsm/webhook/webhook_test.go
@@ -152,6 +152,46 @@ func TestSend_EmptyURL(t *testing.T) {
 	assert.False(t, called.Load(), "no request should be made when URL is empty")
 }
 
+func TestSend_SlackPayload(t *testing.T) {
+	t.Parallel()
+
+	var gotBody []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n := New(Config{URL: srv.URL, Target: "slack"})
+	n.send(EventReplicationFailed, "change stream error")
+
+	var payload map[string]any
+	err := json.Unmarshal(gotBody, &payload)
+	require.NoError(t, err)
+
+	assert.Equal(t, "[replication:failed] change stream error", payload["text"])
+	assert.NotContains(t, payload, "event", "slack payload should not have 'event' field")
+	assert.NotContains(t, payload, "timestamp", "slack payload should not have 'timestamp' field")
+}
+
+func TestSend_SlackNoAuthHeader(t *testing.T) {
+	t.Parallel()
+
+	var gotAuth string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n := New(Config{URL: srv.URL, Target: "slack", AuthToken: "should-be-ignored"})
+	n.send(EventPCSMStarted, "test")
+
+	assert.Empty(t, gotAuth, "Slack webhooks should not send Authorization header")
+}
+
 func TestFailureEvents(t *testing.T) {
 	t.Parallel()
 

--- a/pcsm/webhook/webhook_test.go
+++ b/pcsm/webhook/webhook_test.go
@@ -1,0 +1,161 @@
+package webhook //nolint:testpackage
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSend_DeliversCorrectPayload(t *testing.T) {
+	t.Parallel()
+
+	var gotReq *http.Request
+	var gotBody []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotReq = r
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n := New(Config{URL: srv.URL})
+	n.send(EventPCSMStarted, "test message")
+
+	require.NotNil(t, gotReq)
+	assert.Equal(t, http.MethodPost, gotReq.Method)
+	assert.Equal(t, "application/json", gotReq.Header.Get("Content-Type"))
+
+	var payload Payload
+	err := json.Unmarshal(gotBody, &payload)
+	require.NoError(t, err)
+
+	assert.Equal(t, EventPCSMStarted, payload.Event)
+	assert.Equal(t, "test message", payload.Message)
+
+	_, err = time.Parse(time.RFC3339, payload.Timestamp)
+	assert.NoError(t, err, "timestamp should be valid RFC3339")
+}
+
+func TestSend_SetsAuthHeader(t *testing.T) {
+	t.Parallel()
+
+	var gotAuth string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n := New(Config{URL: srv.URL, AuthToken: "my-token"})
+	n.send(EventPCSMStarted, "")
+
+	assert.Equal(t, "Bearer my-token", gotAuth)
+}
+
+func TestSend_NoAuthHeaderWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	var gotAuth string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n := New(Config{URL: srv.URL})
+	n.send(EventPCSMStarted, "")
+
+	assert.Empty(t, gotAuth)
+}
+
+func TestSend_FiltersEvents(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n := New(Config{URL: srv.URL, Events: FailureEvents()})
+
+	// Failure event should be sent
+	n.send(EventCloneFailed, "clone failed")
+	assert.Equal(t, int32(1), callCount.Load())
+
+	// Non-failure event should be filtered out (Send checks filter before calling send)
+	n.Send(EventPCSMStarted, "started")
+	time.Sleep(50 * time.Millisecond)
+
+	assert.Equal(t, int32(1), callCount.Load(), "non-failure event should be filtered out")
+}
+
+func TestSend_NoFilterSendsAll(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n := New(Config{URL: srv.URL})
+
+	n.Send(EventPCSMStarted, "started")
+	n.Send(EventCloneFailed, "failed")
+	time.Sleep(100 * time.Millisecond)
+
+	assert.Equal(t, int32(2), callCount.Load(), "all events should be sent when no filter is set")
+}
+
+func TestSend_NilNotifier(t *testing.T) {
+	t.Parallel()
+
+	var n *Notifier
+
+	assert.NotPanics(t, func() {
+		n.Send(EventPCSMStarted, "should not panic")
+	})
+}
+
+func TestSend_EmptyURL(t *testing.T) {
+	t.Parallel()
+
+	var called atomic.Bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called.Store(true)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// URL is empty even though server exists
+	n := New(Config{URL: ""})
+
+	n.Send(EventPCSMStarted, "should not send")
+	time.Sleep(50 * time.Millisecond)
+
+	assert.False(t, called.Load(), "no request should be made when URL is empty")
+}
+
+func TestFailureEvents(t *testing.T) {
+	t.Parallel()
+
+	events := FailureEvents()
+
+	assert.Equal(t, []Event{EventCloneFailed, EventReplicationFailed}, events)
+}

--- a/pcsm/webhook/webhook_test.go
+++ b/pcsm/webhook/webhook_test.go
@@ -170,9 +170,14 @@ func TestSend_SlackPayload(t *testing.T) {
 	err := json.Unmarshal(gotBody, &payload)
 	require.NoError(t, err)
 
-	assert.Equal(t, "[replication:failed] change stream error", payload["text"])
+	text, ok := payload["text"].(string)
+	require.True(t, ok)
+
+	assert.Contains(t, text, "*PCSM*")
+	assert.Contains(t, text, "*Event:* `replication:failed`")
+	assert.Contains(t, text, "*Message:* change stream error")
+	assert.Contains(t, text, "*Time:*")
 	assert.NotContains(t, payload, "event", "slack payload should not have 'event' field")
-	assert.NotContains(t, payload, "timestamp", "slack payload should not have 'timestamp' field")
 }
 
 func TestSend_SlackNoAuthHeader(t *testing.T) {


### PR DESCRIPTION
<!-- opencode-summary-start -->
## Summary

Add webhook notifications for PCSM lifecycle events. Send HTTP POST requests to configured URLs when events like replication failures or finalization completion occur. Supports generic JSON payloads and Slack-formatted messages with configurable event filtering and authentication.
<!-- opencode-summary-end -->

[PCSM-308](https://perconadev.atlassian.net/browse/PCSM-308)

### Problem

PCSM has no way to notify external systems about lifecycle events. Users have to poll the `/status` endpoint to detect state changes like replication failures or finalization completion.

### Solution

Add webhook notifications that send HTTP POST requests to a user-configured URL on key lifecycle events.
Notifications are sent in a fire-and-forget manner.

**New CLI options:**

| Flag | Env Var | Description |
|---|---|---|
| `--webhook-url` | `PCSM_WEBHOOK_URL` | Callback URL (required to enable webhooks) |
| `--webhook-events` | `PCSM_WEBHOOK_EVENTS` | Event filter: `all` (default) or `failure` |
| `--webhook-auth-token` | `PCSM_WEBHOOK_AUTH_TOKEN` | Bearer token for authentication |
| `--webhook-target` | `PCSM_WEBHOOK_TARGET` | Payload format: `slack` for Slack incoming webhooks |

**Events:** `pcsm:started`, `initial-sync:clone-completed`, `initial-sync:clone-failed`, `initial-sync:completed`, `replication:failed`, `replication:paused`, `replication:resumed`, `finalization:started`,  `finalization:finished`

**Generic payload:**
```json
{
    "event": "replication:failed",
    "timestamp": "2026-04-16T09:08:49Z",
    "message": "change stream error"
}
```

**Slack payload (--webhook-target slack):**
```json
  {
    "text": "*PCSM*\n*Event:* `replication:failed`\n*Message:* change stream error\n*Time:* 2026-04-16T09:08:49Z"
  }
```

[PCSM-308]: https://perconadev.atlassian.net/browse/PCSM-308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ