### PR TITLE
PCSM-313: fix opencode workflow concurrency and permissions

### DIFF
--- a/.github/workflows/opencode-pr-summary.yml
+++ b/.github/workflows/opencode-pr-summary.yml
@@ -5,7 +5,7 @@ name: OpenCode PR Summary
     types: [created]
 
 concurrency:
-  group: pr-summary-${{ github.event.issue.number }}
+  group: pr-summary-${{ github.event.issue.number }}-${{ github.event.comment.body == '/summary' && 'cmd' || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -18,7 +18,7 @@ jobs:
       id-token: write       # opencode action uses OIDC for app-token exchange
       contents: read
       pull-requests: write
-      issues: read
+      issues: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       REPO_FULL: ${{ github.repository }}

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -5,7 +5,7 @@ name: OpenCode Review
     types: [created]
 
 concurrency:
-  group: opencode-review-${{ github.event.issue.number }}
+  group: opencode-review-${{ github.event.issue.number }}-${{ github.event.comment.body == '/review' && 'cmd' || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -17,8 +17,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       REPO_OWNER: ${{ github.repository_owner }}

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -19,8 +19,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       REPO_OWNER: ${{ github.repository_owner }}


### PR DESCRIPTION
### Problem

After PR #218 hardening + PR #223 token rename, two follow-up bugs surfaced when running /summary, /review, and /oc on PR #222.

The /summary and /review runs were getting cancelled in 4 seconds before any step. Their concurrency group keys (`pr-summary-${PR}` and `opencode-review-${PR}`) with `cancel-in-progress: true` collide on every `issue_comment` event. GitHub evaluates concurrency before the workflow's `if:` filter, so an unrelated comment (e.g. /oc landing while /summary is in flight) creates a same-key run that cancels the prior one even though the new run gets if-skipped immediately. /oc escaped this because its workflow uses `cancel-in-progress: false`.

The /oc run actually executed and failed at the action's reaction step with `Resource not accessible by integration` on the `issues/comments/.../reactions` endpoint. With `use_github_token: true` the opencode binary calls reactions and comments via `GITHUB_TOKEN` scoped by the workflow's `permissions:` block, not the App OIDC token. /oc and /review had `pull-requests: read, issues: read`. /summary had `pull-requests: write` but `issues: read`. The reaction endpoint on `issue_comment` requires `issues: write`.

### Solution

For concurrency, gated the group key on the `if:` predicate so only matching runs share the key:

```yaml
group: pr-summary-${{ github.event.issue.number }}-${{ github.event.comment.body == '/summary' && 'cmd' || github.run_id }}
```

When the comment matches, all instances share the `cmd` key and `cancel-in-progress: true` deduplicates genuine /summary spam. When it doesn't match, the unique `run_id` key isolates the doomed-to-skip run. Applied to /summary and /review. /oc untouched.

For permissions, bumped /oc and /review to `pull-requests: write, issues: write`. /summary only needed `issues: write`.

### Test plan

After merge, re-trigger /summary, /review, and /oc on PR #222 to confirm none cancel and all succeed end-to-end.
