### PR TITLE
PCSM-313: Allow manual dispatch of opencode workflows

### DIFF
--- a/.github/workflows/opencode-pr-summary.yml
+++ b/.github/workflows/opencode-pr-summary.yml
@@ -11,7 +11,7 @@ name: OpenCode PR Summary
         required: true
 
 concurrency:
-  group: pr-summary-${{ github.event.issue.number || inputs.pr_number }}
+  group: pr-summary-${{ github.event.issue.number || inputs.pr_number }}-${{ (github.event_name == 'workflow_dispatch' || github.event.comment.body == '/summary') && 'cmd' || github.run_id }}
   cancel-in-progress: true
 
 permissions:
@@ -166,7 +166,7 @@ jobs:
       pull-requests: write
     env:
       REPO_FULL: ${{ github.repository }}
-      PR_NUMBER: ${{ github.event.issue.number }}
+      PR_NUMBER: ${{ github.event.issue.number || inputs.pr_number }}
     steps:
       - name: Download PR body
         uses: actions/download-artifact@v6

--- a/.github/workflows/opencode-pr-summary.yml
+++ b/.github/workflows/opencode-pr-summary.yml
@@ -3,9 +3,15 @@ name: OpenCode PR Summary
 "on":
   issue_comment:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to summarize'
+        type: number
+        required: true
 
 concurrency:
-  group: pr-summary-${{ github.event.issue.number }}-${{ github.event.comment.body == '/summary' && 'cmd' || github.run_id }}
+  group: pr-summary-${{ github.event.issue.number || inputs.pr_number }}
   cancel-in-progress: true
 
 permissions:
@@ -14,8 +20,9 @@ permissions:
 jobs:
   generate-summary:
     if: |
-      github.event.issue.pull_request != null &&
-      github.event.comment.body == '/summary'
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.issue.pull_request != null &&
+        github.event.comment.body == '/summary')
     runs-on: ubuntu-latest
     permissions:
       id-token: write       # opencode action uses OIDC for app-token exchange
@@ -26,8 +33,8 @@ jobs:
       REPO_FULL: ${{ github.repository }}
       REPO_OWNER: ${{ github.repository_owner }}
       REPO_NAME: ${{ github.event.repository.name }}
-      ACTOR: ${{ github.event.comment.user.login }}
-      PR_NUMBER: ${{ github.event.issue.number }}
+      ACTOR: ${{ github.event.comment.user.login || github.actor }}
+      PR_NUMBER: ${{ github.event.issue.number || inputs.pr_number }}
     outputs:
       skip: ${{ steps.permission.outputs.skip }}
     steps:

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -11,7 +11,7 @@ name: OpenCode Review
         required: true
 
 concurrency:
-  group: opencode-review-${{ github.event.issue.number || inputs.pr_number }}
+  group: opencode-review-${{ github.event.issue.number || inputs.pr_number }}-${{ (github.event_name == 'workflow_dispatch' || github.event.comment.body == '/review') && 'cmd' || github.run_id }}
   cancel-in-progress: true
 
 permissions:
@@ -162,7 +162,7 @@ jobs:
       pull-requests: write
     env:
       REPO_FULL: ${{ github.repository }}
-      PR_NUMBER: ${{ github.event.issue.number }}
+      PR_NUMBER: ${{ github.event.issue.number || inputs.pr_number }}
     steps:
       - name: Download review body
         uses: actions/download-artifact@v6

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -3,9 +3,15 @@ name: OpenCode Review
 "on":
   issue_comment:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to review'
+        type: number
+        required: true
 
 concurrency:
-  group: opencode-review-${{ github.event.issue.number }}-${{ github.event.comment.body == '/review' && 'cmd' || github.run_id }}
+  group: opencode-review-${{ github.event.issue.number || inputs.pr_number }}
   cancel-in-progress: true
 
 permissions:
@@ -14,8 +20,9 @@ permissions:
 jobs:
   generate-review:
     if: |
-      github.event.issue.pull_request != null &&
-      github.event.comment.body == '/review'
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.issue.pull_request != null &&
+        github.event.comment.body == '/review')
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -26,8 +33,8 @@ jobs:
       REPO_FULL: ${{ github.repository }}
       REPO_OWNER: ${{ github.repository_owner }}
       REPO_NAME: ${{ github.event.repository.name }}
-      ACTOR: ${{ github.event.comment.user.login }}
-      PR_NUMBER: ${{ github.event.issue.number }}
+      ACTOR: ${{ github.event.comment.user.login || github.actor }}
+      PR_NUMBER: ${{ github.event.issue.number || inputs.pr_number }}
     outputs:
       skip: ${{ steps.permission.outputs.skip }}
     steps:


### PR DESCRIPTION
[PCSM-313](https://perconadev.atlassian.net/browse/PCSM-313)

### Problem

The \`/summary\` and \`/review\` workflows only run via \`issue_comment\`. That trigger always executes the workflow file from the default branch, so changes to the workflow YAML on a feature branch cannot be validated end-to-end without merging them to \`main\` first.

### Solution

Add a \`workflow_dispatch\` trigger with a required \`pr_number\` input to both \`opencode-review.yml\` and \`opencode-pr-summary.yml\`. The job condition, concurrency group, \`ACTOR\`, and \`PR_NUMBER\` expressions fall back to the dispatch input or \`github.actor\` when \`issue_comment\` context is absent. The maintainer-permission gate, prompt-loading flow, agent step, and validation/post steps stay unchanged.

Once this lands on \`main\`, follow-up hardening work on the same workflows can be validated by running \`gh workflow run "OpenCode Review" --ref <feature-branch> -f pr_number=<test-pr>\` against a real PR before merging.

[PCSM-313]: https://perconadev.atlassian.net/browse/PCSM-313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ