### PR TITLE
PCSM-305: BufBuilder overflow error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ __pycache__
 /scratch.*
 
 CLAUDE.md
+
+.claude

--- a/pcsm/repl/bulk.go
+++ b/pcsm/repl/bulk.go
@@ -11,6 +11,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/percona/percona-clustersync-mongodb/config"
 	"github.com/percona/percona-clustersync-mongodb/errors"
 	"github.com/percona/percona-clustersync-mongodb/log"
 	"github.com/percona/percona-clustersync-mongodb/mdb"
@@ -35,38 +36,45 @@ var collectionBulkOptions = options.BulkWrite().
 
 // Update operation chunking limits to prevent MongoDB's 125 MB BufBuilder overflow (error
 // 13548) and to keep individual update payloads bounded. When a change event combines
-// truncations with conflicting array-index updates, the array-index updates are split off
-// into separate $set follow-up operations, each its own update with its own MongoDB-side
-// BufBuilder. maxBytesPerSetOp is the primary guard; maxFieldsPerSetOp is a secondary guard
-// against degenerate cases with many tiny fields.
+// truncations with conflicting array-index updates or removed sub-paths, the conflicting
+// operations are split off into separate $set/$unset follow-up operations, each its own
+// update with its own MongoDB-side BufBuilder. maxBytesPerSetOp is the primary guard;
+// maxFieldsPerSetOp is a secondary guard against degenerate cases with many tiny fields.
 //
-// maxBulkBytes caps the aggregate wire size of a single bulk command, well under MongoDB's
-// 48 MB MaxMessageSizeBytes default. Combined with the per-update bounds above, this keeps
-// both individual operations and the bulk command within MongoDB's wire-protocol limits.
+// The aggregate wire size of a single bulk command is capped at config.MaxWriteBatchSizeBytes
+// (MongoDB's MaxMessageSizeBytes minus the standard message-header reserve). Per-op envelope
+// overhead (model wrappers, nsInfo, command metadata) is not explicitly accounted for in
+// cbw.bytes; the header reserve plus the empty-bulk exception in WouldOverflow provide the
+// safety margin in practice.
 const (
-	maxFieldsPerSetOp = 100              //nolint:mnd
-	maxBytesPerSetOp  = 512 * 1024       //nolint:mnd // 512 KiB
-	maxBulkBytes      = 32 * 1024 * 1024 //nolint:mnd // 32 MiB - well under 48 MB MaxMessageSizeBytes
+	maxFieldsPerSetOp = 100        //nolint:mnd
+	maxBytesPerSetOp  = 512 * 1024 //nolint:mnd // 512 KiB
 )
 
 // updateOps holds the result of building update operations from a change stream event.
-// When a change event combines an array truncation with conflicting indexed-write updates,
-// the conflicting updates are split into follow-up $set operations so that no single update
-// document carries both a $push (truncation) and a $set on the same array path - which
-// MongoDB rejects as a path conflict - and so that no individual update accumulates enough
-// work to exhaust MongoDB's 125 MB BufBuilder ceiling (error 13548).
+// When a change event combines an array truncation with conflicting indexed-write updates
+// or removed sub-paths, the conflicting updates are split into follow-up $set/$unset
+// operations so that no single update document carries both a $push (truncation) and a
+// $set/$unset on the same array path - which MongoDB rejects as a path conflict - and so
+// that no individual update accumulates enough work to exhaust MongoDB's 125 MB BufBuilder
+// ceiling (error 13548).
 type updateOps struct {
-	// primary is the main update document (bson.D).
-	primary any
-	// followUp contains additional $set operations for array-index updates that conflict
-	// with a truncation in the primary update. Each element is an update document (bson.D)
-	// with a single $set operator. nil when not needed.
+	// primary is the main update document.
+	primary bson.D
+	// followUp contains additional update documents (each with a single $set or $unset
+	// operator) for fields that conflict with a truncation in the primary update. nil
+	// when not needed.
 	followUp []bson.D
 }
 
 type bulkWriter interface {
 	Full() bool
 	Empty() bool
+	// WouldOverflow reports whether appending an operation of the given estimated
+	// BSON byte size would push the bulk past config.MaxWriteBatchSizeBytes. It
+	// returns false when the bulk is empty so a single oversized event can still be
+	// sent on its own.
+	WouldOverflow(estimate int) bool
 	Do(ctx context.Context, m *mongo.Client) (int, error)
 
 	Insert(ns catalog.Namespace, event *InsertEvent)
@@ -77,6 +85,7 @@ type bulkWriter interface {
 
 type clientBulkWrite struct {
 	useSimpleCollation bool
+	maxOpsSize         int
 	bytes              int
 	writes             []mongo.ClientBulkWrite
 }
@@ -84,16 +93,21 @@ type clientBulkWrite struct {
 func newClientBulkWriter(size int, useSimpleCollation bool) *clientBulkWrite {
 	return &clientBulkWrite{
 		useSimpleCollation: useSimpleCollation,
+		maxOpsSize:         size,
 		writes:             make([]mongo.ClientBulkWrite, 0, size),
 	}
 }
 
 func (cbw *clientBulkWrite) Full() bool {
-	return len(cbw.writes) == cap(cbw.writes) || cbw.bytes >= maxBulkBytes
+	return len(cbw.writes) >= cbw.maxOpsSize || cbw.bytes >= config.MaxWriteBatchSizeBytes
 }
 
 func (cbw *clientBulkWrite) Empty() bool {
 	return len(cbw.writes) == 0
+}
+
+func (cbw *clientBulkWrite) WouldOverflow(estimate int) bool {
+	return len(cbw.writes) > 0 && cbw.bytes+estimate > config.MaxWriteBatchSizeBytes
 }
 
 func (cbw *clientBulkWrite) Do(ctx context.Context, m *mongo.Client) (int, error) {
@@ -212,6 +226,9 @@ func (cbw *clientBulkWrite) Insert(ns catalog.Namespace, event *InsertEvent) {
 func (cbw *clientBulkWrite) Update(ns catalog.Namespace, event *UpdateEvent) {
 	ops := collectUpdateOps(event)
 
+	// Marshal the document filter once and reuse for primary + every follow-up.
+	filterLen := marshalLen(event.DocumentKey)
+
 	m := &mongo.ClientUpdateOneModel{
 		Filter: event.DocumentKey,
 		Update: ops.primary,
@@ -224,11 +241,11 @@ func (cbw *clientBulkWrite) Update(ns catalog.Namespace, event *UpdateEvent) {
 	cbw.writes = append(cbw.writes, mongo.ClientBulkWrite{
 		Database: ns.Database, Collection: ns.Collection, Model: m,
 	})
-	cbw.bytes += estimateBytes(event.DocumentKey, ops.primary)
+	cbw.bytes += filterLen + marshalLen(ops.primary)
 
-	// Follow-up $set operations for fields split out due to BufBuilder limits.
-	// Each is a separate updateOne so MongoDB resets its BufBuilder per operation.
-	// Ordered bulk writes guarantee sequential execution.
+	// Follow-up $set/$unset operations for fields split out due to truncation path
+	// conflicts and BufBuilder limits. Each is a separate updateOne so MongoDB resets
+	// its BufBuilder per operation. Ordered bulk writes guarantee sequential execution.
 	for _, followUp := range ops.followUp {
 		fm := &mongo.ClientUpdateOneModel{
 			Filter: event.DocumentKey,
@@ -242,7 +259,7 @@ func (cbw *clientBulkWrite) Update(ns catalog.Namespace, event *UpdateEvent) {
 		cbw.writes = append(cbw.writes, mongo.ClientBulkWrite{
 			Database: ns.Database, Collection: ns.Collection, Model: fm,
 		})
-		cbw.bytes += estimateBytes(event.DocumentKey, followUp)
+		cbw.bytes += filterLen + marshalLen(followUp)
 	}
 }
 
@@ -287,7 +304,7 @@ func (cbw *clientBulkWrite) Delete(ns catalog.Namespace, event *DeleteEvent) {
 
 type collectionBulkWrite struct {
 	useSimpleCollation bool
-	max                int
+	maxOpsSize         int
 	count              int
 	bytes              int
 	writes             map[string][]mongo.WriteModel
@@ -296,17 +313,21 @@ type collectionBulkWrite struct {
 func newCollectionBulkWriter(size int, nonDefaultCollationSupport bool) *collectionBulkWrite {
 	return &collectionBulkWrite{
 		useSimpleCollation: nonDefaultCollationSupport,
-		max:                size,
+		maxOpsSize:         size,
 		writes:             make(map[string][]mongo.WriteModel),
 	}
 }
 
 func (cbw *collectionBulkWrite) Full() bool {
-	return cbw.count == cbw.max || cbw.bytes >= maxBulkBytes
+	return cbw.count >= cbw.maxOpsSize || cbw.bytes >= config.MaxWriteBatchSizeBytes
 }
 
 func (cbw *collectionBulkWrite) Empty() bool {
 	return cbw.count == 0
+}
+
+func (cbw *collectionBulkWrite) WouldOverflow(estimate int) bool {
+	return cbw.count > 0 && cbw.bytes+estimate > config.MaxWriteBatchSizeBytes
 }
 
 func (cbw *collectionBulkWrite) Do(ctx context.Context, m *mongo.Client) (int, error) {
@@ -449,6 +470,8 @@ func (cbw *collectionBulkWrite) Insert(ns catalog.Namespace, event *InsertEvent)
 func (cbw *collectionBulkWrite) Update(ns catalog.Namespace, event *UpdateEvent) {
 	ops := collectUpdateOps(event)
 
+	filterLen := marshalLen(event.DocumentKey)
+
 	m := &mongo.UpdateOneModel{
 		Filter: event.DocumentKey,
 		Update: ops.primary,
@@ -460,9 +483,10 @@ func (cbw *collectionBulkWrite) Update(ns catalog.Namespace, event *UpdateEvent)
 
 	cbw.writes[ns.String()] = append(cbw.writes[ns.String()], m)
 	cbw.count++
-	cbw.bytes += estimateBytes(event.DocumentKey, ops.primary)
+	cbw.bytes += filterLen + marshalLen(ops.primary)
 
-	// Follow-up $set operations for fields split out due to BufBuilder limits.
+	// Follow-up $set/$unset operations for fields split out due to truncation path
+	// conflicts and BufBuilder limits.
 	for _, followUp := range ops.followUp {
 		fm := &mongo.UpdateOneModel{
 			Filter: event.DocumentKey,
@@ -475,7 +499,7 @@ func (cbw *collectionBulkWrite) Update(ns catalog.Namespace, event *UpdateEvent)
 
 		cbw.writes[ns.String()] = append(cbw.writes[ns.String()], fm)
 		cbw.count++
-		cbw.bytes += estimateBytes(event.DocumentKey, followUp)
+		cbw.bytes += filterLen + marshalLen(followUp)
 	}
 }
 
@@ -542,7 +566,7 @@ func handleDuplicateKeyError(ctx context.Context, coll *mongo.Collection, replac
 	log.Ctx(ctx).With(log.NS(coll.Database().Name(), coll.Name())).
 		Infof("Retrying with delete+insert fallback for _id: %v", docID)
 
-	_, err = coll.DeleteOne(ctx, bson.D{{"_id", docID}})
+	_, err = coll.DeleteOne(ctx, bson.D{{Key: "_id", Value: docID}})
 	if err != nil && !errors.Is(err, mongo.ErrNoDocuments) {
 		return errors.Wrap(err, "delete before insert")
 	}
@@ -565,9 +589,14 @@ func estimateBytes(filter, payload any) int {
 }
 
 // marshalLen returns the marshaled BSON length of v, or 0 if v is nil or marshaling fails.
+// Special-cases bson.Raw (already a complete BSON document) to avoid a redundant marshal.
 func marshalLen(v any) int {
 	if v == nil {
 		return 0
+	}
+
+	if r, ok := v.(bson.Raw); ok {
+		return len(r)
 	}
 
 	b, err := bson.Marshal(v)
@@ -578,19 +607,58 @@ func marshalLen(v any) int {
 	return len(b)
 }
 
+// estimateEventBytes returns the approximate BSON byte size that an event will contribute
+// to a bulk write. Used by the worker to preflight WouldOverflow before adding to the
+// current bulk so the byte cap is honored without ever appending past it.
+func estimateEventBytes(parsed any) int {
+	switch e := parsed.(type) {
+	case InsertEvent:
+		return estimateBytes(e.DocumentKey, e.FullDocument)
+	case ReplaceEvent:
+		return estimateBytes(e.DocumentKey, e.FullDocument)
+	case DeleteEvent:
+		return estimateBytes(e.DocumentKey, nil)
+	case UpdateEvent:
+		ops := collectUpdateOps(&e)
+
+		filterLen := marshalLen(e.DocumentKey)
+		total := filterLen + marshalLen(ops.primary)
+
+		for _, fu := range ops.followUp {
+			total += filterLen + marshalLen(fu)
+		}
+
+		return total
+	default:
+		return 0
+	}
+}
+
+// collectUpdateOps builds the update operations for a change stream UpdateEvent. When no
+// truncated array path conflicts with any updated or removed field, a single classic
+// update document is emitted in updateOps.primary. Otherwise it dispatches to
+// collectUpdateOpsWithConflicts to split conflicting writes into ordered follow-up updates.
 func collectUpdateOps(event *UpdateEvent) updateOps {
-	for _, trunc := range event.UpdateDescription.TruncatedArrays {
-		for _, update := range event.UpdateDescription.UpdatedFields {
-			if update.Key == trunc.Field || strings.HasPrefix(update.Key, trunc.Field+".") {
-				return collectUpdateOpsWithConflicts(event) // there is conflict field update
+	if len(event.UpdateDescription.TruncatedArrays) != 0 {
+		prefixes := truncatedPrefixes(event)
+
+		for _, u := range event.UpdateDescription.UpdatedFields {
+			if conflictsWithTruncation(u.Key, prefixes) {
+				return collectUpdateOpsWithConflicts(event, prefixes)
+			}
+		}
+
+		for _, rf := range event.UpdateDescription.RemovedFields {
+			if conflictsWithTruncation(rf, prefixes) {
+				return collectUpdateOpsWithConflicts(event, prefixes)
 			}
 		}
 	}
 
-	ops := make(bson.D, 0, 1)
+	ops := make(bson.D, 0, 3) //nolint:mnd
 
 	if len(event.UpdateDescription.UpdatedFields) != 0 {
-		ops = append(ops, bson.E{"$set", event.UpdateDescription.UpdatedFields})
+		ops = append(ops, bson.E{Key: "$set", Value: event.UpdateDescription.UpdatedFields})
 	}
 
 	if len(event.UpdateDescription.RemovedFields) != 0 {
@@ -600,35 +668,37 @@ func collectUpdateOps(event *UpdateEvent) updateOps {
 			fields[i].Value = 1
 		}
 
-		ops = append(ops, bson.E{"$unset", fields})
+		ops = append(ops, bson.E{Key: "$unset", Value: fields})
 	}
 
 	if len(event.UpdateDescription.TruncatedArrays) != 0 {
 		fields := make(bson.D, len(event.UpdateDescription.TruncatedArrays))
 		for i, field := range event.UpdateDescription.TruncatedArrays {
 			fields[i].Key = field.Field
-			fields[i].Value = bson.D{{"$each", bson.A{}}, {"$slice", field.NewSize}}
+			fields[i].Value = bson.D{{Key: "$each", Value: bson.A{}}, {Key: "$slice", Value: field.NewSize}}
 		}
 
-		ops = append(ops, bson.E{"$push", fields})
+		ops = append(ops, bson.E{Key: "$push", Value: fields})
 	}
 
 	return updateOps{primary: ops}
 }
 
 // collectUpdateOpsWithConflicts builds update operations for change events where one or
-// more updated fields target a path inside a truncated array (e.g. truncation of "arr"
-// together with a write to "arr.5"). MongoDB rejects an update document that combines a
-// $push (truncation) with a $set on the same array path, so the work is split across
-// multiple ordered update operations:
+// more updated fields or removed fields target a path inside a truncated array (e.g.
+// truncation of "arr" together with a write to "arr.5" or a removal of "arr.0.x"). MongoDB
+// rejects an update document that combines a $push (truncation) with a $set or $unset on
+// the same array path, so the work is split across multiple ordered update operations:
 //
-//	primary update:   $push (truncations) + $unset (removed) + $set (non-conflicting fields)
-//	follow-up update: $set (conflicting fields), chunked by maxBytesPerSetOp /
-//	                  maxFieldsPerSetOp to keep each individual update bounded
+//	primary update:   $push (truncations) + $unset (non-conflicting removed) +
+//	                  $set (non-conflicting updated)
+//	follow-up update: $set (conflicting updated) and $unset (conflicting removed),
+//	                  chunked by maxBytesPerSetOp / maxFieldsPerSetOp to keep each
+//	                  individual update bounded
 //
 // Splitting also bounds per-update work on the target side, keeping each update under
 // MongoDB's 125 MB BufBuilder ceiling (error 13548, PCSM-305).
-func collectUpdateOpsWithConflicts(event *UpdateEvent) updateOps {
+func collectUpdateOpsWithConflicts(event *UpdateEvent, prefixes []string) updateOps {
 	primary := make(bson.D, 0, 3) //nolint:mnd
 
 	// Truncations → $push: {field: {$each: [], $slice: NewSize}}.
@@ -642,71 +712,94 @@ func collectUpdateOpsWithConflicts(event *UpdateEvent) updateOps {
 		primary = append(primary, bson.E{Key: "$push", Value: fields})
 	}
 
-	// Removed fields → $unset.
-	if len(event.UpdateDescription.RemovedFields) != 0 {
-		fields := make(bson.D, len(event.UpdateDescription.RemovedFields))
-		for i, field := range event.UpdateDescription.RemovedFields {
-			fields[i].Key = field
-			fields[i].Value = 1
-		}
+	// Partition removed fields: non-conflicting → primary $unset; conflicting → follow-up.
+	var nonConflictingUnset, conflictingUnset bson.D
 
-		primary = append(primary, bson.E{Key: "$unset", Value: fields})
-	}
-
-	truncatedPrefixes := make([]string, 0, len(event.UpdateDescription.TruncatedArrays))
-	for _, ta := range event.UpdateDescription.TruncatedArrays {
-		truncatedPrefixes = append(truncatedPrefixes, ta.Field)
-	}
-
-	// Updated fields are partitioned into:
-	//  - nonConflicting: emitted in primary $set (no overlap with any truncated path).
-	//  - conflicting:    deferred to follow-up $set to avoid same-path $push+$set conflict.
-	var nonConflicting, conflicting bson.D
-
-	for _, field := range event.UpdateDescription.UpdatedFields {
-		if conflictsWithTruncation(field.Key, truncatedPrefixes) {
-			conflicting = append(conflicting, bson.E{Key: field.Key, Value: field.Value})
+	for _, field := range event.UpdateDescription.RemovedFields {
+		if conflictsWithTruncation(field, prefixes) {
+			conflictingUnset = append(conflictingUnset, bson.E{Key: field, Value: 1})
 
 			continue
 		}
 
-		nonConflicting = append(nonConflicting, bson.E{Key: field.Key, Value: field.Value})
+		nonConflictingUnset = append(nonConflictingUnset, bson.E{Key: field, Value: 1})
 	}
 
-	if len(nonConflicting) != 0 {
-		primary = append(primary, bson.E{Key: "$set", Value: nonConflicting})
+	if len(nonConflictingUnset) != 0 {
+		primary = append(primary, bson.E{Key: "$unset", Value: nonConflictingUnset})
 	}
 
-	// Follow-up $set ops carry only conflicting (array-index) fields. They are chunked
-	// by maxBytesPerSetOp / maxFieldsPerSetOp so each individual update is bounded - this
+	// Partition updated fields: non-conflicting → primary $set; conflicting → follow-up.
+	var nonConflictingSet, conflictingSet bson.D
+
+	for _, field := range event.UpdateDescription.UpdatedFields {
+		if conflictsWithTruncation(field.Key, prefixes) {
+			conflictingSet = append(conflictingSet, bson.E{Key: field.Key, Value: field.Value})
+
+			continue
+		}
+
+		nonConflictingSet = append(nonConflictingSet, bson.E{Key: field.Key, Value: field.Value})
+	}
+
+	if len(nonConflictingSet) != 0 {
+		primary = append(primary, bson.E{Key: "$set", Value: nonConflictingSet})
+	}
+
+	// Follow-up ops carry only conflicting (truncation-path) fields. They are chunked by
+	// maxBytesPerSetOp / maxFieldsPerSetOp so each individual update is bounded - this
 	// caps the per-update wire size and keeps target plan execution cheap. Each follow-up
 	// is a separate ordered update operation; MongoDB resets BufBuilder between operations.
 	var followUp []bson.D
 
+	followUp = appendFieldChunks(followUp, "$set", conflictingSet)
+	followUp = appendFieldChunks(followUp, "$unset", conflictingUnset)
+
+	return updateOps{primary: primary, followUp: followUp}
+}
+
+// truncatedPrefixes extracts the list of truncated array paths from an UpdateEvent so they
+// can be reused by both the dispatch check and the partitioning logic.
+func truncatedPrefixes(event *UpdateEvent) []string {
+	prefixes := make([]string, 0, len(event.UpdateDescription.TruncatedArrays))
+	for _, ta := range event.UpdateDescription.TruncatedArrays {
+		prefixes = append(prefixes, ta.Field)
+	}
+
+	return prefixes
+}
+
+// appendFieldChunks splits fields into bounded follow-up update documents, each carrying a
+// single op operator (e.g. "$set" or "$unset"). Chunks are bounded by maxBytesPerSetOp and
+// maxFieldsPerSetOp. Returns followUp with the new chunks appended.
+func appendFieldChunks(followUp []bson.D, op string, fields bson.D) []bson.D {
+	if len(fields) == 0 {
+		return followUp
+	}
+
 	chunkStart := 0
 	chunkBytes := 0
 
-	for i := range conflicting {
-		b, _ := bson.Marshal(bson.D{conflicting[i]})
-		chunkBytes += len(b)
+	for i := range fields {
+		chunkBytes += marshalLen(bson.D{fields[i]})
 
 		if chunkBytes >= maxBytesPerSetOp || (i-chunkStart+1) >= maxFieldsPerSetOp {
-			followUp = append(followUp, bson.D{{Key: "$set", Value: conflicting[chunkStart : i+1]}})
+			followUp = append(followUp, bson.D{{Key: op, Value: fields[chunkStart : i+1]}})
 			chunkStart = i + 1
 			chunkBytes = 0
 		}
 	}
 
-	if chunkStart < len(conflicting) {
-		followUp = append(followUp, bson.D{{Key: "$set", Value: conflicting[chunkStart:]}})
+	if chunkStart < len(fields) {
+		followUp = append(followUp, bson.D{{Key: op, Value: fields[chunkStart:]}})
 	}
 
-	return updateOps{primary: primary, followUp: followUp}
+	return followUp
 }
 
 // conflictsWithTruncation reports whether key is the same as, or a sub-path of, any
 // truncated-array path in prefixes. A conflict means the field cannot share an update
-// document with the truncation $push and must be deferred to a separate follow-up $set.
+// document with the truncation $push and must be deferred to a separate follow-up.
 func conflictsWithTruncation(key string, prefixes []string) bool {
 	for _, p := range prefixes {
 		if key == p || strings.HasPrefix(key, p+".") {

--- a/pcsm/repl/bulk.go
+++ b/pcsm/repl/bulk.go
@@ -713,7 +713,8 @@ func collectUpdateOpsWithConflicts(event *UpdateEvent, prefixes []string) update
 	}
 
 	// Partition removed fields: non-conflicting → primary $unset; conflicting → follow-up.
-	var nonConflictingUnset, conflictingUnset bson.D
+	nonConflictingUnset := make(bson.D, 0, len(event.UpdateDescription.RemovedFields))
+	conflictingUnset := make(bson.D, 0, len(event.UpdateDescription.RemovedFields))
 
 	for _, field := range event.UpdateDescription.RemovedFields {
 		if conflictsWithTruncation(field, prefixes) {
@@ -730,7 +731,8 @@ func collectUpdateOpsWithConflicts(event *UpdateEvent, prefixes []string) update
 	}
 
 	// Partition updated fields: non-conflicting → primary $set; conflicting → follow-up.
-	var nonConflictingSet, conflictingSet bson.D
+	nonConflictingSet := make(bson.D, 0, len(event.UpdateDescription.UpdatedFields))
+	conflictingSet := make(bson.D, 0, len(event.UpdateDescription.UpdatedFields))
 
 	for _, field := range event.UpdateDescription.UpdatedFields {
 		if conflictsWithTruncation(field.Key, prefixes) {

--- a/pcsm/repl/bulk.go
+++ b/pcsm/repl/bulk.go
@@ -3,7 +3,6 @@ package repl
 import (
 	"context"
 	"runtime"
-	"strconv"
 	"strings"
 	"sync/atomic"
 
@@ -34,30 +33,34 @@ var collectionBulkOptions = options.BulkWrite().
 	SetOrdered(true).
 	SetBypassDocumentValidation(false)
 
-// Pipeline $set operation limits to prevent MongoDB's BufBuilder overflow (error 13548).
-// MongoDB's BufBuilder accumulates across ALL stages within a single pipeline, so splitting
-// into multiple $set stages within one pipeline has no effect. Instead, when the batched $set
-// fields exceed these limits, they are emitted as separate standard (non-pipeline) updateOne
-// operations, each with its own BufBuilder. maxBytesPerSetOp is the primary guard;
-// maxFieldsPerSetOp is a secondary guard against degenerate cases with many tiny fields.
+// Update operation chunking limits to prevent MongoDB's 125 MB BufBuilder overflow (error
+// 13548) and to keep individual update payloads bounded. When a change event combines
+// truncations with conflicting array-index updates, the array-index updates are split off
+// into separate $set follow-up operations, each its own update with its own MongoDB-side
+// BufBuilder. maxBytesPerSetOp is the primary guard; maxFieldsPerSetOp is a secondary guard
+// against degenerate cases with many tiny fields.
+//
+// maxBulkBytes caps the aggregate wire size of a single bulk command, well under MongoDB's
+// 48 MB MaxMessageSizeBytes default. Combined with the per-update bounds above, this keeps
+// both individual operations and the bulk command within MongoDB's wire-protocol limits.
 const (
-	maxFieldsPerSetOp = 100        //nolint:mnd
-	maxBytesPerSetOp  = 512 * 1024 //nolint:mnd // 512KB
+	maxFieldsPerSetOp = 100              //nolint:mnd
+	maxBytesPerSetOp  = 512 * 1024       //nolint:mnd // 512 KiB
+	maxBulkBytes      = 32 * 1024 * 1024 //nolint:mnd // 32 MiB - well under 48 MB MaxMessageSizeBytes
 )
 
 // updateOps holds the result of building update operations from a change stream event.
-// When pipeline $set fields exceed size limits, they are split into follow-up standard
-// (non-pipeline) $set operations to prevent MongoDB's BufBuilder overflow (error 13548).
-// Follow-ups use standard $set (bson.D) because pipeline $set treats numeric path
-// components as document field names rather than array indices (e.g. "arr.0.d" in a
-// pipeline creates field "0" in each element instead of navigating to arr[0].d).
-// Standard $set correctly navigates array indices via dotted paths.
+// When a change event combines an array truncation with conflicting indexed-write updates,
+// the conflicting updates are split into follow-up $set operations so that no single update
+// document carries both a $push (truncation) and a $set on the same array path - which
+// MongoDB rejects as a path conflict - and so that no individual update accumulates enough
+// work to exhaust MongoDB's 125 MB BufBuilder ceiling (error 13548).
 type updateOps struct {
-	// primary is the main update: either bson.D (simple update) or bson.A (pipeline).
+	// primary is the main update document (bson.D).
 	primary any
-	// followUp contains additional standard $set operations for fields that were split
-	// out of the primary pipeline to avoid BufBuilder overflow. Each element is a
-	// standard update document (bson.D) with a single $set operator. nil when not needed.
+	// followUp contains additional $set operations for array-index updates that conflict
+	// with a truncation in the primary update. Each element is an update document (bson.D)
+	// with a single $set operator. nil when not needed.
 	followUp []bson.D
 }
 
@@ -74,6 +77,7 @@ type bulkWriter interface {
 
 type clientBulkWrite struct {
 	useSimpleCollation bool
+	bytes              int
 	writes             []mongo.ClientBulkWrite
 }
 
@@ -85,7 +89,7 @@ func newClientBulkWriter(size int, useSimpleCollation bool) *clientBulkWrite {
 }
 
 func (cbw *clientBulkWrite) Full() bool {
-	return len(cbw.writes) == cap(cbw.writes)
+	return len(cbw.writes) == cap(cbw.writes) || cbw.bytes >= maxBulkBytes
 }
 
 func (cbw *clientBulkWrite) Empty() bool {
@@ -102,6 +106,7 @@ func (cbw *clientBulkWrite) Do(ctx context.Context, m *mongo.Client) (int, error
 
 	clear(cbw.writes)
 	cbw.writes = cbw.writes[:0]
+	cbw.bytes = 0
 
 	return totalSize, nil
 }
@@ -201,6 +206,7 @@ func (cbw *clientBulkWrite) Insert(ns catalog.Namespace, event *InsertEvent) {
 	}
 
 	cbw.writes = append(cbw.writes, bw)
+	cbw.bytes += estimateBytes(event.DocumentKey, event.FullDocument)
 }
 
 func (cbw *clientBulkWrite) Update(ns catalog.Namespace, event *UpdateEvent) {
@@ -218,9 +224,10 @@ func (cbw *clientBulkWrite) Update(ns catalog.Namespace, event *UpdateEvent) {
 	cbw.writes = append(cbw.writes, mongo.ClientBulkWrite{
 		Database: ns.Database, Collection: ns.Collection, Model: m,
 	})
+	cbw.bytes += estimateBytes(event.DocumentKey, ops.primary)
 
-	// Follow-up standard $set operations for fields split out due to BufBuilder limits.
-	// Each is a separate updateOne (bson.D) so MongoDB resets its BufBuilder per operation.
+	// Follow-up $set operations for fields split out due to BufBuilder limits.
+	// Each is a separate updateOne so MongoDB resets its BufBuilder per operation.
 	// Ordered bulk writes guarantee sequential execution.
 	for _, followUp := range ops.followUp {
 		fm := &mongo.ClientUpdateOneModel{
@@ -235,6 +242,7 @@ func (cbw *clientBulkWrite) Update(ns catalog.Namespace, event *UpdateEvent) {
 		cbw.writes = append(cbw.writes, mongo.ClientBulkWrite{
 			Database: ns.Database, Collection: ns.Collection, Model: fm,
 		})
+		cbw.bytes += estimateBytes(event.DocumentKey, followUp)
 	}
 }
 
@@ -255,6 +263,7 @@ func (cbw *clientBulkWrite) Replace(ns catalog.Namespace, event *ReplaceEvent) {
 	}
 
 	cbw.writes = append(cbw.writes, bw)
+	cbw.bytes += estimateBytes(event.DocumentKey, event.FullDocument)
 }
 
 func (cbw *clientBulkWrite) Delete(ns catalog.Namespace, event *DeleteEvent) {
@@ -273,12 +282,14 @@ func (cbw *clientBulkWrite) Delete(ns catalog.Namespace, event *DeleteEvent) {
 	}
 
 	cbw.writes = append(cbw.writes, bw)
+	cbw.bytes += estimateBytes(event.DocumentKey, nil)
 }
 
 type collectionBulkWrite struct {
 	useSimpleCollation bool
 	max                int
 	count              int
+	bytes              int
 	writes             map[string][]mongo.WriteModel
 }
 
@@ -291,7 +302,7 @@ func newCollectionBulkWriter(size int, nonDefaultCollationSupport bool) *collect
 }
 
 func (cbw *collectionBulkWrite) Full() bool {
-	return cbw.count == cbw.max
+	return cbw.count == cbw.max || cbw.bytes >= maxBulkBytes
 }
 
 func (cbw *collectionBulkWrite) Empty() bool {
@@ -331,6 +342,7 @@ func (cbw *collectionBulkWrite) Do(ctx context.Context, m *mongo.Client) (int, e
 
 	clear(cbw.writes)
 	cbw.count = 0
+	cbw.bytes = 0
 
 	return int(total.Load()), nil
 }
@@ -431,6 +443,7 @@ func (cbw *collectionBulkWrite) Insert(ns catalog.Namespace, event *InsertEvent)
 	cbw.writes[ns.String()] = append(cbw.writes[ns.String()], m)
 
 	cbw.count++
+	cbw.bytes += estimateBytes(event.DocumentKey, event.FullDocument)
 }
 
 func (cbw *collectionBulkWrite) Update(ns catalog.Namespace, event *UpdateEvent) {
@@ -447,8 +460,9 @@ func (cbw *collectionBulkWrite) Update(ns catalog.Namespace, event *UpdateEvent)
 
 	cbw.writes[ns.String()] = append(cbw.writes[ns.String()], m)
 	cbw.count++
+	cbw.bytes += estimateBytes(event.DocumentKey, ops.primary)
 
-	// Follow-up standard $set operations for fields split out due to BufBuilder limits.
+	// Follow-up $set operations for fields split out due to BufBuilder limits.
 	for _, followUp := range ops.followUp {
 		fm := &mongo.UpdateOneModel{
 			Filter: event.DocumentKey,
@@ -461,6 +475,7 @@ func (cbw *collectionBulkWrite) Update(ns catalog.Namespace, event *UpdateEvent)
 
 		cbw.writes[ns.String()] = append(cbw.writes[ns.String()], fm)
 		cbw.count++
+		cbw.bytes += estimateBytes(event.DocumentKey, followUp)
 	}
 }
 
@@ -477,6 +492,7 @@ func (cbw *collectionBulkWrite) Replace(ns catalog.Namespace, event *ReplaceEven
 	cbw.writes[ns.String()] = append(cbw.writes[ns.String()], m)
 
 	cbw.count++
+	cbw.bytes += estimateBytes(event.DocumentKey, event.FullDocument)
 }
 
 func (cbw *collectionBulkWrite) Delete(ns catalog.Namespace, event *DeleteEvent) {
@@ -491,6 +507,7 @@ func (cbw *collectionBulkWrite) Delete(ns catalog.Namespace, event *DeleteEvent)
 	cbw.writes[ns.String()] = append(cbw.writes[ns.String()], m)
 
 	cbw.count++
+	cbw.bytes += estimateBytes(event.DocumentKey, nil)
 }
 
 // handleDuplicateKeyError handles a duplicate key error on ReplaceOne by performing delete+insert.
@@ -538,11 +555,34 @@ func handleDuplicateKeyError(ctx context.Context, coll *mongo.Collection, replac
 	return nil
 }
 
+// estimateBytes approximates the wire size contribution of a bulk write operation by
+// marshaling its filter and payload (update doc or replacement doc). Used as the per-bulk
+// byte budget signal for Full() to keep aggregate command size below MongoDB's
+// MaxMessageSizeBytes wire-protocol limit. Marshal errors yield a zero estimate, which is
+// fine because the count-based Full() condition still applies.
+func estimateBytes(filter, payload any) int {
+	return marshalLen(filter) + marshalLen(payload)
+}
+
+// marshalLen returns the marshaled BSON length of v, or 0 if v is nil or marshaling fails.
+func marshalLen(v any) int {
+	if v == nil {
+		return 0
+	}
+
+	b, err := bson.Marshal(v)
+	if err != nil {
+		return 0
+	}
+
+	return len(b)
+}
+
 func collectUpdateOps(event *UpdateEvent) updateOps {
 	for _, trunc := range event.UpdateDescription.TruncatedArrays {
 		for _, update := range event.UpdateDescription.UpdatedFields {
 			if update.Key == trunc.Field || strings.HasPrefix(update.Key, trunc.Field+".") {
-				return collectUpdateOpsWithPipeline(event) // there is conflict field update
+				return collectUpdateOpsWithConflicts(event) // there is conflict field update
 			}
 		}
 	}
@@ -576,165 +616,103 @@ func collectUpdateOps(event *UpdateEvent) updateOps {
 	return updateOps{primary: ops}
 }
 
-func collectUpdateOpsWithPipeline(event *UpdateEvent) updateOps {
-	s := len(event.UpdateDescription.UpdatedFields) +
-		len(event.UpdateDescription.RemovedFields) +
-		len(event.UpdateDescription.TruncatedArrays)
-	pipeline := make(bson.A, 0, s)
+// collectUpdateOpsWithConflicts builds update operations for change events where one or
+// more updated fields target a path inside a truncated array (e.g. truncation of "arr"
+// together with a write to "arr.5"). MongoDB rejects an update document that combines a
+// $push (truncation) with a $set on the same array path, so the work is split across
+// multiple ordered update operations:
+//
+//	primary update:   $push (truncations) + $unset (removed) + $set (non-conflicting fields)
+//	follow-up update: $set (conflicting fields), chunked by maxBytesPerSetOp /
+//	                  maxFieldsPerSetOp to keep each individual update bounded
+//
+// Splitting also bounds per-update work on the target side, keeping each update under
+// MongoDB's 125 MB BufBuilder ceiling (error 13548, PCSM-305).
+func collectUpdateOpsWithConflicts(event *UpdateEvent) updateOps {
+	primary := make(bson.D, 0, 3) //nolint:mnd
 
-	var dp map[string][]any
-
-	if event.UpdateDescription.DisambiguatedPaths != nil {
-		dp = make(map[string][]any, len(event.UpdateDescription.DisambiguatedPaths))
-		for _, path := range event.UpdateDescription.DisambiguatedPaths {
-			dp[path.Key] = path.Value.(bson.A) //nolint:forcetypeassert
+	// Truncations → $push: {field: {$each: [], $slice: NewSize}}.
+	if len(event.UpdateDescription.TruncatedArrays) != 0 {
+		fields := make(bson.D, len(event.UpdateDescription.TruncatedArrays))
+		for i, ta := range event.UpdateDescription.TruncatedArrays {
+			fields[i].Key = ta.Field
+			fields[i].Value = bson.D{{Key: "$each", Value: bson.A{}}, {Key: "$slice", Value: ta.NewSize}}
 		}
+
+		primary = append(primary, bson.E{Key: "$push", Value: fields})
 	}
 
-	truncatedFields := make(map[string]struct{}, len(event.UpdateDescription.TruncatedArrays))
+	// Removed fields → $unset.
+	if len(event.UpdateDescription.RemovedFields) != 0 {
+		fields := make(bson.D, len(event.UpdateDescription.RemovedFields))
+		for i, field := range event.UpdateDescription.RemovedFields {
+			fields[i].Key = field
+			fields[i].Value = 1
+		}
+
+		primary = append(primary, bson.E{Key: "$unset", Value: fields})
+	}
+
+	truncatedPrefixes := make([]string, 0, len(event.UpdateDescription.TruncatedArrays))
 	for _, ta := range event.UpdateDescription.TruncatedArrays {
-		truncatedFields[ta.Field] = struct{}{}
+		truncatedPrefixes = append(truncatedPrefixes, ta.Field)
 	}
 
-	// Handle truncated arrays
-	for _, truncation := range event.UpdateDescription.TruncatedArrays {
-		stage := bson.D{{Key: "$set", Value: bson.D{
-			{Key: truncation.Field, Value: bson.D{
-				{Key: "$slice", Value: bson.A{"$" + truncation.Field, truncation.NewSize}},
-			}},
-		}}}
-
-		pipeline = append(pipeline, stage)
-	}
-
-	// Handle updated fields
-	var nonArrayFields bson.D
+	// Updated fields are partitioned into:
+	//  - nonConflicting: emitted in primary $set (no overlap with any truncated path).
+	//  - conflicting:    deferred to follow-up $set to avoid same-path $push+$set conflict.
+	var nonConflicting, conflicting bson.D
 
 	for _, field := range event.UpdateDescription.UpdatedFields {
-		if !isArrayPath(field.Key, dp, truncatedFields) {
-			nonArrayFields = append(nonArrayFields, bson.E{Key: field.Key, Value: field.Value})
+		if conflictsWithTruncation(field.Key, truncatedPrefixes) {
+			conflicting = append(conflicting, bson.E{Key: field.Key, Value: field.Value})
 
 			continue
 		}
 
-		parts := strings.Split(field.Key, ".")
-		fieldName := strings.Join(parts[:len(parts)-1], ".")
-		fieldIdx, _ := strconv.Atoi(parts[len(parts)-1])
-		fieldExpr := "$" + fieldName
-
-		stage := bson.D{{
-			"$set", bson.D{
-				{fieldName, bson.D{
-					{"$concatArrays", bson.A{
-						bson.D{{"$slice", bson.A{fieldExpr, fieldIdx}}},
-						bson.A{field.Value},
-						bson.D{{
-							"$slice",
-							bson.A{fieldExpr, fieldIdx + 1, bson.D{{"$max", bson.A{1, bson.D{{"$size", fieldExpr}}}}}},
-						}},
-					}},
-				}},
-			},
-		}}
-
-		pipeline = append(pipeline, stage)
+		nonConflicting = append(nonConflicting, bson.E{Key: field.Key, Value: field.Value})
 	}
 
-	// Emit non-array $set fields as separate standard (non-pipeline) $set operations.
-	// They MUST NOT go into the primary pipeline for two reasons:
-	// 1. MongoDB's BufBuilder accumulates across ALL stages within a single pipeline,
-	//    so even a single $set stage with many large dotted-path values can overflow.
-	// 2. Pipeline $set treats numeric dotted-path components as document field names
-	//    rather than array indices (e.g. "arr.0.d" creates field "0" in each element
-	//    instead of navigating to arr[0].d). Standard $set handles this correctly.
-	// Fields are chunked by size/count to keep individual updates manageable.
+	if len(nonConflicting) != 0 {
+		primary = append(primary, bson.E{Key: "$set", Value: nonConflicting})
+	}
+
+	// Follow-up $set ops carry only conflicting (array-index) fields. They are chunked
+	// by maxBytesPerSetOp / maxFieldsPerSetOp so each individual update is bounded - this
+	// caps the per-update wire size and keeps target plan execution cheap. Each follow-up
+	// is a separate ordered update operation; MongoDB resets BufBuilder between operations.
 	var followUp []bson.D
 
 	chunkStart := 0
 	chunkBytes := 0
 
-	for i := range nonArrayFields {
-		b, _ := bson.Marshal(bson.D{nonArrayFields[i]})
+	for i := range conflicting {
+		b, _ := bson.Marshal(bson.D{conflicting[i]})
 		chunkBytes += len(b)
 
 		if chunkBytes >= maxBytesPerSetOp || (i-chunkStart+1) >= maxFieldsPerSetOp {
-			followUp = append(followUp, bson.D{{Key: "$set", Value: nonArrayFields[chunkStart : i+1]}})
+			followUp = append(followUp, bson.D{{Key: "$set", Value: conflicting[chunkStart : i+1]}})
 			chunkStart = i + 1
 			chunkBytes = 0
 		}
 	}
 
-	if chunkStart < len(nonArrayFields) {
-		followUp = append(followUp, bson.D{{Key: "$set", Value: nonArrayFields[chunkStart:]}})
+	if chunkStart < len(conflicting) {
+		followUp = append(followUp, bson.D{{Key: "$set", Value: conflicting[chunkStart:]}})
 	}
 
-	// Handle removed fields
-	if len(event.UpdateDescription.RemovedFields) != 0 {
-		pipeline = append(
-			pipeline,
-			bson.D{{Key: "$unset", Value: event.UpdateDescription.RemovedFields}},
-		)
-	}
-
-	return updateOps{primary: pipeline, followUp: followUp}
+	return updateOps{primary: primary, followUp: followUp}
 }
 
-// isArrayPath checks if the path is an path to an array index (e.g. "a.b.1").
-func isArrayPath(field string, disambiguatedPaths map[string][]any, truncatedFields map[string]struct{}) bool {
-	// Case 1: disambiguatedPaths[field] exists → check LAST component only
-	if path, ok := disambiguatedPaths[field]; ok {
-		if len(path) == 0 {
-			return false
-		}
-
-		lastComponent := path[len(path)-1]
-		switch lastComponent.(type) {
-		case int, int8, int16, int32, int64:
+// conflictsWithTruncation reports whether key is the same as, or a sub-path of, any
+// truncated-array path in prefixes. A conflict means the field cannot share an update
+// document with the truncation $push and must be deferred to a separate follow-up $set.
+func conflictsWithTruncation(key string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if key == p || strings.HasPrefix(key, p+".") {
 			return true
-		default:
-			return false
 		}
 	}
 
-	// Case 2: disambiguatedPaths is nil (MongoDB <6.1) → use truncatedFields only.
-	//
-	// Without disambiguatedPaths, a path like "arr.0.10" is ambiguous: "10" could be
-	// an array index (→ $concatArrays needed) or a document field name (→ standard $set).
-	// The previous depth heuristic (len > 2 → assume array index) caused data corruption
-	// for documents with numeric-string field names inside array elements.
-	//
-	// The only reliable indicator available without disambiguatedPaths is whether the
-	// direct parent path is in truncatedFields. $concatArrays is needed precisely when
-	// the truncated array is the direct parent of the updated index — e.g., "arr.5" when
-	// "arr" was truncated. For deeper paths like "arr.0.10", the parent "arr.0" was not
-	// truncated, so standard $set handles it correctly regardless of whether "10" is an
-	// index or a field name.
-	if disambiguatedPaths == nil {
-		parts := strings.Split(field, ".")
-		if len(parts) < 2 { //nolint:mnd
-			return false
-		}
-
-		// Check if last segment is numeric
-		_, err := strconv.Atoi(parts[len(parts)-1])
-		if err != nil {
-			return false
-		}
-
-		// Only use $concatArrays when the direct parent was truncated.
-		parentPath := strings.Join(parts[:len(parts)-1], ".")
-		_, ok := truncatedFields[parentPath]
-
-		return ok
-	}
-
-	// Case 3: disambiguatedPaths non-nil but field not in it → Atoi fallback (unambiguous)
-	parts := strings.Split(field, ".")
-	if len(parts) < 2 { //nolint:mnd
-		return false
-	}
-
-	_, err := strconv.Atoi(parts[len(parts)-1])
-
-	return err == nil
+	return false
 }

--- a/pcsm/repl/bulk_test.go
+++ b/pcsm/repl/bulk_test.go
@@ -126,7 +126,7 @@ func TestCollectUpdateOps(t *testing.T) {
 			},
 		},
 		{
-			name: "nested-in-array truncation conflict spills indexed writes (PCSM-305 shape)",
+			name: "truncation of nested array spills inside-truncated-array writes to follow-up",
 			event: &UpdateEvent{
 				UpdateDescription: UpdateDescription{
 					TruncatedArrays: []struct {
@@ -301,13 +301,12 @@ func TestCollectUpdateOpsWithConflicts_ChunksLargeFields(t *testing.T) {
 	assert.Len(t, gotKeys, numFields, "all fields must be preserved across follow-ups")
 }
 
-// TestCollectUpdateOpsWithConflicts_PCSM305CustomerShape is the regression test for the
-// customer's BufBuilder 125 MB target-side crash. The truncated array is nested inside
-// another array (groups.<idx>.items where groups is itself an array). The fix avoids
-// pipeline form entirely - the truncation goes to a primary classic $push and indexed
-// writes spill to follow-up classic $set ops, which correctly navigate dotted numeric
-// paths through arrays without exhausting BufBuilder.
-func TestCollectUpdateOpsWithConflicts_PCSM305CustomerShape(t *testing.T) {
+// TestCollectUpdateOpsWithConflicts_NestedArrayTruncation covers a truncated array
+// nested inside another array (groups.<idx>.items where groups is itself an array).
+// The truncation goes to a primary $push and indexed writes spill to follow-up $set
+// ops, which correctly navigate dotted numeric paths through arrays without exhausting
+// MongoDB's 125 MB BufBuilder.
+func TestCollectUpdateOpsWithConflicts_NestedArrayTruncation(t *testing.T) {
 	t.Parallel()
 
 	const numIndexed = 15

--- a/pcsm/repl/bulk_test.go
+++ b/pcsm/repl/bulk_test.go
@@ -527,7 +527,7 @@ func TestClientBulkWrite_FullAfterUpdateWithFollowUps(t *testing.T) {
 
 	// Build an UpdateEvent that produces primary + 2 follow-ups (3 ops total) so the
 	// total count after this Update is 2 + 3 = 5, past the count cap of 3.
-	conflicting := bson.D{}
+	conflicting := make(bson.D, 0, 2*maxFieldsPerSetOp)
 	for i := range 2 * maxFieldsPerSetOp { // 200 fields → 2 chunks of follow-ups
 		conflicting = append(conflicting, bson.E{Key: "arr." + strconv.Itoa(i), Value: i})
 	}
@@ -569,7 +569,7 @@ func TestCollectionBulkWrite_FullAfterUpdateWithFollowUps(t *testing.T) {
 
 	assert.False(t, cbw.Full(), "bulk should not be full at count=2 with cap=3")
 
-	conflicting := bson.D{}
+	conflicting := make(bson.D, 0, 2*maxFieldsPerSetOp)
 	for i := range 2 * maxFieldsPerSetOp {
 		conflicting = append(conflicting, bson.E{Key: "arr." + strconv.Itoa(i), Value: i})
 	}

--- a/pcsm/repl/bulk_test.go
+++ b/pcsm/repl/bulk_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/mongo-driver/v2/bson"
 
+	"github.com/percona/percona-clustersync-mongodb/config"
 	"github.com/percona/percona-clustersync-mongodb/pcsm/catalog"
 )
 
@@ -36,12 +37,7 @@ func TestCollectUpdateOps(t *testing.T) {
 				t.Helper()
 				assert.Empty(t, ops.followUp)
 
-				doc, ok := ops.primary.(bson.D)
-				if !ok {
-					t.Fatalf("expected primary bson.D, got %T", ops.primary)
-				}
-
-				keys := topLevelKeys(doc)
+				keys := topLevelKeys(ops.primary)
 				assert.Equal(t, []string{setOp}, keys)
 			},
 		},
@@ -56,12 +52,7 @@ func TestCollectUpdateOps(t *testing.T) {
 				t.Helper()
 				assert.Empty(t, ops.followUp)
 
-				doc, ok := ops.primary.(bson.D)
-				if !ok {
-					t.Fatalf("expected primary bson.D, got %T", ops.primary)
-				}
-
-				assert.Equal(t, []string{unsetOp}, topLevelKeys(doc))
+				assert.Equal(t, []string{unsetOp}, topLevelKeys(ops.primary))
 			},
 		},
 		{
@@ -80,12 +71,7 @@ func TestCollectUpdateOps(t *testing.T) {
 				t.Helper()
 				assert.Empty(t, ops.followUp)
 
-				doc, ok := ops.primary.(bson.D)
-				if !ok {
-					t.Fatalf("expected primary bson.D, got %T", ops.primary)
-				}
-
-				assertHasTruncationPush(t, doc, "arr", 3)
+				assertHasTruncationPush(t, ops.primary, "arr", 3)
 			},
 		},
 		{
@@ -107,15 +93,10 @@ func TestCollectUpdateOps(t *testing.T) {
 			assert: func(t *testing.T, ops updateOps) {
 				t.Helper()
 
-				doc, ok := ops.primary.(bson.D)
-				if !ok {
-					t.Fatalf("expected primary bson.D, got %T", ops.primary)
-				}
-
 				// Primary must hold $push (truncation) and $set (non-conflicting).
-				assertHasTruncationPush(t, doc, "arr", 3)
+				assertHasTruncationPush(t, ops.primary, "arr", 3)
 
-				primarySet := findSetDoc(t, doc)
+				primarySet := findSetDoc(t, ops.primary)
 				assert.Equal(t, bson.D{{Key: "meta", Value: "Y"}}, primarySet,
 					"non-conflicting field 'meta' must remain in primary $set")
 
@@ -146,14 +127,9 @@ func TestCollectUpdateOps(t *testing.T) {
 			assert: func(t *testing.T, ops updateOps) {
 				t.Helper()
 
-				doc, ok := ops.primary.(bson.D)
-				if !ok {
-					t.Fatalf("expected primary bson.D, got %T", ops.primary)
-				}
+				assertHasTruncationPush(t, ops.primary, "groups.4.items", 1000)
 
-				assertHasTruncationPush(t, doc, "groups.4.items", 1000)
-
-				primarySet := findSetDoc(t, doc)
+				primarySet := findSetDoc(t, ops.primary)
 				gotKeys := setKeys(primarySet)
 				// signature and groups.4.count do not conflict with truncation.
 				assert.ElementsMatch(t, []string{"signature", "groups.4.count"}, gotKeys)
@@ -186,12 +162,7 @@ func TestCollectUpdateOps(t *testing.T) {
 				assert.Empty(t, ops.followUp,
 					"items_count must not be treated as conflict with truncated 'items'")
 
-				doc, ok := ops.primary.(bson.D)
-				if !ok {
-					t.Fatalf("expected primary bson.D, got %T", ops.primary)
-				}
-
-				primarySet := findSetDoc(t, doc)
+				primarySet := findSetDoc(t, ops.primary)
 				assert.Equal(t, []string{"items_count"}, setKeys(primarySet))
 			},
 		},
@@ -236,16 +207,11 @@ func TestCollectUpdateOpsWithConflicts_ChunksConflictingFields(t *testing.T) {
 		},
 	}
 
-	ops := collectUpdateOpsWithConflicts(event)
+	ops := collectUpdateOpsWithConflicts(event, truncatedPrefixes(event))
 
 	// Primary should have just $push (truncation), no $set (no non-conflicting fields).
-	doc, ok := ops.primary.(bson.D)
-	if !ok {
-		t.Fatalf("expected primary bson.D, got %T", ops.primary)
-	}
-
-	assertHasTruncationPush(t, doc, "arr", int32(numIndexed))
-	assert.Empty(t, findSetDoc(t, doc), "no non-conflicting $set fields expected")
+	assertHasTruncationPush(t, ops.primary, "arr", int32(numIndexed))
+	assert.Empty(t, findSetDoc(t, ops.primary), "no non-conflicting $set fields expected")
 
 	// All conflicting fields must spill to follow-ups, chunked by count.
 	expectedFollowUps := (numIndexed + maxFieldsPerSetOp - 1) / maxFieldsPerSetOp
@@ -286,7 +252,7 @@ func TestCollectUpdateOpsWithConflicts_ChunksLargeFields(t *testing.T) {
 		},
 	}
 
-	ops := collectUpdateOpsWithConflicts(event)
+	ops := collectUpdateOpsWithConflicts(event, truncatedPrefixes(event))
 
 	// 100 × 20 KB = 2 MB total; maxBytesPerSetOp is 512 KiB → ~4 follow-up chunks.
 	assert.NotEmpty(t, ops.followUp)
@@ -335,16 +301,11 @@ func TestCollectUpdateOpsWithConflicts_NestedArrayTruncation(t *testing.T) {
 		},
 	}
 
-	ops := collectUpdateOpsWithConflicts(event)
+	ops := collectUpdateOpsWithConflicts(event, truncatedPrefixes(event))
 
-	doc, ok := ops.primary.(bson.D)
-	if !ok {
-		t.Fatalf("expected primary bson.D (classic update), got %T", ops.primary)
-	}
+	assertHasTruncationPush(t, ops.primary, "groups.4.items", 1000)
 
-	assertHasTruncationPush(t, doc, "groups.4.items", 1000)
-
-	primarySet := findSetDoc(t, doc)
+	primarySet := findSetDoc(t, ops.primary)
 	primaryKeys := setKeys(primarySet)
 	assert.ElementsMatch(t, []string{"signature", "updated_at", "groups.4.count"}, primaryKeys)
 
@@ -382,9 +343,10 @@ func TestClientBulkWrite_FullByBytes(t *testing.T) {
 		}
 	}
 
-	assert.True(t, cbw.Full(), "Full() must be true after exceeding maxBulkBytes")
+	assert.True(t, cbw.Full(), "Full() must be true after exceeding byte budget")
 	assert.Less(t, len(cbw.writes), 10_000, "Full() must trigger before reaching count cap")
-	assert.GreaterOrEqual(t, cbw.bytes, maxBulkBytes, "byte counter must have reached maxBulkBytes")
+	assert.GreaterOrEqual(t, cbw.bytes, config.MaxWriteBatchSizeBytes,
+		"byte counter must have reached the byte budget")
 }
 
 // TestCollectionBulkWrite_FullByBytes mirrors the client-bulk byte budget test for the
@@ -413,9 +375,10 @@ func TestCollectionBulkWrite_FullByBytes(t *testing.T) {
 		}
 	}
 
-	assert.True(t, cbw.Full(), "Full() must be true after exceeding maxBulkBytes")
+	assert.True(t, cbw.Full(), "Full() must be true after exceeding byte budget")
 	assert.Less(t, cbw.count, 10_000, "Full() must trigger before reaching count cap")
-	assert.GreaterOrEqual(t, cbw.bytes, maxBulkBytes, "byte counter must have reached maxBulkBytes")
+	assert.GreaterOrEqual(t, cbw.bytes, config.MaxWriteBatchSizeBytes,
+		"byte counter must have reached the byte budget")
 }
 
 // TestClientBulkWrite_FullByCount preserves the existing count-based Full() behavior for
@@ -439,7 +402,8 @@ func TestClientBulkWrite_FullByCount(t *testing.T) {
 	}
 
 	assert.True(t, cbw.Full(), "Full() must be true at count cap")
-	assert.Less(t, cbw.bytes, maxBulkBytes, "byte counter must be well below maxBulkBytes")
+	assert.Less(t, cbw.bytes, config.MaxWriteBatchSizeBytes,
+		"byte counter must be well below the byte budget")
 }
 
 // TestCollectionBulkWrite_FullByCount preserves the count-based Full() behavior.
@@ -462,7 +426,299 @@ func TestCollectionBulkWrite_FullByCount(t *testing.T) {
 	}
 
 	assert.True(t, cbw.Full(), "Full() must be true at count cap")
-	assert.Less(t, cbw.bytes, maxBulkBytes, "byte counter must be well below maxBulkBytes")
+	assert.Less(t, cbw.bytes, config.MaxWriteBatchSizeBytes,
+		"byte counter must be well below the byte budget")
+}
+
+// TestCollectUpdateOps_TruncationWithRemovedFieldOnSamePathSpills (issue #1) verifies that
+// a removed field whose path equals or is nested under a truncated array spills to a
+// follow-up $unset operation rather than colliding with $push in the primary update
+// document. MongoDB rejects update docs that combine $push and $unset on overlapping paths
+// with "Updating the path '...' would create a conflict at '...'".
+func TestCollectUpdateOps_TruncationWithRemovedFieldOnSamePathSpills(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		removedFields    []string
+		wantPrimaryUnset []string // fields expected in primary $unset (non-conflicting)
+		wantFollowUpKeys []string // fields expected in follow-up $unset (conflicting)
+	}{
+		{
+			name:             "sub-path of truncated array",
+			removedFields:    []string{"arr.0.x", "other"},
+			wantPrimaryUnset: []string{"other"},
+			wantFollowUpKeys: []string{"arr.0.x"},
+		},
+		{
+			name:             "exact truncated path",
+			removedFields:    []string{"arr"},
+			wantPrimaryUnset: nil,
+			wantFollowUpKeys: []string{"arr"},
+		},
+		{
+			name:             "multiple conflicting and one non-conflicting",
+			removedFields:    []string{"arr.5.field", "arr.7", "meta"},
+			wantPrimaryUnset: []string{"meta"},
+			wantFollowUpKeys: []string{"arr.5.field", "arr.7"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			event := &UpdateEvent{
+				UpdateDescription: UpdateDescription{
+					TruncatedArrays: []struct {
+						Field   string `bson:"field"`
+						NewSize int32  `bson:"newSize"`
+					}{
+						{Field: "arr", NewSize: 5},
+					},
+					RemovedFields: tt.removedFields,
+				},
+			}
+
+			ops := collectUpdateOps(event)
+
+			// Primary must always carry $push for the truncation.
+			assertHasTruncationPush(t, ops.primary, "arr", 5)
+
+			// Primary $unset (if any) must contain only non-conflicting paths.
+			primaryUnset := findUnsetDoc(t, ops.primary)
+			gotPrimary := setKeys(primaryUnset)
+			assert.ElementsMatch(t, tt.wantPrimaryUnset, gotPrimary,
+				"primary $unset must contain only non-conflicting fields")
+
+			// Follow-up must carry the conflicting $unset paths.
+			gotFollowUp := collectFollowUpUnsetKeys(t, ops.followUp)
+			assert.ElementsMatch(t, tt.wantFollowUpKeys, gotFollowUp,
+				"conflicting removed fields must spill to follow-up $unset")
+
+			// Sanity: the primary update doc must not simultaneously contain $push for "arr"
+			// and $unset for any path under "arr" — that's the conflict the fix prevents.
+			for _, primaryKey := range gotPrimary {
+				assert.False(t, primaryKey == "arr" || strings.HasPrefix(primaryKey, "arr."),
+					"primary $unset must not include path %q overlapping truncation 'arr'", primaryKey)
+			}
+		})
+	}
+}
+
+// TestClientBulkWrite_FullAfterUpdateWithFollowUps (issue #2) verifies that Full() honors
+// the count cap even after Update appends primary + multiple follow-ups, which can grow
+// the underlying slice past its initial cap.
+func TestClientBulkWrite_FullAfterUpdateWithFollowUps(t *testing.T) {
+	t.Parallel()
+
+	cbw := newClientBulkWriter(3, false)
+	ns := catalog.Namespace{Database: "db", Collection: "c"}
+
+	// Two single-op inserts: count = 2.
+	for i := range 2 {
+		cbw.Insert(ns, &InsertEvent{
+			DocumentKey:  bson.D{{Key: "_id", Value: i}},
+			FullDocument: bson.Raw(mustMarshal(t, bson.D{{Key: "_id", Value: i}})),
+		})
+	}
+
+	assert.False(t, cbw.Full(), "bulk should not be full at count=2 with cap=3")
+
+	// Build an UpdateEvent that produces primary + 2 follow-ups (3 ops total) so the
+	// total count after this Update is 2 + 3 = 5, past the count cap of 3.
+	conflicting := bson.D{}
+	for i := range 2 * maxFieldsPerSetOp { // 200 fields → 2 chunks of follow-ups
+		conflicting = append(conflicting, bson.E{Key: "arr." + strconv.Itoa(i), Value: i})
+	}
+
+	event := &UpdateEvent{
+		DocumentKey: bson.D{{Key: "_id", Value: 99}},
+		UpdateDescription: UpdateDescription{
+			TruncatedArrays: []struct {
+				Field   string `bson:"field"`
+				NewSize int32  `bson:"newSize"`
+			}{
+				{Field: "arr", NewSize: 1000},
+			},
+			UpdatedFields: conflicting,
+		},
+	}
+
+	cbw.Update(ns, event)
+
+	assert.True(t, cbw.Full(), "Full() must be true after Update appended past count cap")
+	assert.Greater(t, len(cbw.writes), cbw.maxOpsSize,
+		"Update must have grown the slice past its initial cap")
+}
+
+// TestCollectionBulkWrite_FullAfterUpdateWithFollowUps mirrors the client-bulk variant
+// for the collection-level path.
+func TestCollectionBulkWrite_FullAfterUpdateWithFollowUps(t *testing.T) {
+	t.Parallel()
+
+	cbw := newCollectionBulkWriter(3, false)
+	ns := catalog.Namespace{Database: "db", Collection: "c"}
+
+	for i := range 2 {
+		cbw.Insert(ns, &InsertEvent{
+			DocumentKey:  bson.D{{Key: "_id", Value: i}},
+			FullDocument: bson.Raw(mustMarshal(t, bson.D{{Key: "_id", Value: i}})),
+		})
+	}
+
+	assert.False(t, cbw.Full(), "bulk should not be full at count=2 with cap=3")
+
+	conflicting := bson.D{}
+	for i := range 2 * maxFieldsPerSetOp {
+		conflicting = append(conflicting, bson.E{Key: "arr." + strconv.Itoa(i), Value: i})
+	}
+
+	event := &UpdateEvent{
+		DocumentKey: bson.D{{Key: "_id", Value: 99}},
+		UpdateDescription: UpdateDescription{
+			TruncatedArrays: []struct {
+				Field   string `bson:"field"`
+				NewSize int32  `bson:"newSize"`
+			}{
+				{Field: "arr", NewSize: 1000},
+			},
+			UpdatedFields: conflicting,
+		},
+	}
+
+	cbw.Update(ns, event)
+
+	assert.True(t, cbw.Full(), "Full() must be true after Update appended past count cap")
+	assert.Greater(t, cbw.count, cbw.maxOpsSize,
+		"Update must have pushed count past max")
+}
+
+// TestBulkWriter_WouldOverflowPreflight (issue #3) verifies the byte-budget preflight:
+// WouldOverflow returns true when adding the estimate would push past config.MaxWriteBatchSizeBytes,
+// returns false when the bulk is empty (so a single oversized event still proceeds), and
+// returns false when the estimate fits.
+func TestBulkWriter_WouldOverflowPreflight(t *testing.T) {
+	t.Parallel()
+
+	t.Run("client bulk", func(t *testing.T) {
+		t.Parallel()
+
+		cbw := newClientBulkWriter(10_000, false)
+
+		// Empty bulk: WouldOverflow must always be false even for huge estimates so a
+		// single oversized event can still be sent on its own bulk.
+		assert.False(t, cbw.WouldOverflow(2*config.MaxWriteBatchSizeBytes),
+			"empty bulk must accept any estimate")
+
+		// Fill close to the byte cap.
+		ns := catalog.Namespace{Database: "db", Collection: "c"}
+		largeValue := strings.Repeat("X", 1024*1024)
+
+		for i := range 30 {
+			raw := bson.Raw(mustMarshal(t,
+				bson.D{{Key: "_id", Value: i}, {Key: "blob", Value: largeValue}}))
+			cbw.Insert(ns, &InsertEvent{
+				DocumentKey:  bson.D{{Key: "_id", Value: i}},
+				FullDocument: raw,
+			})
+		}
+
+		// A small estimate must fit.
+		assert.False(t, cbw.WouldOverflow(1024),
+			"small estimate must not trigger overflow")
+
+		// A large estimate that pushes past the cap must trigger overflow.
+		remaining := config.MaxWriteBatchSizeBytes - cbw.bytes
+		assert.True(t, cbw.WouldOverflow(remaining+1),
+			"estimate exceeding remaining budget must trigger overflow")
+	})
+
+	t.Run("collection bulk", func(t *testing.T) {
+		t.Parallel()
+
+		cbw := newCollectionBulkWriter(10_000, false)
+
+		assert.False(t, cbw.WouldOverflow(2*config.MaxWriteBatchSizeBytes),
+			"empty bulk must accept any estimate")
+
+		ns := catalog.Namespace{Database: "db", Collection: "c"}
+		largeValue := strings.Repeat("X", 1024*1024)
+
+		for i := range 30 {
+			raw := bson.Raw(mustMarshal(t,
+				bson.D{{Key: "_id", Value: i}, {Key: "blob", Value: largeValue}}))
+			cbw.Insert(ns, &InsertEvent{
+				DocumentKey:  bson.D{{Key: "_id", Value: i}},
+				FullDocument: raw,
+			})
+		}
+
+		assert.False(t, cbw.WouldOverflow(1024),
+			"small estimate must not trigger overflow")
+
+		remaining := config.MaxWriteBatchSizeBytes - cbw.bytes
+		assert.True(t, cbw.WouldOverflow(remaining+1),
+			"estimate exceeding remaining budget must trigger overflow")
+	})
+}
+
+// mustMarshal marshals v with bson.Marshal or fails the test on error.
+func mustMarshal(t *testing.T, v any) []byte {
+	t.Helper()
+
+	b, err := bson.Marshal(v)
+	if err != nil {
+		t.Fatalf("bson.Marshal: %v", err)
+	}
+
+	return b
+}
+
+// findUnsetDoc returns the $unset sub-document from a classic update doc, or nil if absent.
+func findUnsetDoc(t *testing.T, doc bson.D) bson.D {
+	t.Helper()
+
+	for _, elem := range doc {
+		if elem.Key != unsetOp {
+			continue
+		}
+
+		unsetDoc, ok := elem.Value.(bson.D)
+		if !ok {
+			t.Fatalf("$unset value is not bson.D: %T", elem.Value)
+		}
+
+		return unsetDoc
+	}
+
+	return nil
+}
+
+// collectFollowUpUnsetKeys returns every $unset key across follow-up updates in source order.
+func collectFollowUpUnsetKeys(t *testing.T, followUp []bson.D) []string {
+	t.Helper()
+
+	keys := make([]string, 0)
+
+	for _, fu := range followUp {
+		for _, elem := range fu {
+			if elem.Key != unsetOp {
+				continue
+			}
+
+			unsetDoc, ok := elem.Value.(bson.D)
+			if !ok {
+				t.Fatalf("$unset value is not bson.D: %T", elem.Value)
+			}
+
+			for _, f := range unsetDoc {
+				keys = append(keys, f.Key)
+			}
+		}
+	}
+
+	return keys
 }
 
 // topLevelKeys returns the top-level keys of a classic update document in source order.

--- a/pcsm/repl/bulk_test.go
+++ b/pcsm/repl/bulk_test.go
@@ -311,11 +311,12 @@ func TestCollectUpdateOpsWithConflicts_NestedArrayTruncation(t *testing.T) {
 
 	const numIndexed = 15
 
-	updatedFields := bson.D{
-		{Key: "signature", Value: "sig"},
-		{Key: "updated_at", Value: "now"},
-		{Key: "groups.4.count", Value: 1000},
-	}
+	updatedFields := make(bson.D, 0, 3+numIndexed)
+	updatedFields = append(updatedFields,
+		bson.E{Key: "signature", Value: "sig"},
+		bson.E{Key: "updated_at", Value: "now"},
+		bson.E{Key: "groups.4.count", Value: 1000},
+	)
 
 	for i := range numIndexed {
 		key := "groups.4.items." + strconv.Itoa(985+i)

--- a/pcsm/repl/bulk_test.go
+++ b/pcsm/repl/bulk_test.go
@@ -7,230 +7,193 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/mongo-driver/v2/bson"
+
+	"github.com/percona/percona-clustersync-mongodb/pcsm/catalog"
 )
 
-const setOp = "$set"
-
-func TestIsArrayPath(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name  string
-		field string
-		dp    map[string][]any
-		tf    map[string]struct{}
-		want  bool
-	}{
-		{
-			name:  "dp nil: depth 2 numeric path returns false",
-			field: "a.1",
-			dp:    nil,
-			tf:    nil,
-			want:  false,
-		},
-		{
-			name:  "dp nil: another depth 2 numeric path returns false",
-			field: "f2.1",
-			dp:    nil,
-			tf:    nil,
-			want:  false,
-		},
-		{
-			name:  "dp present, field not in dp, Atoi true",
-			field: "a.b.1",
-			dp:    map[string][]any{"a.b": {"c", "d"}},
-			tf:    nil,
-			want:  true,
-		},
-		{
-			name:  "dp present, field exists, last is integer",
-			field: "a.22.1",
-			dp:    map[string][]any{"a.22.1": {"a", "22", 1}},
-			tf:    nil,
-			want:  true,
-		},
-		{
-			name:  "dp present, field exists, last is string",
-			field: "a.b.22",
-			dp:    map[string][]any{"a.b.22": {"a", "b", "22"}},
-			tf:    nil,
-			want:  false,
-		},
-		{
-			name:  "dp present, field exists, last component is integer",
-			field: "arr.2",
-			dp:    map[string][]any{"arr.2": {"arr", 2}},
-			tf:    nil,
-			want:  true,
-		},
-		{
-			name:  "dp present, field exists, interior int but last string",
-			field: "f2.0.2.0",
-			dp:    map[string][]any{"f2.0.2.0": {"f2", "0", 2, "0"}},
-			tf:    nil,
-			want:  false,
-		},
-		{
-			name:  "single segment",
-			field: "field",
-			dp:    nil,
-			tf:    nil,
-			want:  false,
-		},
-		{
-			name:  "dp present, field exists, empty path",
-			field: "x.0",
-			dp:    map[string][]any{"x.0": {}},
-			tf:    nil,
-			want:  false,
-		},
-		{
-			name:  "dp present, field not in dp, Atoi false",
-			field: "a.b.x",
-			dp:    map[string][]any{"other": {"x"}},
-			tf:    nil,
-			want:  false,
-		},
-		{
-			name:  "dp nil, truncated parent: real array index",
-			field: "a.2",
-			dp:    nil,
-			tf:    map[string]struct{}{"a": {}},
-			want:  true,
-		},
-		{
-			name:  "dp nil, depth 2 non-truncated parent: returns false",
-			field: "f2.0",
-			dp:    nil,
-			tf:    map[string]struct{}{"a": {}},
-			want:  false,
-		},
-		{
-			// "a.2.b.3": last="3" numeric, direct parent="a.2.b" not in truncatedFields
-			// → standard $set (no $concatArrays needed; only direct parent matters)
-			name:  "dp nil, deeply nested: direct parent not truncated returns false",
-			field: "a.2.b.3",
-			dp:    nil,
-			tf:    map[string]struct{}{"a": {}},
-			want:  false,
-		},
-		{
-			name:  "dp nil, nested truncated parent: real array index",
-			field: "f2.0.3",
-			dp:    nil,
-			tf:    map[string]struct{}{"f2.0": {}},
-			want:  true,
-		},
-		{
-			name:  "dp nil, empty truncatedFields: depth 2 returns false",
-			field: "a.1",
-			dp:    nil,
-			tf:    map[string]struct{}{},
-			want:  false,
-		},
-		{
-			// "arr.0.10": last="10" numeric, direct parent="arr.0" not in truncatedFields
-			// ("arr" is truncated but "arr.0" is not) → standard $set to avoid data corruption
-			// from misidentifying "10" (a document field name) as an array index.
-			// This is the slice_zero scenario on MongoDB <6.1 without disambiguatedPaths.
-			name:  "dp nil, slice_zero scenario: numeric string field name not direct parent",
-			field: "arr.0.10",
-			dp:    nil,
-			tf:    map[string]struct{}{"arr": {}},
-			want:  false,
-		},
-		{
-			// "arr.0": last="0" numeric, direct parent="arr" IS in truncatedFields
-			// → $concatArrays needed (genuine array element replacement under truncated array)
-			name:  "dp nil, direct array element under truncated array returns true",
-			field: "arr.0",
-			dp:    nil,
-			tf:    map[string]struct{}{"arr": {}},
-			want:  true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			got := isArrayPath(tt.field, tt.dp, tt.tf)
-			if got != tt.want {
-				t.Errorf("isArrayPath(%q, %v, %v) = %v, want %v", tt.field, tt.dp, tt.tf, got, tt.want)
-			}
-		})
-	}
-}
+const (
+	setOp   = "$set"
+	pushOp  = "$push"
+	unsetOp = "$unset"
+)
 
 func TestCollectUpdateOps(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name                  string
-		event                 *UpdateEvent
-		expectPipeline        bool
-		expectConcatArraysFor []string // Fields that should use $concatArrays
-		expectSimpleSetFor    []string // Fields that should use simple $set
+		name   string
+		event  *UpdateEvent
+		assert func(t *testing.T, ops updateOps)
 	}{
 		{
-			name: "dp nil: truncated parent uses $concatArrays, depth 2 uses $set",
+			name: "simple $set with no truncation produces a single classic update",
+			event: &UpdateEvent{
+				UpdateDescription: UpdateDescription{
+					UpdatedFields: bson.D{{Key: "a", Value: 1}, {Key: "b.c", Value: 2}},
+				},
+			},
+			assert: func(t *testing.T, ops updateOps) {
+				t.Helper()
+				assert.Empty(t, ops.followUp)
+
+				doc, ok := ops.primary.(bson.D)
+				if !ok {
+					t.Fatalf("expected primary bson.D, got %T", ops.primary)
+				}
+
+				keys := topLevelKeys(doc)
+				assert.Equal(t, []string{setOp}, keys)
+			},
+		},
+		{
+			name: "removed fields produce $unset",
+			event: &UpdateEvent{
+				UpdateDescription: UpdateDescription{
+					RemovedFields: []string{"x", "y.z"},
+				},
+			},
+			assert: func(t *testing.T, ops updateOps) {
+				t.Helper()
+				assert.Empty(t, ops.followUp)
+
+				doc, ok := ops.primary.(bson.D)
+				if !ok {
+					t.Fatalf("expected primary bson.D, got %T", ops.primary)
+				}
+
+				assert.Equal(t, []string{unsetOp}, topLevelKeys(doc))
+			},
+		},
+		{
+			name: "truncation alone produces classic $push with $each:[]/$slice",
 			event: &UpdateEvent{
 				UpdateDescription: UpdateDescription{
 					TruncatedArrays: []struct {
 						Field   string `bson:"field"`
 						NewSize int32  `bson:"newSize"`
 					}{
-						{Field: "a1", NewSize: 3},
+						{Field: "arr", NewSize: 3},
 					},
-					UpdatedFields: bson.D{
-						{Key: "a1.2", Value: "X"},
-						{Key: "f2.1", Value: "Y"},
-					},
-					DisambiguatedPaths: nil, // MongoDB 6.0
 				},
 			},
-			expectPipeline:        true,
-			expectConcatArraysFor: []string{"a1"},
-			expectSimpleSetFor:    []string{"f2.1"},
+			assert: func(t *testing.T, ops updateOps) {
+				t.Helper()
+				assert.Empty(t, ops.followUp)
+
+				doc, ok := ops.primary.(bson.D)
+				if !ok {
+					t.Fatalf("expected primary bson.D, got %T", ops.primary)
+				}
+
+				assertHasTruncationPush(t, doc, "arr", 3)
+			},
 		},
 		{
-			name: "dp present: confirmed array uses $concatArrays",
+			name: "truncation conflict splits indexed write into follow-up $set",
 			event: &UpdateEvent{
 				UpdateDescription: UpdateDescription{
 					TruncatedArrays: []struct {
 						Field   string `bson:"field"`
 						NewSize int32  `bson:"newSize"`
 					}{
-						{Field: "a1", NewSize: 3},
+						{Field: "arr", NewSize: 3},
 					},
 					UpdatedFields: bson.D{
-						{Key: "a1.2", Value: "X"},
-						{Key: "f2.1", Value: "Y"},
-					},
-					DisambiguatedPaths: bson.D{
-						{Key: "a1.2", Value: bson.A{"a1", 2}},
+						{Key: "arr.2", Value: "X"},
+						{Key: "meta", Value: "Y"},
 					},
 				},
 			},
-			expectPipeline:        true,
-			expectConcatArraysFor: []string{"a1", "f2"},
-			expectSimpleSetFor:    []string{},
+			assert: func(t *testing.T, ops updateOps) {
+				t.Helper()
+
+				doc, ok := ops.primary.(bson.D)
+				if !ok {
+					t.Fatalf("expected primary bson.D, got %T", ops.primary)
+				}
+
+				// Primary must hold $push (truncation) and $set (non-conflicting).
+				assertHasTruncationPush(t, doc, "arr", 3)
+
+				primarySet := findSetDoc(t, doc)
+				assert.Equal(t, bson.D{{Key: "meta", Value: "Y"}}, primarySet,
+					"non-conflicting field 'meta' must remain in primary $set")
+
+				// arr.2 conflicts with truncation 'arr', must spill to follow-up.
+				followUpKeys := collectFollowUpKeys(t, ops.followUp)
+				assert.Equal(t, []string{"arr.2"}, followUpKeys,
+					"conflicting field 'arr.2' must be in follow-up $set")
+			},
 		},
 		{
-			name: "dp present: string key uses $set",
+			name: "nested-in-array truncation conflict spills indexed writes (PCSM-305 shape)",
 			event: &UpdateEvent{
 				UpdateDescription: UpdateDescription{
-					UpdatedFields: bson.D{
-						{Key: "f2.1", Value: "Y"},
+					TruncatedArrays: []struct {
+						Field   string `bson:"field"`
+						NewSize int32  `bson:"newSize"`
+					}{
+						{Field: "groups.4.items", NewSize: 1000},
 					},
-					DisambiguatedPaths: bson.D{
-						{Key: "f2.1", Value: bson.A{"f2", "1"}},
+					UpdatedFields: bson.D{
+						{Key: "signature", Value: "sig"},
+						{Key: "groups.4.count", Value: 1000},
+						{Key: "groups.4.items.985", Value: "v0"},
+						{Key: "groups.4.items.986", Value: "v1"},
 					},
 				},
 			},
-			expectPipeline:        false,
-			expectConcatArraysFor: []string{},
-			expectSimpleSetFor:    []string{"f2.1"},
+			assert: func(t *testing.T, ops updateOps) {
+				t.Helper()
+
+				doc, ok := ops.primary.(bson.D)
+				if !ok {
+					t.Fatalf("expected primary bson.D, got %T", ops.primary)
+				}
+
+				assertHasTruncationPush(t, doc, "groups.4.items", 1000)
+
+				primarySet := findSetDoc(t, doc)
+				gotKeys := setKeys(primarySet)
+				// signature and groups.4.count do not conflict with truncation.
+				assert.ElementsMatch(t, []string{"signature", "groups.4.count"}, gotKeys)
+
+				// Both indexed writes inside the truncated path go to follow-up.
+				followUpKeys := collectFollowUpKeys(t, ops.followUp)
+				assert.ElementsMatch(t, []string{
+					"groups.4.items.985",
+					"groups.4.items.986",
+				}, followUpKeys)
+			},
+		},
+		{
+			name: "non-conflicting prefix-match field stays in primary",
+			event: &UpdateEvent{
+				UpdateDescription: UpdateDescription{
+					TruncatedArrays: []struct {
+						Field   string `bson:"field"`
+						NewSize int32  `bson:"newSize"`
+					}{
+						{Field: "items", NewSize: 5},
+					},
+					UpdatedFields: bson.D{
+						{Key: "items_count", Value: 5}, // prefix 'items' but separate field
+					},
+				},
+			},
+			assert: func(t *testing.T, ops updateOps) {
+				t.Helper()
+				assert.Empty(t, ops.followUp,
+					"items_count must not be treated as conflict with truncated 'items'")
+
+				doc, ok := ops.primary.(bson.D)
+				if !ok {
+					t.Fatalf("expected primary bson.D, got %T", ops.primary)
+				}
+
+				primarySet := findSetDoc(t, doc)
+				assert.Equal(t, []string{"items_count"}, setKeys(primarySet))
+			},
 		},
 	}
 
@@ -239,137 +202,27 @@ func TestCollectUpdateOps(t *testing.T) {
 			t.Parallel()
 
 			ops := collectUpdateOps(tt.event)
-
-			switch v := ops.primary.(type) {
-			case bson.A:
-				if !tt.expectPipeline {
-					t.Errorf("Expected simple update doc (bson.D), got pipeline (bson.A)")
-
-					return
-				}
-
-				foundConcatArrays, foundSimpleSet := extractPipelineFields(t, v)
-
-				// Non-array fields may be in follow-up standard $set ops, collect those too.
-				for _, fu := range ops.followUp {
-					for _, elem := range fu {
-						if elem.Key == "$set" {
-							if setDoc, ok := elem.Value.(bson.D); ok {
-								for _, f := range setDoc {
-									foundSimpleSet[f.Key] = true
-								}
-							}
-						}
-					}
-				}
-
-				assertFieldsPresent(t, foundConcatArrays, tt.expectConcatArraysFor, "$concatArrays")
-				assertFieldsPresent(t, foundSimpleSet, tt.expectSimpleSetFor, "simple $set")
-
-			case bson.D:
-				if tt.expectPipeline {
-					t.Errorf("Expected pipeline (bson.A), got simple update doc (bson.D)")
-
-					return
-				}
-
-				verifySimpleUpdateDoc(t, v, tt.expectSimpleSetFor)
-
-			default:
-				t.Errorf("Unexpected result type: %T", ops.primary)
-			}
+			tt.assert(t, ops)
 		})
 	}
 }
 
-func TestCollectUpdateOps_NoFalsePositiveConflict(t *testing.T) {
+// TestCollectUpdateOpsWithConflicts_ChunksConflictingFields verifies that many array-index
+// updates conflicting with a truncation are chunked into multiple follow-up $set ops by
+// maxBytesPerSetOp / maxFieldsPerSetOp, keeping each individual update bounded.
+func TestCollectUpdateOpsWithConflicts_ChunksConflictingFields(t *testing.T) {
 	t.Parallel()
 
-	// "items_count" should NOT conflict with truncated array "items"
-	// because "items_count" is a separate field, not a sub-path of "items".
-	tests := []struct {
-		name           string
-		truncField     string
-		updateKey      string
-		expectPipeline bool
-	}{
-		{
-			name:           "prefix match is not a conflict: items_count vs items",
-			truncField:     "items",
-			updateKey:      "items_count",
-			expectPipeline: false,
-		},
-		{
-			name:           "prefix match is not a conflict: data vs database",
-			truncField:     "data",
-			updateKey:      "database",
-			expectPipeline: false,
-		},
-		{
-			name:           "exact match is a conflict",
-			truncField:     "items",
-			updateKey:      "items",
-			expectPipeline: true,
-		},
-		{
-			name:           "dot-separated sub-path is a conflict",
-			truncField:     "items",
-			updateKey:      "items.2",
-			expectPipeline: true,
-		},
-		{
-			name:           "deeply nested sub-path is a conflict",
-			truncField:     "items",
-			updateKey:      "items.2.name",
-			expectPipeline: true,
-		},
+	const numIndexed = 250 // > maxFieldsPerSetOp (100) → chunked into multiple follow-ups
+
+	updatedFields := make(bson.D, 0, numIndexed)
+	expectedKeys := make([]string, 0, numIndexed)
+
+	for i := range numIndexed {
+		key := "arr." + strconv.Itoa(i)
+		updatedFields = append(updatedFields, bson.E{Key: key, Value: "v" + strconv.Itoa(i)})
+		expectedKeys = append(expectedKeys, key)
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			event := &UpdateEvent{
-				UpdateDescription: UpdateDescription{
-					TruncatedArrays: []struct {
-						Field   string `bson:"field"`
-						NewSize int32  `bson:"newSize"`
-					}{
-						{Field: tt.truncField, NewSize: 3},
-					},
-					UpdatedFields: bson.D{
-						{Key: tt.updateKey, Value: "val"},
-					},
-				},
-			}
-
-			ops := collectUpdateOps(event)
-
-			_, isPipeline := ops.primary.(bson.A)
-			if isPipeline != tt.expectPipeline {
-				t.Errorf("collectUpdateOps() returned pipeline=%v, want pipeline=%v", isPipeline, tt.expectPipeline)
-			}
-		})
-	}
-}
-
-func TestCollectUpdateOpsWithPipeline_ChunksSmallFields(t *testing.T) {
-	t.Parallel()
-
-	// Many small fields should be chunked by field count (maxFieldsPerSetOp),
-	// since their total byte size is well under maxBytesPerSetOp.
-	// All 250 non-array fields go to follow-up standard $set operations: 3 chunks of (100, 100, 50).
-	const numFields = 250
-
-	updatedFields := make(bson.D, 0, numFields+1)
-	for i := range numFields {
-		updatedFields = append(updatedFields, bson.E{
-			Key:   "field_" + strconv.Itoa(i),
-			Value: "value",
-		})
-	}
-
-	updatedFields = append(updatedFields, bson.E{Key: "arr.2", Value: "arrval"})
 
 	event := &UpdateEvent{
 		UpdateDescription: UpdateDescription{
@@ -377,206 +230,97 @@ func TestCollectUpdateOpsWithPipeline_ChunksSmallFields(t *testing.T) {
 				Field   string `bson:"field"`
 				NewSize int32  `bson:"newSize"`
 			}{
-				{Field: "arr", NewSize: 5},
+				{Field: "arr", NewSize: int32(numIndexed)},
 			},
 			UpdatedFields: updatedFields,
 		},
 	}
 
-	ops := collectUpdateOpsWithPipeline(event)
+	ops := collectUpdateOpsWithConflicts(event)
 
-	pipeline, ok := ops.primary.(bson.A)
+	// Primary should have just $push (truncation), no $set (no non-conflicting fields).
+	doc, ok := ops.primary.(bson.D)
 	if !ok {
-		t.Fatalf("Expected pipeline (bson.A), got %T", ops.primary)
+		t.Fatalf("expected primary bson.D, got %T", ops.primary)
 	}
 
-	concatArraysStages, truncationStages := classifySetStages(t, pipeline)
+	assertHasTruncationPush(t, doc, "arr", int32(numIndexed))
+	assert.Empty(t, findSetDoc(t, doc), "no non-conflicting $set fields expected")
 
-	assert.Equal(t, 1, concatArraysStages, "$concatArrays stages")
-	assert.Equal(t, 1, truncationStages, "truncation stages")
+	// All conflicting fields must spill to follow-ups, chunked by count.
+	expectedFollowUps := (numIndexed + maxFieldsPerSetOp - 1) / maxFieldsPerSetOp
+	assert.Len(t, ops.followUp, expectedFollowUps)
 
-	// Count all $set fields across primary pipeline and follow-ups
-	totalFields := countAllSetFields(t, ops)
-
-	assert.Equal(t, numFields, totalFields, "total fields across primary + follow-ups")
-
-	// All batched fields go to follow-ups: 250 / 100 = 3 follow-ups (100, 100, 50)
-	expectedFollowUps := (numFields + maxFieldsPerSetOp - 1) / maxFieldsPerSetOp
-
-	assert.Len(t, ops.followUp, expectedFollowUps, "follow-up operations")
+	gotKeys := collectFollowUpKeys(t, ops.followUp)
+	assert.Equal(t, expectedKeys, gotKeys, "conflicting fields must be preserved in source order")
 }
 
-func TestCollectUpdateOpsWithPipeline_ChunksLargeFields(t *testing.T) {
+// TestCollectUpdateOpsWithConflicts_ChunksLargeFields verifies byte-based chunking when
+// individual fields are large (~20 KB each) - chunks split by maxBytesPerSetOp before
+// reaching maxFieldsPerSetOp.
+func TestCollectUpdateOpsWithConflicts_ChunksLargeFields(t *testing.T) {
 	t.Parallel()
 
-	// Large fields (~20KB each) should be chunked by byte size (maxBytesPerSetOp),
-	// producing follow-up standard $set operations. This is the BufBuilder overflow scenario.
 	const numFields = 100
+
 	largeValue := strings.Repeat("X", 20_000)
 
-	updatedFields := make(bson.D, 0, numFields+1)
+	updatedFields := make(bson.D, 0, numFields)
+
 	for i := range numFields {
 		updatedFields = append(updatedFields, bson.E{
-			Key:   "arr." + strconv.Itoa(i) + ".d",
+			Key:   "arr." + strconv.Itoa(i),
 			Value: largeValue,
 		})
 	}
 
-	updatedFields = append(updatedFields, bson.E{Key: "meta.updated", Value: true})
-
 	event := &UpdateEvent{
 		UpdateDescription: UpdateDescription{
 			TruncatedArrays: []struct {
 				Field   string `bson:"field"`
 				NewSize int32  `bson:"newSize"`
 			}{
-				{Field: "arr", NewSize: 250},
+				{Field: "arr", NewSize: int32(numFields)},
 			},
 			UpdatedFields: updatedFields,
 		},
 	}
 
-	ops := collectUpdateOpsWithPipeline(event)
+	ops := collectUpdateOpsWithConflicts(event)
 
-	pipeline, ok := ops.primary.(bson.A)
-	if !ok {
-		t.Fatalf("Expected pipeline (bson.A), got %T", ops.primary)
-	}
+	// 100 × 20 KB = 2 MB total; maxBytesPerSetOp is 512 KiB → ~4 follow-up chunks.
+	assert.NotEmpty(t, ops.followUp)
+	assert.GreaterOrEqual(t, len(ops.followUp), 2)
 
-	concatArraysStages, _ := classifySetStages(t, pipeline)
-
-	assert.Equal(t, 0, concatArraysStages, "$concatArrays stages (all fields should be batched)")
-
-	// Must have follow-ups since 100 × 20KB = 2MB >> 512KB limit
-	assert.NotEmpty(t, ops.followUp, "should have follow-up operations due to byte size")
-
-	// Each follow-up must be a standard update (bson.D) with a single $set operator
 	for i, fu := range ops.followUp {
 		assert.Len(t, fu, 1, "follow-up %d should have exactly 1 operator ($set)", i)
-		assert.Equal(t, "$set", fu[0].Key, "follow-up %d operator key", i)
+		assert.Equal(t, setOp, fu[0].Key, "follow-up %d operator key", i)
 	}
 
-	// Count total fields across everything
-	totalFields := countAllSetFields(t, ops)
-	assert.Equal(t, numFields+1, totalFields, "total fields across primary + follow-ups (100 arr + 1 meta)")
+	gotKeys := collectFollowUpKeys(t, ops.followUp)
+	assert.Len(t, gotKeys, numFields, "all fields must be preserved across follow-ups")
 }
 
-// classifySetStages counts $concatArrays and truncation $set stages in a pipeline.
-func classifySetStages(t *testing.T, pipeline bson.A) (int, int) {
-	t.Helper()
-
-	var concatArrays, truncation int
-
-	for _, stage := range pipeline {
-		stageDoc, ok := stage.(bson.D)
-		if !ok {
-			continue
-		}
-
-		for _, elem := range stageDoc {
-			if elem.Key != setOp {
-				continue
-			}
-
-			setDoc, ok := elem.Value.(bson.D)
-			if !ok {
-				continue
-			}
-
-			switch {
-			case len(setDoc) == 1 && hasConcatArrays(setDoc[0].Value):
-				concatArrays++
-			case len(setDoc) == 1 && hasSlice(setDoc[0].Value):
-				truncation++
-			}
-		}
-	}
-
-	return concatArrays, truncation
-}
-
-// extractSetFieldsFromPipeline collects non-array $set field keys from a pipeline in order.
-func extractSetFieldsFromPipeline(t *testing.T, pipeline bson.A) []string {
-	t.Helper()
-
-	var keys []string
-
-	for _, stage := range pipeline {
-		stageDoc, ok := stage.(bson.D)
-		if !ok {
-			continue
-		}
-
-		for _, elem := range stageDoc {
-			if elem.Key != setOp {
-				continue
-			}
-
-			setDoc, ok := elem.Value.(bson.D)
-			if !ok {
-				continue
-			}
-
-			for _, f := range setDoc {
-				if !hasConcatArrays(f.Value) && !hasSlice(f.Value) {
-					keys = append(keys, f.Key)
-				}
-			}
-		}
-	}
-
-	return keys
-}
-
-// collectSetFieldKeys collects all non-array $set field keys from primary + follow-ups in order.
-func collectSetFieldKeys(t *testing.T, ops updateOps) []string {
-	t.Helper()
-
-	pipeline, ok := ops.primary.(bson.A)
-	if !ok {
-		t.Fatalf("Expected pipeline (bson.A), got %T", ops.primary)
-	}
-
-	keys := extractSetFieldsFromPipeline(t, pipeline)
-
-	// Follow-ups are standard $set (bson.D), not pipelines
-	for _, fu := range ops.followUp {
-		for _, elem := range fu {
-			if elem.Key == "$set" {
-				if setDoc, ok := elem.Value.(bson.D); ok {
-					for _, f := range setDoc {
-						keys = append(keys, f.Key)
-					}
-				}
-			}
-		}
-	}
-
-	return keys
-}
-
-// countAllSetFields counts all non-array $set fields across primary pipeline + follow-ups.
-func countAllSetFields(t *testing.T, ops updateOps) int {
-	t.Helper()
-
-	return len(collectSetFieldKeys(t, ops))
-}
-
-func TestCollectUpdateOpsWithPipeline_ChunkedSetPreservesOrder(t *testing.T) {
+// TestCollectUpdateOpsWithConflicts_PCSM305CustomerShape is the regression test for the
+// customer's BufBuilder 125 MB target-side crash. The truncated array is nested inside
+// another array (groups.<idx>.items where groups is itself an array). The fix avoids
+// pipeline form entirely - the truncation goes to a primary classic $push and indexed
+// writes spill to follow-up classic $set ops, which correctly navigate dotted numeric
+// paths through arrays without exhausting BufBuilder.
+func TestCollectUpdateOpsWithConflicts_PCSM305CustomerShape(t *testing.T) {
 	t.Parallel()
 
-	// Field ordering must be preserved across chunks to avoid breaking
-	// exact-match queries on embedded documents (MongoDB compares embedded
-	// documents by BSON byte order, so field reordering changes query semantics).
-	const numFields = 250 // spans multiple chunks of maxFieldsPerSetStage
+	const numIndexed = 15
 
-	updatedFields := make(bson.D, 0, numFields)
-	expectedOrder := make([]string, 0, numFields)
+	updatedFields := bson.D{
+		{Key: "signature", Value: "sig"},
+		{Key: "updated_at", Value: "now"},
+		{Key: "groups.4.count", Value: 1000},
+	}
 
-	for i := range numFields {
-		key := "field_" + strconv.Itoa(i)
-		updatedFields = append(updatedFields, bson.E{Key: key, Value: i})
-		expectedOrder = append(expectedOrder, key)
+	for i := range numIndexed {
+		key := "groups.4.items." + strconv.Itoa(985+i)
+		updatedFields = append(updatedFields, bson.E{Key: key, Value: "v" + strconv.Itoa(i)})
 	}
 
 	event := &UpdateEvent{
@@ -585,172 +329,155 @@ func TestCollectUpdateOpsWithPipeline_ChunkedSetPreservesOrder(t *testing.T) {
 				Field   string `bson:"field"`
 				NewSize int32  `bson:"newSize"`
 			}{
-				{Field: "arr", NewSize: 5},
+				{Field: "groups.4.items", NewSize: 1000},
 			},
 			UpdatedFields: updatedFields,
 		},
 	}
 
-	ops := collectUpdateOpsWithPipeline(event)
+	ops := collectUpdateOpsWithConflicts(event)
 
-	// Collect all non-array $set fields in order: primary pipeline first, then follow-ups
-	gotOrder := collectSetFieldKeys(t, ops)
-
-	if len(gotOrder) != len(expectedOrder) {
-		t.Fatalf("Expected %d fields, got %d", len(expectedOrder), len(gotOrder))
+	doc, ok := ops.primary.(bson.D)
+	if !ok {
+		t.Fatalf("expected primary bson.D (classic update), got %T", ops.primary)
 	}
 
-	for i := range expectedOrder {
-		if gotOrder[i] != expectedOrder[i] {
-			t.Errorf("Field at position %d: got %q, want %q", i, gotOrder[i], expectedOrder[i])
-		}
+	assertHasTruncationPush(t, doc, "groups.4.items", 1000)
+
+	primarySet := findSetDoc(t, doc)
+	primaryKeys := setKeys(primarySet)
+	assert.ElementsMatch(t, []string{"signature", "updated_at", "groups.4.count"}, primaryKeys)
+
+	// Every array-index update key must appear in some follow-up $set.
+	followUpKeys := collectFollowUpKeys(t, ops.followUp)
+	for i := range numIndexed {
+		key := "groups.4.items." + strconv.Itoa(985+i)
+		assert.Contains(t, followUpKeys, key, "expected follow-up $set to include %s", key)
 	}
 }
 
-func TestCollectUpdateOpsWithPipeline_SliceUsesMaxForPositive(t *testing.T) {
+// TestClientBulkWrite_FullByBytes verifies that the per-bulk byte budget triggers Full()
+// before the count cap when individual writes are large.
+func TestClientBulkWrite_FullByBytes(t *testing.T) {
 	t.Parallel()
 
-	// The $slice third argument must always be positive.
-	// Verify the pipeline uses $max to guarantee this.
-	event := &UpdateEvent{
-		UpdateDescription: UpdateDescription{
-			TruncatedArrays: []struct {
-				Field   string `bson:"field"`
-				NewSize int32  `bson:"newSize"`
-			}{
-				{Field: "arr", NewSize: 0}, // Array truncated to size 0
-			},
-			UpdatedFields: bson.D{
-				{Key: "arr.0", Value: "new_val"},
-			},
-		},
-	}
+	cbw := newClientBulkWriter(10_000, false)
+	ns := catalog.Namespace{Database: "db", Collection: "c"}
 
-	ops := collectUpdateOpsWithPipeline(event)
+	largeValue := strings.Repeat("X", 1024*1024)
 
-	pipeline, ok := ops.primary.(bson.A)
-	if !ok {
-		t.Fatalf("Expected pipeline (bson.A), got %T", ops.primary)
-	}
-
-	// Find the $concatArrays stage for "arr"
-	found := false
-
-	for _, stage := range pipeline {
-		stageDoc, ok := stage.(bson.D)
-		if !ok {
-			continue
+	for i := range 100 {
+		raw, err := bson.Marshal(bson.D{{Key: "_id", Value: i}, {Key: "blob", Value: largeValue}})
+		if err != nil {
+			t.Fatalf("marshal full document: %v", err)
 		}
 
-		for _, elem := range stageDoc {
-			if elem.Key != setOp {
-				continue
-			}
+		cbw.Insert(ns, &InsertEvent{
+			DocumentKey:  bson.D{{Key: "_id", Value: i}},
+			FullDocument: raw,
+		})
 
-			setDoc, ok := elem.Value.(bson.D)
-			if !ok {
-				continue
-			}
-
-			for _, setField := range setDoc {
-				if setField.Key != "arr" {
-					continue
-				}
-
-				arrDoc, ok := setField.Value.(bson.D)
-				if !ok {
-					continue
-				}
-
-				for _, arrElem := range arrDoc {
-					if arrElem.Key != "$concatArrays" {
-						continue
-					}
-
-					concatArr, ok := arrElem.Value.(bson.A)
-					if !ok || len(concatArr) != 3 {
-						t.Fatalf("Expected $concatArrays with 3 elements, got %v", arrElem.Value)
-					}
-
-					// Third element is the trailing $slice
-					sliceDoc, ok := concatArr[2].(bson.D)
-					if !ok {
-						t.Fatalf("Expected third $concatArrays element to be bson.D, got %T", concatArr[2])
-					}
-
-					for _, sliceElem := range sliceDoc {
-						if sliceElem.Key != "$slice" {
-							continue
-						}
-
-						sliceArgs, ok := sliceElem.Value.(bson.A)
-						if !ok || len(sliceArgs) != 3 {
-							t.Fatalf("Expected $slice with 3 args, got %v", sliceElem.Value)
-						}
-
-						// Third arg should be bson.D{{"$max", bson.A{1, ...}}}
-						maxDoc, ok := sliceArgs[2].(bson.D)
-						if !ok {
-							t.Fatalf("Expected $slice third arg to be bson.D, got %T", sliceArgs[2])
-						}
-
-						hasMax := false
-						for _, maxElem := range maxDoc {
-							if maxElem.Key == "$max" {
-								hasMax = true
-
-								maxArr, ok := maxElem.Value.(bson.A)
-								if !ok || len(maxArr) != 2 {
-									t.Fatalf("Expected $max with 2 elements, got %v", maxElem.Value)
-								}
-
-								minVal, ok := maxArr[0].(int)
-								if !ok || minVal != 1 {
-									t.Errorf("Expected $max minimum to be 1, got %v", maxArr[0])
-								}
-							}
-						}
-
-						if !hasMax {
-							t.Error("$slice third argument does not use $max to guarantee positive value")
-						}
-
-						found = true
-					}
-				}
-			}
+		if cbw.Full() {
+			break
 		}
 	}
 
-	if !found {
-		t.Error("Could not find $concatArrays with $slice in pipeline")
-	}
+	assert.True(t, cbw.Full(), "Full() must be true after exceeding maxBulkBytes")
+	assert.Less(t, len(cbw.writes), 10_000, "Full() must trigger before reaching count cap")
+	assert.GreaterOrEqual(t, cbw.bytes, maxBulkBytes, "byte counter must have reached maxBulkBytes")
 }
 
-func extractPipelineFields(t *testing.T, pipeline bson.A) (map[string]bool, map[string]bool) {
-	t.Helper()
+// TestCollectionBulkWrite_FullByBytes mirrors the client-bulk byte budget test for the
+// pre-MongoDB-8.0 collection-level bulk write path.
+func TestCollectionBulkWrite_FullByBytes(t *testing.T) {
+	t.Parallel()
 
-	concatArrays := make(map[string]bool)
-	simpleSet := make(map[string]bool)
+	cbw := newCollectionBulkWriter(10_000, false)
+	ns := catalog.Namespace{Database: "db", Collection: "c"}
 
-	for _, stage := range pipeline {
-		stageDoc, ok := stage.(bson.D)
-		if !ok {
-			t.Errorf("Pipeline stage is not bson.D: %T", stage)
+	largeValue := strings.Repeat("X", 1024*1024)
 
-			continue
+	for i := range 100 {
+		raw, err := bson.Marshal(bson.D{{Key: "_id", Value: i}, {Key: "blob", Value: largeValue}})
+		if err != nil {
+			t.Fatalf("marshal full document: %v", err)
 		}
 
-		extractSetFields(t, stageDoc, concatArrays, simpleSet)
+		cbw.Insert(ns, &InsertEvent{
+			DocumentKey:  bson.D{{Key: "_id", Value: i}},
+			FullDocument: raw,
+		})
+
+		if cbw.Full() {
+			break
+		}
 	}
 
-	return concatArrays, simpleSet
+	assert.True(t, cbw.Full(), "Full() must be true after exceeding maxBulkBytes")
+	assert.Less(t, cbw.count, 10_000, "Full() must trigger before reaching count cap")
+	assert.GreaterOrEqual(t, cbw.bytes, maxBulkBytes, "byte counter must have reached maxBulkBytes")
 }
 
-func extractSetDocs(t *testing.T, doc bson.D) []bson.D {
-	t.Helper()
+// TestClientBulkWrite_FullByCount preserves the existing count-based Full() behavior for
+// small writes that don't reach the byte budget.
+func TestClientBulkWrite_FullByCount(t *testing.T) {
+	t.Parallel()
 
-	docs := make([]bson.D, 0, len(doc))
+	cbw := newClientBulkWriter(3, false)
+	ns := catalog.Namespace{Database: "db", Collection: "c"}
+
+	for i := range 3 {
+		raw, err := bson.Marshal(bson.D{{Key: "_id", Value: i}})
+		if err != nil {
+			t.Fatalf("marshal full document: %v", err)
+		}
+
+		cbw.Insert(ns, &InsertEvent{
+			DocumentKey:  bson.D{{Key: "_id", Value: i}},
+			FullDocument: raw,
+		})
+	}
+
+	assert.True(t, cbw.Full(), "Full() must be true at count cap")
+	assert.Less(t, cbw.bytes, maxBulkBytes, "byte counter must be well below maxBulkBytes")
+}
+
+// TestCollectionBulkWrite_FullByCount preserves the count-based Full() behavior.
+func TestCollectionBulkWrite_FullByCount(t *testing.T) {
+	t.Parallel()
+
+	cbw := newCollectionBulkWriter(3, false)
+	ns := catalog.Namespace{Database: "db", Collection: "c"}
+
+	for i := range 3 {
+		raw, err := bson.Marshal(bson.D{{Key: "_id", Value: i}})
+		if err != nil {
+			t.Fatalf("marshal full document: %v", err)
+		}
+
+		cbw.Insert(ns, &InsertEvent{
+			DocumentKey:  bson.D{{Key: "_id", Value: i}},
+			FullDocument: raw,
+		})
+	}
+
+	assert.True(t, cbw.Full(), "Full() must be true at count cap")
+	assert.Less(t, cbw.bytes, maxBulkBytes, "byte counter must be well below maxBulkBytes")
+}
+
+// topLevelKeys returns the top-level keys of a classic update document in source order.
+func topLevelKeys(doc bson.D) []string {
+	keys := make([]string, len(doc))
+	for i, e := range doc {
+		keys[i] = e.Key
+	}
+
+	return keys
+}
+
+// findSetDoc returns the $set sub-document from a classic update doc, or nil if absent.
+func findSetDoc(t *testing.T, doc bson.D) bson.D {
+	t.Helper()
 
 	for _, elem := range doc {
 		if elem.Key != setOp {
@@ -759,80 +486,100 @@ func extractSetDocs(t *testing.T, doc bson.D) []bson.D {
 
 		setDoc, ok := elem.Value.(bson.D)
 		if !ok {
-			t.Errorf("$set value is not bson.D: %T", elem.Value)
+			t.Fatalf("$set value is not bson.D: %T", elem.Value)
+		}
 
+		return setDoc
+	}
+
+	return nil
+}
+
+// setKeys returns the keys of a $set sub-document in source order.
+func setKeys(setDoc bson.D) []string {
+	keys := make([]string, len(setDoc))
+	for i, e := range setDoc {
+		keys[i] = e.Key
+	}
+
+	return keys
+}
+
+// assertHasTruncationPush verifies the classic update doc carries
+// $push: {field: {$each: [], $slice: newSize}}.
+func assertHasTruncationPush(t *testing.T, doc bson.D, field string, newSize int32) {
+	t.Helper()
+
+	for _, elem := range doc {
+		if elem.Key != pushOp {
 			continue
 		}
 
-		docs = append(docs, setDoc)
+		pushDoc, ok := elem.Value.(bson.D)
+		if !ok {
+			t.Fatalf("$push value is not bson.D: %T", elem.Value)
+		}
+
+		for _, p := range pushDoc {
+			if p.Key != field {
+				continue
+			}
+
+			spec, ok := p.Value.(bson.D)
+			if !ok {
+				t.Fatalf("$push.%s value is not bson.D: %T", field, p.Value)
+			}
+
+			var hasEach, hasSlice bool
+
+			for _, s := range spec {
+				switch s.Key {
+				case "$each":
+					arr, ok := s.Value.(bson.A)
+					assert.True(t, ok && len(arr) == 0, "$each must be empty array")
+
+					hasEach = true
+				case "$slice":
+					assert.Equal(t, newSize, s.Value, "$slice must equal newSize")
+
+					hasSlice = true
+				}
+			}
+
+			assert.True(t, hasEach, "$push.%s must include $each:[]", field)
+			assert.True(t, hasSlice, "$push.%s must include $slice", field)
+
+			return
+		}
+
+		t.Fatalf("$push does not contain field %q", field)
 	}
 
-	return docs
+	t.Fatalf("classic update doc does not contain $push for %q", field)
 }
 
-func extractSetFields(t *testing.T, stageDoc bson.D, concatArrays, simpleSet map[string]bool) {
+// collectFollowUpKeys returns every $set key across follow-up updates in source order.
+func collectFollowUpKeys(t *testing.T, followUp []bson.D) []string {
 	t.Helper()
 
-	for _, setDoc := range extractSetDocs(t, stageDoc) {
-		for _, setField := range setDoc {
-			if hasConcatArrays(setField.Value) {
-				concatArrays[setField.Key] = true
-			} else {
-				simpleSet[setField.Key] = true
+	keys := make([]string, 0)
+
+	for _, fu := range followUp {
+		for _, elem := range fu {
+			if elem.Key != setOp {
+				continue
+			}
+
+			setDoc, ok := elem.Value.(bson.D)
+			if !ok {
+				t.Fatalf("$set value is not bson.D: %T", elem.Value)
+			}
+
+			for _, f := range setDoc {
+				keys = append(keys, f.Key)
 			}
 		}
 	}
-}
 
-func hasConcatArrays(v any) bool {
-	valueDoc, ok := v.(bson.D)
-	if !ok {
-		return false
-	}
-
-	for _, elem := range valueDoc {
-		if elem.Key == "$concatArrays" {
-			return true
-		}
-	}
-
-	return false
-}
-
-func hasSlice(v any) bool {
-	valueDoc, ok := v.(bson.D)
-	if !ok {
-		return false
-	}
-
-	for _, elem := range valueDoc {
-		if elem.Key == "$slice" {
-			return true
-		}
-	}
-
-	return false
-}
-
-func assertFieldsPresent(t *testing.T, found map[string]bool, expected []string, fieldType string) {
-	t.Helper()
-
-	for _, field := range expected {
-		if !found[field] {
-			t.Errorf("Expected field %q to use %s, but it doesn't", field, fieldType)
-		}
-	}
-}
-
-func verifySimpleUpdateDoc(t *testing.T, doc bson.D, expectedFields []string) {
-	t.Helper()
-
-	for _, setDoc := range extractSetDocs(t, doc) {
-		foundFields := make(map[string]bool)
-		for _, setField := range setDoc {
-			foundFields[setField.Key] = true
-		}
-
-		assertFieldsPresent(t, foundFields, expectedFields, "$set")
-	}
+	return keys
 }

--- a/pcsm/repl/worker.go
+++ b/pcsm/repl/worker.go
@@ -304,6 +304,10 @@ func (w *worker) run(ctx context.Context) {
 // addToCurrentBulk parses the deferred DML event body from raw BSON and adds
 // it to the current bulk write.
 // Returns a non-nil error if parsing fails, which is reported to the main loop.
+//
+// If adding the parsed event would push the current bulk past config.MaxWriteBatchSizeBytes,
+// the current bulk is enqueued first so the byte budget is honored without ever appending
+// past it.
 func (w *worker) addToCurrentBulk(event *routedEvent) error {
 	parsed, err := parseDMLEvent(event.change.RawData, event.change.OperationType)
 	if err != nil {
@@ -311,6 +315,15 @@ func (w *worker) addToCurrentBulk(event *routedEvent) error {
 	}
 
 	event.change.RawData = nil // release raw bytes for GC
+
+	// Preflight: if the current bulk would overflow the byte budget, enqueue it first
+	// and start fresh. The WouldOverflow guard returns false when the bulk is empty so
+	// a single oversized event can still be sent on its own bulk.
+	if w.currentBulkWrite.WouldOverflow(estimateEventBytes(parsed)) {
+		if !w.enqueueBulk() {
+			return errors.Wrap(w.writerErr, "writer stopped")
+		}
+	}
 
 	switch e := parsed.(type) { //nolint:exhaustive
 	case InsertEvent:

--- a/pcsm/repl/worker_test.go
+++ b/pcsm/repl/worker_test.go
@@ -313,8 +313,9 @@ type mockBulkWriter struct {
 	fullAt int   // Full() returns true when count >= fullAt (0 = never full)
 }
 
-func (m *mockBulkWriter) Full() bool  { return m.fullAt > 0 && m.count >= m.fullAt }
-func (m *mockBulkWriter) Empty() bool { return m.count == 0 }
+func (m *mockBulkWriter) Full() bool               { return m.fullAt > 0 && m.count >= m.fullAt }
+func (m *mockBulkWriter) Empty() bool              { return m.count == 0 }
+func (m *mockBulkWriter) WouldOverflow(_ int) bool { return false }
 
 func (m *mockBulkWriter) Do(_ context.Context, _ *mongo.Client) (int, error) {
 	n := m.count

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1,4 +1,5 @@
 # pylint: disable=missing-docstring,redefined-outer-name
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 
 import pymongo
@@ -293,6 +294,135 @@ def test_update_one_with_trucated_arrays(t: Testing, phase: Runner.Phase):
                 }
             ],
         )
+
+    t.compare_all()
+
+
+@pytest.mark.timeout(180)
+@pytest.mark.parametrize("phase", [Runner.Phase.APPLY])
+def test_pcsm_305_bufbuilder_overflow(t: Testing, phase: Runner.Phase):
+    """Regression test for PCSM-305 (BufBuilder 125MB target-side crash).
+
+    Each updated document emits a change-stream event combining:
+      - truncation of an array nested under an indexed parent
+      - indexed writes within that truncated array
+      - sibling count and signature updates
+
+    With the bug, PCSM bundles many such events into a single target bulkWrite
+    that exceeds MongoDB's 125MB BufBuilder limit and change replication fails
+    ('BufBuilder attempted to grow() to 131072001 bytes, past the 125MB limit').
+    The harness surfaces this as either an AssertionError on the state==RUNNING
+    check in wait_for_current_optime, a WaitTimeoutError, or a compare_all()
+    content mismatch. With the fix, source and target converge.
+    """
+    parent_index = 4
+    base_array_size = 1500
+    new_size = 1000
+    indexed_updates = 15
+    iterations = 10
+    parallel_workers = 25
+    total_docs = iterations * parallel_workers  # 250
+
+    def build_seed_doc(doc_id):
+        groups = []
+        for i in range(parent_index + 1):
+            if i == parent_index:
+                groups.append(
+                    {
+                        "name": f"group_{i}",
+                        "count": base_array_size,
+                        "items": [f"item_{j}" for j in range(base_array_size)],
+                    }
+                )
+            else:
+                groups.append({"name": f"group_{i}", "count": 0, "items": []})
+        return {
+            "_id": doc_id,
+            "groups": groups,
+            "signature": "initial",
+            "updated_at": "initial",
+        }
+
+    def build_pipeline_computed_diff_update():
+        # Truncates groups.<idx>.items to new_size, rewrites the trailing
+        # `indexed_updates` elements via $concatArrays/$slice, and updates the
+        # sibling count/signature fields. Avoids classic-modifier path
+        # conflicts so the resulting change-stream event combines truncation +
+        # indexed writes + count update on the same array path.
+        start_idx = max(0, new_size - indexed_updates)
+        touched_indexes = list(range(start_idx, new_size))
+
+        target_group_expr = {"$arrayElemAt": ["$groups", parent_index]}
+        source_items_expr = {
+            "$ifNull": [
+                {"$getField": {"field": "items", "input": target_group_expr}},
+                [],
+            ]
+        }
+        mutated_items_expr = {"$slice": [source_items_expr, new_size]}
+        for idx in touched_indexes:
+            mutated_items_expr = {
+                "$concatArrays": [
+                    {"$slice": [mutated_items_expr, idx]},
+                    [f"updated_{idx}"],
+                    {"$slice": [mutated_items_expr, idx + 1, new_size]},
+                ]
+            }
+
+        updated_group_expr = {
+            "$mergeObjects": [
+                target_group_expr,
+                {"count": new_size, "items": mutated_items_expr},
+            ]
+        }
+
+        trailing_count_expr = {
+            "$max": [0, {"$subtract": [{"$size": "$groups"}, parent_index + 1]}]
+        }
+        trailing_slice_expr = {
+            "$let": {
+                "vars": {"tailCount": trailing_count_expr},
+                "in": {
+                    "$cond": [
+                        {"$gt": ["$$tailCount", 0]},
+                        {"$slice": ["$groups", parent_index + 1, "$$tailCount"]},
+                        [],
+                    ]
+                },
+            }
+        }
+        updated_groups_expr = {
+            "$concatArrays": [
+                {"$slice": ["$groups", parent_index]},
+                [updated_group_expr],
+                trailing_slice_expr,
+            ]
+        }
+
+        return [
+            {
+                "$set": {
+                    "groups": updated_groups_expr,
+                    "signature": "updated",
+                    "updated_at": "updated",
+                }
+            }
+        ]
+
+    seed_docs = [build_seed_doc(i) for i in range(total_docs)]
+    t.source["db_1"]["coll_1"].insert_many(seed_docs)
+    t.target["db_1"]["coll_1"].insert_many(seed_docs)
+
+    update_pipeline = build_pipeline_computed_diff_update()
+
+    def apply_one(doc_id):
+        t.source["db_1"]["coll_1"].update_one({"_id": doc_id}, update_pipeline)
+
+    with t.run(phase, wait_timeout=10):
+        with ThreadPoolExecutor(max_workers=parallel_workers) as ex:
+            futures = [ex.submit(apply_one, doc_id) for doc_id in range(total_docs)]
+            for fut in as_completed(futures):
+                fut.result()  # surface any source-side write error
 
     t.compare_all()
 

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -319,9 +319,9 @@ def test_pcsm_305_bufbuilder_overflow(t: Testing, phase: Runner.Phase):
     base_array_size = 1500
     new_size = 1000
     indexed_updates = 15
-    iterations = 10
-    parallel_workers = 25
-    total_docs = iterations * parallel_workers  # 250
+    iterations = 5
+    parallel_workers = 10
+    total_docs = iterations * parallel_workers  # 50
 
     def build_seed_doc(doc_id):
         groups = []

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -376,9 +376,7 @@ def test_pcsm_305_bufbuilder_overflow(t: Testing, phase: Runner.Phase):
             ]
         }
 
-        trailing_count_expr = {
-            "$max": [0, {"$subtract": [{"$size": "$groups"}, parent_index + 1]}]
-        }
+        trailing_count_expr = {"$max": [0, {"$subtract": [{"$size": "$groups"}, parent_index + 1]}]}
         trailing_slice_expr = {
             "$let": {
                 "vars": {"tailCount": trailing_count_expr},


### PR DESCRIPTION
[PCSM-305](https://perconadev.atlassian.net/browse/PCSM-305)

### Problem

Change replication failed with MongoDB's 125 MB BufBuilder ceiling (`Plan executor
error during update :: caused by :: BufBuilder attempted to grow() to 131072001
bytes, past the 125MB limit`) when a single change event combined an array
truncation with multiple indexed writes (updates targeting specific array element
positions, e.g. element 5 and 6 of an array) into the same array — and especially
when the truncated array was nested inside another array (e.g. `groups.4.items`).

PCSM translated such events into aggregation-pipeline updates whose `$concatArrays`
stages on a large array exhausted BufBuilder; for paths traversing an outer array,
the pipeline form also produced incorrect results because aggregation field
expressions like `$groups.4.items` broadcast across array elements rather than
indexing into them. Under realistic batched workloads, change replication
transitioned to `failed` and source/target diverged.

### Solution

Translate change events into classic update modifiers instead of aggregation
pipelines. Truncations become `$push: {field: {$each: [], $slice: N}}`, removed
fields become `$unset`, and updated fields become `$set` — the same form PCSM
already used for the no-conflict path. Standard `$set` correctly navigates dotted
numeric path components into arrays, so paths nested through outer arrays are now
handled correctly without any pipeline-form workaround.

When updated fields **or removed fields** target a path inside a truncated array,
MongoDB rejects combining `$push` with `$set`/`$unset` on the same path within one
update document, so those conflicting writes are split into separate ordered
follow-up operations bounded by per-update size and field-count caps. Each
follow-up gets its own MongoDB-side BufBuilder, keeping per-update plan execution
cheap regardless of how many indexed writes the source emitted.

#### Bulk-write safety and accounting

- **Byte-budget preflight.** A new `WouldOverflow(estimate)` check on the bulk
  writer is consulted *before* appending each event. If the next event would push
  the bulk past `config.MaxWriteBatchSizeBytes` (MongoDB's `MaxMessageSizeBytes`
  minus the standard message-header reserve), the current bulk is enqueued first
  and the event lands on a fresh bulk. An empty-bulk exception lets a single
  oversized event still proceed on its own. This replaces the previous
  post-append accounting, which could overshoot the cap by a full event size.
- **Count-cap correctness.** `Full()` now compares `len(writes)` against an
  explicit `maxOpsSize` field with `>=`, instead of relying on `cap(slice)`/`==`.
  When `Update` appends a primary plus N follow-ups, the slice can grow past its
  initial capacity; the new check still fires correctly.


[PCSM-305]: https://perconadev.atlassian.net/browse/PCSM-305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ