### PR TITLE
PCSM-313: Handoff /summary PR data through files

### DIFF
--- a/.github/opencode/summary-prompt.md
+++ b/.github/opencode/summary-prompt.md
@@ -4,11 +4,9 @@ You are editing a GitHub pull request description. The author has written some i
 
 ## Workflow
 
-1. Read the current PR body: `gh api "repos/$REPO_FULL/pulls/$PR_NUMBER"` and parse `.body`.
-2. Read the commits: `gh api "repos/$REPO_FULL/pulls/$PR_NUMBER/commits"`.
-3. Read the file patches: `gh api --paginate "repos/$REPO_FULL/pulls/$PR_NUMBER/files"`.
-4. Produce the new body per the rules below.
-5. Update the PR body: `gh api --method PATCH "repos/$REPO_FULL/pulls/$PR_NUMBER" -f body=@<path to new body file>`.
+1. Read the current PR body, commits, and file patches from the pre-fetched JSON files (paths in Environment below). Do not call `gh api`.
+2. Produce the new body per the rules below.
+3. Write the new body to `$NEW_BODY_FILE`. A follow-up workflow step PATCHes the PR with that file. Your text reply must be one short line confirming the file was written; do not echo the body in your reply.
 
 ## Environment
 
@@ -16,9 +14,14 @@ Your shell has these variables pre-set by the workflow:
 
 - `$REPO_FULL` — GitHub repo in `owner/repo` form
 - `$PR_NUMBER` — the pull request number you are handling
-- `$GH_TOKEN` — GitHub token for `gh api` calls
+- `$PR_PAYLOAD_FILE` — path to a JSON file with the PR object (parse `.body` for the current body, `.title`, etc.)
+- `$PR_COMMITS_FILE` — path to a JSON array of commits on the PR
+- `$PR_FILES_FILE` — path to a JSON array of changed files with patches
+- `$NEW_BODY_FILE` — path to write the new PR body to
 
-Use `$RUNNER_TEMP` for any scratch files.
+Use `$RUNNER_TEMP` for any other scratch files.
+
+You have no GitHub API token. Do not call `gh`, `gh api`, or any GitHub REST endpoint.
 
 ## Required structure
 
@@ -37,7 +40,7 @@ If `### Problem` or `### Solution` is missing, create the heading and place the 
 1. **Never modify author-authored content.** Text that sits outside the agent markers stays exactly as the author wrote it, character-for-character, including whitespace, typos, and formatting quirks.
 2. **Never modify sections that are not Problem, Solution, or Other changes.** `### Testing`, `### Screenshots`, custom sections — all untouched.
 3. **Strip legacy markers.** If the body contains a `<!-- opencode-summary-start -->` ... `<!-- opencode-summary-end -->` block, remove the block and its contents entirely. The content was agent-generated and is superseded by the new per-section markers.
-4. **Do not wrap the response in a code fence.** Return the body as raw markdown. The body may contain code fences internally for diffs or examples — those stay. Do not wrap the whole response.
+4. **Do not wrap the file content in a code fence.** Write raw markdown to `$NEW_BODY_FILE`. The body may contain code fences internally for diffs or examples — those stay. Do not wrap the whole file.
 
 ## What goes inside each marker pair
 
@@ -94,12 +97,11 @@ Switch to a fresh session per chunk and re-derive the shard key before each appl
 
 ## Hard constraints
 
-- The only write operation allowed is the PATCH that updates PR #`$PR_NUMBER`'s body.
-- Do not post any comment on the PR or its commits.
+- The only output side effect is writing to `$NEW_BODY_FILE`. Do not write anywhere else in the filesystem; use `$RUNNER_TEMP` for scratch files only.
+- Do not call `gh`, `gh api`, or any GitHub REST endpoint. You have no token.
 - Do not push commits or modify any branch, including the PR branch.
-- Do not open new PRs, issues, or discussions.
-- Do not edit files in the checked-out workspace. Use `$RUNNER_TEMP` if you need scratch space.
+- Do not edit files in the checked-out workspace.
 
 ## Output
 
-Return ONLY the complete new PR body as markdown. No commentary before or after. No code fences wrapping the whole response.
+Write the complete new PR body as raw markdown to `$NEW_BODY_FILE`. Your conversational reply must be a single short sentence (e.g. `Wrote new PR body to $NEW_BODY_FILE.`). Do not echo the body content in your reply.

--- a/.github/workflows/opencode-pr-summary.yml
+++ b/.github/workflows/opencode-pr-summary.yml
@@ -17,10 +17,10 @@ jobs:
     permissions:
       id-token: write       # opencode action uses OIDC for app-token exchange
       contents: read
-      pull-requests: write
+      pull-requests: write  # bash post-step PATCHes the PR body
       issues: write
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       REPO_FULL: ${{ github.repository }}
       REPO_OWNER: ${{ github.repository_owner }}
       REPO_NAME: ${{ github.event.repository.name }}
@@ -42,6 +42,25 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Read PR payload
+        if: env.SKIP != 'true'
+        run: |
+          set -euo pipefail
+          # Pre-fetch PR data outside the LLM step so the agent does not need
+          # GitHub API access. The opencode step reads from these files instead
+          # of calling `gh api` itself, which previously hung the action.
+          PR_FILE="$RUNNER_TEMP/pr.json"
+          COMMITS_FILE="$RUNNER_TEMP/pr_commits.json"
+          FILES_FILE="$RUNNER_TEMP/pr_files.json"
+          gh api "repos/$REPO_FULL/pulls/$PR_NUMBER" > "$PR_FILE"
+          gh api --paginate "repos/$REPO_FULL/pulls/$PR_NUMBER/commits" > "$COMMITS_FILE"
+          gh api --paginate "repos/$REPO_FULL/pulls/$PR_NUMBER/files" > "$FILES_FILE"
+          {
+            echo "PR_PAYLOAD_FILE=$PR_FILE"
+            echo "PR_COMMITS_FILE=$COMMITS_FILE"
+            echo "PR_FILES_FILE=$FILES_FILE"
+          } >> "$GITHUB_ENV"
+
       - name: Load summary prompt
         if: env.SKIP != 'true'
         id: prompt
@@ -62,12 +81,30 @@ jobs:
         if: env.SKIP != 'true'
         timeout-minutes: 10
         uses: anomalyco/opencode/github@77fc88c8ade8e5a620ebbe1197f3a572d29ae91a # github-v1.2.19
+        # GH_TOKEN is intentionally not passed. The agent reads PR data from
+        # files and writes the new body to NEW_BODY_FILE; a follow-up bash
+        # step PATCHes the PR. This mirrors the /jira flow.
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          REPO_FULL: ${{ env.REPO_FULL }}
+          PR_NUMBER: ${{ env.PR_NUMBER }}
+          PR_PAYLOAD_FILE: ${{ env.PR_PAYLOAD_FILE }}
+          PR_COMMITS_FILE: ${{ env.PR_COMMITS_FILE }}
+          PR_FILES_FILE: ${{ env.PR_FILES_FILE }}
+          NEW_BODY_FILE: ${{ runner.temp }}/new_body.md
         with:
           model: anthropic/claude-opus-4-7
-          # Use GITHUB_TOKEN directly so the agent shell can call `gh api` for the
-          # PR body PATCH. Default OIDC exchange holds the App token internally and
-          # strips it from the agent shell, which causes the PATCH call to hang.
-          use_github_token: true
           prompt: ${{ steps.prompt.outputs.content }}
+
+      - name: Update PR body
+        if: env.SKIP != 'true'
+        run: |
+          set -euo pipefail
+          BODY_FILE="$RUNNER_TEMP/new_body.md"
+          if [[ ! -f "$BODY_FILE" ]]; then
+            echo "::error::New PR body file not produced by opencode step at $BODY_FILE."
+            exit 1
+          fi
+          # --field with @file feeds the body verbatim; no shell quoting hazards.
+          gh api --method PATCH "repos/$REPO_FULL/pulls/$PR_NUMBER" \
+            --field "body=@$BODY_FILE"


### PR DESCRIPTION
## Problem

`/summary` on a PR hangs the opencode action and times out after 10
minutes. The agent issues `gh api "repos/$REPO_FULL/pulls/$PR_NUMBER"`
as its first tool call and produces no output until the step is
killed. The same `gh api` call works fine from the workflow's bash
steps, where `GH_TOKEN` is plain in the env. From the agent shell
launched by the opencode binary it does not, regardless of whether
`use_github_token: true` is set on the action. `/oc` and `/review` are
unaffected because their agents only run `git` commands; the action
posts their replies as comments using its own auth.

## Solution

Mirror the `/jira` flow: read GitHub via workflow bash, hand the data
to the agent through files, write back via workflow bash.

A new `Read PR payload` step calls `gh api` for the PR object,
commits, and files into `$RUNNER_TEMP/*.json` and exports their paths
via `$GITHUB_ENV`. The opencode step now passes only those paths,
`REPO_FULL`, `PR_NUMBER`, and a `NEW_BODY_FILE` target in its env
block. `use_github_token: true` and `GH_TOKEN` are removed from the
opencode step. The agent reads the JSON files, writes the new body to
`$NEW_BODY_FILE`, and replies with one short confirmation line. A
follow-up `Update PR body` step PATCHes the PR via
`gh api --method PATCH ... --field body=@FILE`, which feeds the file
content verbatim with no shell-quoting hazards.

The prompt is updated to match: read from the file env vars, write to
`$NEW_BODY_FILE`, do not call `gh api`. The "you have no GitHub
token" line and explicit `gh` ban are now hard constraints.

## Test plan

After merge, comment `/summary` on PR #222 and confirm the run
completes, the PR body is updated, and the action posts a short
confirmation comment.
