### PR TITLE
PCSM-255: Fix sharded e2e flakiness on MongoDB 6.0/7.0

### DIFF
--- a/.github/workflows/e2etests.yml
+++ b/.github/workflows/e2etests.yml
@@ -89,25 +89,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # 6.0/7.0 source: sharded-specific tests only (full suite blocked by PCSM-255)
           - src_mongo_version: "6.0"
             tgt_mongo_version: "6.0"
-            test_scope: tests/test_collections_sharded.py tests/test_documents_sharded.py tests/test_pipeline_updates.py
           - src_mongo_version: "7.0"
             tgt_mongo_version: "7.0"
-            test_scope: tests/test_collections_sharded.py tests/test_documents_sharded.py tests/test_pipeline_updates.py
           - src_mongo_version: "8.0"
             tgt_mongo_version: "8.0"
-            test_scope: ""
           - src_mongo_version: "6.0"
             tgt_mongo_version: "7.0"
-            test_scope: tests/test_collections_sharded.py tests/test_documents_sharded.py tests/test_pipeline_updates.py
           - src_mongo_version: "6.0"
             tgt_mongo_version: "8.0"
-            test_scope: tests/test_collections_sharded.py tests/test_documents_sharded.py tests/test_pipeline_updates.py
           - src_mongo_version: "7.0"
             tgt_mongo_version: "8.0"
-            test_scope: tests/test_collections_sharded.py tests/test_documents_sharded.py tests/test_pipeline_updates.py
 
     env:
       SRC_MONGO_VERSION: ${{ matrix.src_mongo_version }}
@@ -156,7 +149,7 @@ jobs:
           export TEST_PCSM_URL=http://127.0.0.1:2242
           export TEST_PCSM_BIN=./bin/pcsm_test
 
-          poetry run pytest ${{ matrix.test_scope }}
+          poetry run pytest
 
       - name: Teardown Docker Compose
         if: always()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,13 +88,39 @@ def drop_all_database(source_conn: MongoClient, target_conn: MongoClient):
 PCSM_PROC: subprocess.Popen = None
 
 
+def _pcsm_url(request: pytest.FixtureRequest):
+    return request.config.getoption("--pcsm_url") or os.environ["TEST_PCSM_URL"]
+
+
+def _wait_for_pcsm_ready(pcsm_url: str, timeout: float = 10.0):
+    """Poll PCSM /status until it returns state=idle or timeout."""
+    deadline = time.monotonic() + timeout
+    pcsm_client = PCSM(pcsm_url)
+    last_err = "no response"
+    while time.monotonic() < deadline:
+        try:
+            payload = pcsm_client.status()
+            if payload.get("state") == PCSM.State.IDLE:
+                return
+            last_err = f"unexpected state={payload.get('state')}"
+        except Exception as e:  # noqa: BLE001 - any failure during startup is retryable
+            last_err = str(e)
+        time.sleep(0.1)
+    raise TimeoutError(f"PCSM not ready within {timeout}s: {last_err}")
+
+
 def start_pcsm(pcsm_bin: str, request: pytest.FixtureRequest):
     source = source_uri(request)
     target = target_uri(request)
     rv = subprocess.Popen(
         [pcsm_bin, "--source", source, "--target", target, "--reset-state", "--log-level=trace"]
     )
-    time.sleep(1)
+    try:
+        _wait_for_pcsm_ready(_pcsm_url(request))
+    except Exception:  # noqa: BLE001 - cleanup orphaned process before re-raising
+        rv.terminate()
+        rv.wait()
+        raise
     return rv
 
 

--- a/tests/pcsm.py
+++ b/tests/pcsm.py
@@ -226,19 +226,9 @@ class Runner:
                 # Even though PCSM has processed the oplog entry, MongoDB metadata updates
                 # (like collection/database creation) may not be immediately visible to other
                 # connections. Poll the target with exponential backoff to ensure visibility.
-                for retry in range(6):
-                    # When PCSM creates a collection or database on the target cluster:
-                    #   - PCSM writes the change and confirms it's applied
-                    #   - But test's MongoDB connection still has stale metadata cached
-                    #   - Immediately querying for that collection might return "not found"
-
-                    # The ping command causes the driver to refresh its metadata cache,
-                    # ensuring subsequent queries  see the latest state.
+                for retry in range(12):
                     self.target.admin.command("ping")
-
-                    # Exponential backoff with cap: 0.05s, 0.10s, 0.20s, 0.20s, 0.20s, 0.20s
-                    # Total wait: ~0.95 seconds
-                    time.sleep(min(0.05 * (2**retry), 0.2))
+                    time.sleep(min(0.05 * (2**retry), 0.5))
 
                 return
 


### PR DESCRIPTION
[PCSM-255](https://perconadev.atlassian.net/browse/PCSM-255)

### Problem

Sharded e2e tests on MongoDB 6.0 and 7.0 fail consistently during `phase:apply` create-collection cases. The compare step in `compare_all_sharded` (`tests/testing.py`) trips with `AssertionError: {'db_1'} != set()` because the source has the database but the target does not. PCSM logs `"No collection to clone"` (`pcsm/clone/clone.go:313`) even though the source has data.

8.0 mostly survives because `transitionFromDedicatedConfigServer` is invoked only on 8.0+ in `hack/sh/run.sh`, which acts as an implicit shard-sync barrier between cluster startup and the first PCSM `/start`. On 6.0/7.0 that barrier is gone and the cluster startup race surfaces consistently. The CI matrix had to skip the full sharded suite on 6.0/7.0 because of this.

The test infra also amplified the race in two places:

1. `manage_pcsm_process` did `time.sleep(1)` after `Popen` and assumed PCSM was ready. Tests began posting `/start` while PCSM was still binding the port or working through startup.
2. `Runner.wait_for_current_optime` capped the metadata-refresh backoff at ~0.95s total. On sharded clusters that wasn't enough for catalog propagation across mongos, config server, and shards, so the next compare ran against stale target metadata.

### Solution

Replace the `time.sleep(1)` with `_wait_for_pcsm_ready()` polling `/status` until `state=idle` (10s deadline). On timeout, terminate the `Popen` before re-raising so failed readiness doesn't leak orphan PCSM processes.

Extend the metadata-refresh ceiling in `wait_for_current_optime` from ~0.95s to ~4.75s (loop now `range(12)` capped at 0.5s).

Drop the `test_scope` workaround in `e2etests.yml`. All three sharded matrix entries (6.0, 7.0, 8.0) now run the full sharded suite.

Validation: 5 consecutive green runs of `test_collections_sharded.py -k apply` per version (the canonical failure surface from the ticket), plus one full sharded suite run per version on 6.0/7.0/8.0. No regression on 8.0.

[PCSM-255]: https://perconadev.atlassian.net/browse/PCSM-255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ