### PR TITLE
PCSM-289: Cross-version replication support (6.0 to 8.0)

### DIFF
--- a/.github/workflows/e2etests.yml
+++ b/.github/workflows/e2etests.yml
@@ -21,6 +21,8 @@ jobs:
             tgt_mongo_version: "7.0"
           - src_mongo_version: "8.0"
             tgt_mongo_version: "8.0"
+          - src_mongo_version: "6.0"
+            tgt_mongo_version: "8.0"
           - src_mongo_version: "7.0"
             tgt_mongo_version: "8.0"
 

--- a/.github/workflows/e2etests.yml
+++ b/.github/workflows/e2etests.yml
@@ -22,6 +22,8 @@ jobs:
           - src_mongo_version: "8.0"
             tgt_mongo_version: "8.0"
           - src_mongo_version: "6.0"
+            tgt_mongo_version: "7.0"
+          - src_mongo_version: "6.0"
             tgt_mongo_version: "8.0"
           - src_mongo_version: "7.0"
             tgt_mongo_version: "8.0"
@@ -80,23 +82,36 @@ jobs:
         run: docker compose -f hack/rs/compose.yml down
 
   sharded:
-    name: Sharded (MongoDB ${{ matrix.mongo_version }})
+    name: Sharded (${{ matrix.src_mongo_version }} → ${{ matrix.tgt_mongo_version }})
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
         include:
-          # 6.0/7.0: sharded-specific tests only (full suite blocked by PCSM-255)
-          - mongo_version: "6.0"
+          # 6.0/7.0 source: sharded-specific tests only (full suite blocked by PCSM-255)
+          - src_mongo_version: "6.0"
+            tgt_mongo_version: "6.0"
             test_scope: tests/test_collections_sharded.py tests/test_documents_sharded.py tests/test_pipeline_updates.py
-          - mongo_version: "7.0"
+          - src_mongo_version: "7.0"
+            tgt_mongo_version: "7.0"
             test_scope: tests/test_collections_sharded.py tests/test_documents_sharded.py tests/test_pipeline_updates.py
-          - mongo_version: "8.0"
+          - src_mongo_version: "8.0"
+            tgt_mongo_version: "8.0"
             test_scope: ""
+          - src_mongo_version: "6.0"
+            tgt_mongo_version: "7.0"
+            test_scope: tests/test_collections_sharded.py tests/test_documents_sharded.py tests/test_pipeline_updates.py
+          - src_mongo_version: "6.0"
+            tgt_mongo_version: "8.0"
+            test_scope: tests/test_collections_sharded.py tests/test_documents_sharded.py tests/test_pipeline_updates.py
+          - src_mongo_version: "7.0"
+            tgt_mongo_version: "8.0"
+            test_scope: tests/test_collections_sharded.py tests/test_documents_sharded.py tests/test_pipeline_updates.py
 
     env:
-      MONGO_VERSION: ${{ matrix.mongo_version }}
+      SRC_MONGO_VERSION: ${{ matrix.src_mongo_version }}
+      TGT_MONGO_VERSION: ${{ matrix.tgt_mongo_version }}
       PYTEST_TIMEOUT: 60
 
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,16 +40,16 @@ If `poetry run` fails with a "bad interpreter" error (e.g. after a Python versio
 
 ## Supported MongoDB Versions
 
-| Source | Target | Topology    | Notes                             |
-| ------ | ------ | ----------- | --------------------------------- |
-| 6.0    | 6.0    | RS, Sharded |                                   |
-| 7.0    | 7.0    | RS, Sharded |                                   |
-| 8.0    | 8.0    | RS, Sharded |                                   |
-| 7.0    | 8.0    | RS          | Cross-version; PCSM-286           |
-| 6.0    | 8.0    | RS          | Cross-version; PCSM-289           |
-| 6.0    | 7.0    | RS          | Measurement-only; not CI-verified |
+| Source | Target | Topology    |
+| ------ | ------ | ----------- |
+| 6.0    | 6.0    | RS, Sharded |
+| 7.0    | 7.0    | RS, Sharded |
+| 8.0    | 8.0    | RS, Sharded |
+| 6.0    | 7.0    | RS, Sharded |
+| 6.0    | 8.0    | RS, Sharded |
+| 7.0    | 8.0    | RS, Sharded |
 
-Sharded cross-version combinations are not supported (blocked by PCSM-255).
+Sharded entries (except 8.0 → 8.0) run a reduced E2E scope in CI; the full sharded suite is blocked by PCSM-255.
 Downgrade (higher → lower) is not supported.
 
 ## Cluster Topology

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,20 @@ If `poetry run` fails with a "bad interpreter" error (e.g. after a Python versio
 | `SRC_SHARDS`    | `2`     | Number of source shards (sharded topology only, max 3) |
 | `TGT_SHARDS`    | `2`     | Number of target shards (sharded topology only, max 3) |
 
+## Supported MongoDB Versions
+
+| Source | Target | Topology    | Notes                             |
+| ------ | ------ | ----------- | --------------------------------- |
+| 6.0    | 6.0    | RS, Sharded |                                   |
+| 7.0    | 7.0    | RS, Sharded |                                   |
+| 8.0    | 8.0    | RS, Sharded |                                   |
+| 7.0    | 8.0    | RS          | Cross-version; PCSM-286           |
+| 6.0    | 8.0    | RS          | Cross-version; PCSM-289           |
+| 6.0    | 7.0    | RS          | Measurement-only; not CI-verified |
+
+Sharded cross-version combinations are not supported (blocked by PCSM-255).
+Downgrade (higher → lower) is not supported.
+
 ## Cluster Topology
 
 ### Connection URIs

--- a/main.go
+++ b/main.go
@@ -639,7 +639,7 @@ func createServer(ctx context.Context, cfg *config.Config) (*server, error) {
 	promRegistry := prometheus.NewRegistry()
 	metrics.Init(promRegistry)
 
-	pcs := pcsm.New(ctx, source, target)
+	pcs := pcsm.New(ctx, source, target, sourceVersion)
 
 	err = Restore(ctx, target, pcs)
 	if err != nil {

--- a/mdb/connect_test.go
+++ b/mdb/connect_test.go
@@ -12,7 +12,7 @@ import (
 func TestSanitizeConnString(t *testing.T) {
 	t.Parallel()
 
-	const baseURI = "mongodb://usr:pass@mongo:27018"
+	const baseURI = "mongodb://usr:pass@mongo:27018" //nolint:gosec // test-only URI fixture, not real credentials
 
 	// realOptions is list of real options that are not in the allowed list.
 	realOptions := []string{

--- a/mdb/errors.go
+++ b/mdb/errors.go
@@ -62,6 +62,13 @@ func IsCappedPositionLost(err error) bool {
 	return isMongoCommandError(err, "CappedPositionLost")
 }
 
+// IsDatabaseDropPending checks if an error is caused by a database drop pending state.
+// MongoDB returns this error (code 357) when an operation targets a database
+// that is in the process of being dropped.
+func IsDatabaseDropPending(err error) bool {
+	return isMongoCommandError(err, "DatabaseDropPending")
+}
+
 // isMongoCommandError checks if an error is a MongoDB error with the specified name.
 func isMongoCommandError(err error, name string) bool {
 	var cmdErr mongo.CommandError

--- a/mdb/errors_test.go
+++ b/mdb/errors_test.go
@@ -1,0 +1,34 @@
+package mdb_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+
+	"github.com/percona/percona-clustersync-mongodb/errors"
+	"github.com/percona/percona-clustersync-mongodb/mdb"
+)
+
+func TestIsDatabaseDropPending(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{"DatabaseDropPending error", mongo.CommandError{Name: "DatabaseDropPending", Code: 357}, true},
+		{"other command error", mongo.CommandError{Name: "NamespaceNotFound"}, false},
+		{"nil error", nil, false},
+		{"non-command error", errors.New("generic"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.expected, mdb.IsDatabaseDropPending(tt.err))
+		})
+	}
+}

--- a/pcsm/catalog/catalog.go
+++ b/pcsm/catalog/catalog.go
@@ -1078,6 +1078,12 @@ func (c *Catalog) doModifyIndexOption(
 
 		return errors.Wrapf(err, "modify index %s.%s.%s: %s", db, coll, indexName, propName)
 	})
+	if mdb.IsNamespaceNotFound(err) {
+		log.Ctx(ctx).Warn(err.Error())
+
+		return nil
+	}
+
 	if mdb.IsIndexOptionsConflict(err) {
 		return c.dropAndRecreateIndex(ctx, db, coll, indexName)
 	}

--- a/pcsm/catalog/catalog.go
+++ b/pcsm/catalog/catalog.go
@@ -143,6 +143,7 @@ var _ BaseCatalog = (*Catalog)(nil)
 type Catalog struct {
 	lock      sync.RWMutex
 	target    *mongo.Client
+	sourceVer mdb.ServerVersion
 	Databases map[string]databaseCatalog
 }
 
@@ -172,9 +173,10 @@ func (i indexCatalogEntry) Unsuccessful() bool {
 }
 
 // NewCatalog creates a new Catalog.
-func NewCatalog(target *mongo.Client) *Catalog {
+func NewCatalog(target *mongo.Client, sourceVer mdb.ServerVersion) *Catalog {
 	return &Catalog{
 		target:    target,
+		sourceVer: sourceVer,
 		Databases: make(map[string]databaseCatalog),
 	}
 }

--- a/pcsm/catalog/catalog_test.go
+++ b/pcsm/catalog/catalog_test.go
@@ -16,6 +16,8 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
+
+	"github.com/percona/percona-clustersync-mongodb/mdb"
 )
 
 const testDB = "pcsm_test_catalog"
@@ -132,7 +134,7 @@ func TestCreateCollection_Idempotency(t *testing.T) {
 	client := connectToMongoDB(t)
 	defer func() { _ = client.Disconnect(ctx) }()
 
-	cat := NewCatalog(client)
+	cat := NewCatalog(client, mdb.ServerVersion{})
 
 	db := testDB + "_coll"
 	coll := "test_create_collection"
@@ -164,7 +166,7 @@ func TestCreateView_Idempotency(t *testing.T) {
 	client := connectToMongoDB(t)
 	defer func() { _ = client.Disconnect(ctx) }()
 
-	cat := NewCatalog(client)
+	cat := NewCatalog(client, mdb.ServerVersion{})
 
 	db := testDB + "_view"
 	sourceColl := "test_view_source"

--- a/pcsm/catalog/modify_index_test.go
+++ b/pcsm/catalog/modify_index_test.go
@@ -165,6 +165,11 @@ func TestDoModifyIndexOption(t *testing.T) {
 		}
 	})
 
+	t.Run("returns nil when namespace not found", func(t *testing.T) {
+		err := cat.doModifyIndexOption(ctx, db, "nonexistent_collection", indexName, "expireAfterSeconds", int64(999))
+		assert.NoError(t, err)
+	})
+
 	t.Run("converts non-unique to unique via prepareUnique", func(t *testing.T) {
 		unique := true
 		uniqueSpec := &mdb.IndexSpecification{

--- a/pcsm/catalog/modify_index_test.go
+++ b/pcsm/catalog/modify_index_test.go
@@ -66,7 +66,7 @@ func TestDropAndRecreateIndex(t *testing.T) {
 	}).Err()
 	require.NoError(t, err)
 
-	cat := NewCatalog(client)
+	cat := NewCatalog(client, mdb.ServerVersion{})
 	seedIndex(t, cat, db, coll, spec)
 
 	t.Run("drops and recreates index from catalog spec", func(t *testing.T) {
@@ -127,7 +127,7 @@ func TestDoModifyIndexOption(t *testing.T) {
 	}).Err()
 	require.NoError(t, err)
 
-	cat := NewCatalog(client)
+	cat := NewCatalog(client, mdb.ServerVersion{})
 	seedIndex(t, cat, db, coll, spec)
 
 	t.Run("modifies expireAfterSeconds via collMod", func(t *testing.T) {

--- a/pcsm/clone/copy.go
+++ b/pcsm/clone/copy.go
@@ -31,6 +31,12 @@ var (
 	errEOS = errors.New("end of segment")
 )
 
+const (
+	minNumWorkers                 = 1
+	defaultNumReadWorkersDivisor  = 4
+	defaultNumInsertWorkersFactor = 2
+)
+
 // CopyManager orchestrates the cloning process by managing read and insert workers,
 // handling parallel collection cloning, batching, and segmentation.
 // It encapsulates the logic needed to coordinate concurrent operations and maintain progress.
@@ -64,30 +70,30 @@ type CopyProgressUpdate struct {
 // It controls concurrency settings and memory limits for collection cloning operations.
 type CopyManagerOptions struct {
 	// NumReadWorkers is the total number of concurrent read workers.
-	// min: 1; default: [runtime.NumCPU] / 4.
+	// min: 1; default: max([runtime.NumCPU] / 4, 1).
 	NumReadWorkers int
 	// NumInsertWorkers is the total number of concurrent insert workers.
-	// min: 1; default: [runtime.NumCPU] * 4.
+	// min: 1; default: [runtime.NumCPU] * 2.
 	NumInsertWorkers int
 	// SegmentSizeBytes is the logical segment size in bytes for splitting collections.
 	// min: [config.MinCloneSegmentSizeBytes].
-	// min: [config.MaxCloneSegmentSizeBytes].
+	// max: [config.MaxCloneSegmentSizeBytes].
 	// default: auto (per collection) [config.AutoCloneSegmentSize].
 	SegmentSizeBytes int64
 	// ReadBatchSizeBytes is the maximum read batch size in bytes.
 	// min: [config.MinCloneReadBatchSizeBytes].
 	// max: [config.MaxCloneReadBatchSizeBytes].
-	// default: config.DefaultCloneReadBatchSizeBytes].
+	// default: [config.DefaultCloneReadBatchSizeBytes].
 	ReadBatchSizeBytes int32
 }
 
 func (o *CopyManagerOptions) applyDefaults() {
-	if o.NumReadWorkers < 1 {
-		o.NumReadWorkers = max(runtime.NumCPU()/4, 1) //nolint:mnd
+	if o.NumReadWorkers < minNumWorkers {
+		o.NumReadWorkers = max(runtime.NumCPU()/defaultNumReadWorkersDivisor, minNumWorkers)
 	}
 
-	if o.NumInsertWorkers < 1 {
-		o.NumInsertWorkers = runtime.NumCPU() * 2 //nolint:mnd
+	if o.NumInsertWorkers < minNumWorkers {
+		o.NumInsertWorkers = runtime.NumCPU() * defaultNumInsertWorkersFactor
 	}
 
 	if o.SegmentSizeBytes < 0 {
@@ -447,6 +453,7 @@ type collectionCopySession struct {
 }
 
 func newCollectionCopySession(ctx context.Context, ns catalog.Namespace, isCapped bool) *collectionCopySession {
+	//nolint:gosec // G118 false positive: cancel is stored on session and called later via session.cancel().
 	sessionCtx, cancel := context.WithCancel(ctx)
 
 	return &collectionCopySession{

--- a/pcsm/pcsm.go
+++ b/pcsm/pcsm.go
@@ -102,6 +102,8 @@ type PCSM struct {
 	source *mongo.Client // Source MongoDB client
 	target *mongo.Client // Target MongoDB client
 
+	sourceVer mdb.ServerVersion
+
 	nsInclude []string
 	nsExclude []string
 	nsFilter  sel.NSFilter // Namespace filter
@@ -122,11 +124,12 @@ type PCSM struct {
 }
 
 // New creates a new PCSM.
-func New(lifecycleCtx context.Context, source, target *mongo.Client) *PCSM {
+func New(lifecycleCtx context.Context, source, target *mongo.Client, sourceVer mdb.ServerVersion) *PCSM {
 	return &PCSM{
 		lifecycleCtx:   lifecycleCtx,
 		source:         source,
 		target:         target,
+		sourceVer:      sourceVer,
 		state:          StateIdle,
 		onStateChanged: func(State) {},
 	}
@@ -194,10 +197,10 @@ func (p *PCSM) Recover(ctx context.Context, data []byte) error {
 	}
 
 	nsFilter := sel.MakeFilter(cp.NSInclude, cp.NSExclude)
-	cat := catalog.NewCatalog(p.target)
+	cat := catalog.NewCatalog(p.target, p.sourceVer)
 	// Use empty options for recovery (clone tuning is less relevant when resuming from checkpoint)
 	cln := clone.NewClone(p.source, p.target, cat, nsFilter, &clone.Options{})
-	rpl := repl.NewRepl(p.source, p.target, cat, nsFilter, &repl.Options{})
+	rpl := repl.NewRepl(p.source, p.target, cat, nsFilter, &repl.Options{}, p.sourceVer)
 
 	if cp.Catalog != nil {
 		err = cat.Recover(cp.Catalog)
@@ -352,9 +355,9 @@ func (p *PCSM) Start(ctx context.Context, options *StartOptions) error {
 	p.nsExclude = options.ExcludeNamespaces
 	p.nsFilter = sel.MakeFilter(p.nsInclude, p.nsExclude)
 	p.pauseOnInitialSync = options.PauseOnInitialSync
-	p.catalog = catalog.NewCatalog(p.target)
+	p.catalog = catalog.NewCatalog(p.target, p.sourceVer)
 	p.clone = clone.NewClone(p.source, p.target, p.catalog, p.nsFilter, &options.Clone)
-	p.repl = repl.NewRepl(p.source, p.target, p.catalog, p.nsFilter, &options.Repl)
+	p.repl = repl.NewRepl(p.source, p.target, p.catalog, p.nsFilter, &options.Repl, p.sourceVer)
 	p.state = StateRunning
 
 	go p.run(p.lifecycleCtx)

--- a/pcsm/pcsm_test.go
+++ b/pcsm/pcsm_test.go
@@ -10,6 +10,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 
 	"github.com/percona/percona-clustersync-mongodb/errors"
+	"github.com/percona/percona-clustersync-mongodb/mdb"
 	"github.com/percona/percona-clustersync-mongodb/pcsm/catalog"
 	"github.com/percona/percona-clustersync-mongodb/pcsm/clone"
 	"github.com/percona/percona-clustersync-mongodb/pcsm/repl"
@@ -18,7 +19,7 @@ import (
 func TestNew(t *testing.T) {
 	t.Parallel()
 
-	p := New(t.Context(), nil, nil)
+	p := New(t.Context(), nil, nil, mdb.ServerVersion{})
 
 	assert.Equal(t, State(StateIdle), p.state, "initial state should be StateIdle")
 	assert.Nil(t, p.source, "source should be nil when passed nil")
@@ -54,7 +55,7 @@ func TestCheckpoint(t *testing.T) {
 		p := &PCSM{
 			state:          StatePaused,
 			onStateChanged: func(State) {},
-			catalog:        catalog.NewCatalog(nil),
+			catalog:        catalog.NewCatalog(nil, mdb.ServerVersion{}),
 			clone:          &mockCloner{doneCh: make(chan struct{})},
 			repl:           &mockReplicator{doneCh: make(chan struct{})},
 		}
@@ -79,7 +80,7 @@ func TestCheckpoint(t *testing.T) {
 			onStateChanged: func(State) {},
 			nsInclude:      []string{"db1.*", "db2.coll"},
 			nsExclude:      []string{"db1.excluded"},
-			catalog:        catalog.NewCatalog(nil),
+			catalog:        catalog.NewCatalog(nil, mdb.ServerVersion{}),
 			clone:          &mockCloner{doneCh: make(chan struct{})},
 			repl:           &mockReplicator{doneCh: make(chan struct{})},
 		}
@@ -102,7 +103,7 @@ func TestCheckpoint(t *testing.T) {
 			state:          StateFailed,
 			onStateChanged: func(State) {},
 			err:            errors.New("test error"),
-			catalog:        catalog.NewCatalog(nil),
+			catalog:        catalog.NewCatalog(nil, mdb.ServerVersion{}),
 			clone:          &mockCloner{doneCh: make(chan struct{})},
 			repl:           &mockReplicator{doneCh: make(chan struct{})},
 		}
@@ -128,7 +129,7 @@ func TestCheckpoint(t *testing.T) {
 		p := &PCSM{
 			state:          StatePaused,
 			onStateChanged: func(State) {},
-			catalog:        catalog.NewCatalog(nil),
+			catalog:        catalog.NewCatalog(nil, mdb.ServerVersion{}),
 			clone:          &mockCloner{doneCh: make(chan struct{}), checkpoint: cloneCP},
 			repl:           &mockReplicator{doneCh: make(chan struct{})},
 		}
@@ -156,7 +157,7 @@ func TestCheckpoint(t *testing.T) {
 		p := &PCSM{
 			state:          StatePaused,
 			onStateChanged: func(State) {},
-			catalog:        catalog.NewCatalog(nil),
+			catalog:        catalog.NewCatalog(nil, mdb.ServerVersion{}),
 			clone:          &mockCloner{doneCh: make(chan struct{})},
 			repl:           &mockReplicator{doneCh: make(chan struct{}), checkpoint: replCP},
 		}

--- a/pcsm/repl/repl.go
+++ b/pcsm/repl/repl.go
@@ -930,7 +930,12 @@ func (r *Repl) applyDDLChange(ctx context.Context, change *ChangeEvent) error {
 		// the definitive state and stale DDL events are safely skippable.
 		// IsInvalidOptions covers collMod on collections that no longer match
 		// the expected type (e.g. collMod capped on a non-capped collection).
-		if mdb.IsNamespaceNotFound(err) || mdb.IsIndexNotFound(err) || mdb.IsInvalidOptions(err) {
+		// IsDatabaseDropPending covers concurrent database drops during
+		// change-stream catchup.
+		if mdb.IsNamespaceNotFound(err) ||
+			mdb.IsIndexNotFound(err) ||
+			mdb.IsInvalidOptions(err) ||
+			mdb.IsDatabaseDropPending(err) {
 			lg.Warn(err.Error())
 
 			return nil

--- a/pcsm/repl/repl.go
+++ b/pcsm/repl/repl.go
@@ -942,6 +942,17 @@ func (r *Repl) applyDDLChange(ctx context.Context, change *ChangeEvent) error {
 	return nil
 }
 
+// alignCappedSize rounds size up to the nearest 256-byte boundary.
+// MongoDB 6.x internally applies this rounding to capped collections;
+// later versions do not. Use when replicating collMod cappedSize events
+// from a 6.x source so the target stores an identical value.
+func alignCappedSize(size int64) int64 {
+	const alignment int64 = 256
+	const alignmentOffset = alignment - 1
+
+	return (size + alignmentOffset) / alignment * alignment
+}
+
 func (r *Repl) doModify(ctx context.Context, ns catalog.Namespace, event *ModifyEvent) error {
 	opts := event.OperationDescription
 
@@ -973,8 +984,16 @@ func (r *Repl) doModify(ctx context.Context, ns catalog.Namespace, event *Modify
 		}
 
 	case opts.CappedSize != nil || opts.CappedMax != nil:
+		cappedSize := opts.CappedSize
+		if cappedSize != nil && r.sourceVer.Major() == 6 {
+			// MongoDB 6.x rounds capped sizes to the nearest 256-byte boundary
+			// internally. Replicate this alignment when applying collMod events
+			// from a 6.x source so source and target store identical values.
+			aligned := alignCappedSize(*cappedSize)
+			cappedSize = &aligned
+		}
 		err := r.catalog.ModifyCappedCollection(ctx,
-			ns.Database, ns.Collection, opts.CappedSize, opts.CappedMax)
+			ns.Database, ns.Collection, cappedSize, opts.CappedMax)
 		if err != nil {
 			return errors.Wrap(err, "Resize capped collection")
 		}

--- a/pcsm/repl/repl.go
+++ b/pcsm/repl/repl.go
@@ -112,6 +112,8 @@ type Repl struct {
 	source *mongo.Client // Source MongoDB client
 	target *mongo.Client // Target MongoDB client
 
+	sourceVer mdb.ServerVersion
+
 	nsFilter sel.NSFilter // Namespace filter
 	catalog  Catalog      // Catalog for managing collections and indexes
 
@@ -173,6 +175,7 @@ func NewRepl(
 	cat Catalog,
 	nsFilter sel.NSFilter,
 	opts *Options,
+	sourceVer mdb.ServerVersion,
 ) *Repl {
 	opts.applyDefaults()
 
@@ -187,13 +190,14 @@ func NewRepl(
 	lg.Infof("Config: WorkerBulkQueueSize: %d", opts.WorkerBulkQueueSize)
 
 	return &Repl{
-		source:   source,
-		target:   target,
-		nsFilter: nsFilter,
-		catalog:  cat,
-		options:  opts,
-		pauseCh:  make(chan struct{}),
-		doneCh:   make(chan struct{}),
+		source:    source,
+		target:    target,
+		sourceVer: sourceVer,
+		nsFilter:  nsFilter,
+		catalog:   cat,
+		options:   opts,
+		pauseCh:   make(chan struct{}),
+		doneCh:    make(chan struct{}),
 	}
 }
 

--- a/pcsm/repl/repl_test.go
+++ b/pcsm/repl/repl_test.go
@@ -234,3 +234,27 @@ func TestAdvanceReportedOpTime(t *testing.T) {
 		})
 	}
 }
+
+func TestAlignCappedSize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    int64
+		expected int64
+	}{
+		{"non-aligned rounds up", 3333, 3584},
+		{"already aligned is unchanged", 3584, 3584},
+		{"zero stays zero", 0, 0},
+		{"256 stays 256", 256, 256},
+		{"257 rounds to 512", 257, 512},
+		{"1 rounds to 256", 1, 256},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, alignCappedSize(tt.input))
+		})
+	}
+}


### PR DESCRIPTION
### Problem

We still needed explicit 6.0→8.0 coverage and guardrails for behavior differences that show up when source and target are on different major versions. Finalization paths also needed to be more tolerant to transient/drop-related states so cross-version runs dont fail on racey DDL timing.

New bug found during triage and fixed here: 6.x source `cappedSize` event value can differ from 7.0+/8.0 target expectation due to 256-byte rounding in `collMod` path.

Sharded stabilization still needs PCSM-255 resolved.

### Solution

Thread `sourceVer` through `Catalog`, `Repl`, and `PCSM` constructors so replication code can make version-aware decisions where needed. Add a 6.x-specific capped collection size alignment in `collMod` handling to match MongoDB's 256-byte rounding on source metadata vs emitted events. Harden finalization by tolerating `DatabaseDropPending` and `NamespaceNotFound` in expected race windows.

Expand the CI matrix:

- RS: add 6.0→7.0 alongside the existing 6.0→8.0 and 7.0→8.0 cross-version entries.
- Sharded: add 6.0→7.0, 6.0→8.0, 7.0→8.0 cross-version entries running the limited scope (`tests/test_collections_sharded.py tests/test_documents_sharded.py tests/test_pipeline_updates.py`). Full sharded suite remains blocked by PCSM-255.

Update AGENTS.md with the supported-version matrix.

### Full sharded suite — local runs (not part of CI, PCSM-255 blocked)

To confirm PCSM-255 still blocks the same code paths and that no new regressions surface in the limited CI scope, full sharded suites were run locally for all three cross-version pairs:

| Source → Target | Result | Duration |
|---|---|---|
| Sharded 6.0 → 7.0 | 197 passed / **34 failed** / 8 skipped | 13:24 |
| Sharded 6.0 → 8.0 | 191 passed / **40 failed** / 8 skipped | 13:08 |
| Sharded 7.0 → 8.0 | 194 passed / **37 failed** / 8 skipped | 13:08 |

All failures are `[phase:apply]` cases — same PCSM-255 root cause across pairs. The 8 skipped tests in each run are pre-existing skips unrelated to this PR.

Full test suite outcome: <https://psmdb.cd.percona.com/job/hetzner-pcsm-functional-tests/160/>
One unstable failed test: `test_failure_resilience::test_csync_PML_T47[dst-replicaset_3n]`.Infrastructure flakiness, not a PCSM code regression.
