### PR TITLE
PCSM-313: Rename env and pass to opencode action

### DIFF
--- a/.github/workflows/opencode-pr-summary.yml
+++ b/.github/workflows/opencode-pr-summary.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
       issues: read
     env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       REPO_FULL: ${{ github.repository }}
       REPO_OWNER: ${{ github.repository_owner }}
       REPO_NAME: ${{ github.event.repository.name }}
@@ -64,9 +64,6 @@ jobs:
         uses: anomalyco/opencode/github@77fc88c8ade8e5a620ebbe1197f3a572d29ae91a # github-v1.2.19
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GH_TOKEN: ${{ env.GH_TOKEN }}
-          REPO_FULL: ${{ env.REPO_FULL }}
-          PR_NUMBER: ${{ env.PR_NUMBER }}
         with:
           model: anthropic/claude-opus-4-7
           # Use GITHUB_TOKEN directly so the agent shell can call `gh api` for the

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: read
       issues: read
     env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       REPO_OWNER: ${{ github.repository_owner }}
       REPO_NAME: ${{ github.event.repository.name }}
       ACTOR: ${{ github.event.comment.user.login }}

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -22,7 +22,7 @@ jobs:
       pull-requests: read
       issues: read
     env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       REPO_OWNER: ${{ github.repository_owner }}
       REPO_NAME: ${{ github.event.repository.name }}
       ACTOR: ${{ github.event.comment.user.login }}


### PR DESCRIPTION
## Problem

`/summary` on PR #222 failed immediately at action pre-flight:

```
GITHUB_TOKEN environment variable is not set. When using
use_github_token, you must provide GITHUB_TOKEN.
```

`/review` and `/oc` are broken the same way. Root cause: PR #218 added `use_github_token: true` to expose the token to the agent shell (needed because OIDC mode strips `GITHUB_TOKEN` from the shell and `gh api` PATCH calls hang). The opencode action's pre-flight on that flag checks for the env var named exactly `GITHUB_TOKEN`. We were setting `GH_TOKEN` at job level, which `gh` CLI accepts but the action does not.

`/jira` is unaffected because it intentionally stays in OIDC mode with no GH auth in the agent shell.

## Solution

Rename the job-level env to `GITHUB_TOKEN` in `opencode.yml`, `opencode-review.yml`, and `opencode-pr-summary.yml`. The maintainer permission check still works because `gh` reads either name.

Also drop the redundant step-level env re-export of `GH_TOKEN`, `REPO_FULL`, `PR_NUMBER` in `opencode-pr-summary.yml`. Job-level env propagates, confirmed from the failure log showing `ACTOR` and `REPO_NAME` reaching the action step despite not being listed there.

## Test plan

After merge, trigger `/summary` on an open PR and verify the action runs end-to-end and PATCHes the PR body.