### PR TITLE
PCSM-323: Broken auto segmenter

### DIFF
--- a/.github/workflows/e2etests.yml
+++ b/.github/workflows/e2etests.yml
@@ -149,7 +149,10 @@ jobs:
           export TEST_PCSM_URL=http://127.0.0.1:2242
           export TEST_PCSM_BIN=./bin/pcsm_test
 
-          poetry run pytest
+          # test_clone_auto_segment_size_not_byte_count is RS-only; the bug it
+          # guards is topology-agnostic and the profiler helpers in tests/testing.py
+          # only support replica sets. See the test's docstring for details.
+          poetry run pytest --deselect tests/test_documents.py::test_clone_auto_segment_size_not_byte_count
 
       - name: Teardown Docker Compose
         if: always()

--- a/main.go
+++ b/main.go
@@ -292,8 +292,8 @@ func newStartCmd(cfg *config.Config) *cobra.Command {
 		"Number of read workers during clone (0 = auto)")
 	cmd.Flags().Int("clone-num-insert-workers", 0,
 		"Number of insert workers during clone (0 = auto)")
-	cmd.Flags().String("clone-segment-size", "", "")
-	cmd.Flags().MarkHidden("clone-segment-size") //nolint:errcheck
+	cmd.Flags().String("clone-segment-size", "",
+		"Segment size for clone operations (e.g. \"500MB\", \"1GiB\"). Empty = auto.")
 
 	cmd.Flags().String("clone-read-batch-size", "", "")
 	cmd.Flags().MarkHidden("clone-read-batch-size") //nolint:errcheck

--- a/mdb/retry.go
+++ b/mdb/retry.go
@@ -46,7 +46,7 @@ func RunWithRetry(
 			return err
 		}
 
-		log.Ctx(ctx).Warnf("Transient write error: %v, retry attempt %d retrying in %s",
+		log.Ctx(ctx).Warnf("Transient error: %v, retry attempt %d retrying in %s",
 			err, attempt, currentInterval)
 
 		time.Sleep(currentInterval)

--- a/pcsm/clone/copy.go
+++ b/pcsm/clone/copy.go
@@ -678,10 +678,7 @@ func NewSegmenter(
 	if docCount == 0 {
 		docCount = stats.Size / stats.AvgObjSize
 	}
-	expectedSegments := int64(1)
-	if segmentSize > 0 {
-		expectedSegments = max(1, (docCount+segmentSize-1)/segmentSize)
-	}
+	expectedSegments := max(1, (docCount+segmentSize-1)/segmentSize)
 	log.Ctx(ctx).With(log.NS(ns.Database, ns.Collection)).Infof(
 		"Segmenter for %s.%s: %s (%d docs), segmentation: %s, segment size: %d docs, segments: ~%d",
 		ns.Database, ns.Collection,

--- a/pcsm/clone/copy.go
+++ b/pcsm/clone/copy.go
@@ -337,7 +337,7 @@ func (cm *CopyManager) copyCollection(
 		segmenter, err := NewSegmenter(ctx, cm.source, namespace, SegmentOptions{
 			SegmentSizeBytes: cm.options.SegmentSizeBytes,
 			BatchSizeBytes:   cm.options.ReadBatchSizeBytes,
-			AutoNumSegment:   cm.options.NumReadWorkers,
+			AutoSegmentCount: cm.options.NumReadWorkers,
 		})
 		if err != nil {
 			if errors.Is(err, errEOC) {
@@ -619,12 +619,15 @@ type segmentKey = bson.RawValue
 var nilSegmentID segmentKey //nolint:gochecknoglobals
 
 // SegmentOptions configures how a MongoDB collection is segmented during cloning.
-// It defines the logical segment size in bytes, the read batch size, or the exact number of
-// segments to create.
+// It defines the logical segment size in bytes, the read batch size, and the desired
+// number of segments to produce when running in auto mode.
 type SegmentOptions struct {
 	SegmentSizeBytes int64
 	BatchSizeBytes   int32
-	AutoNumSegment   int
+	// AutoSegmentCount is the desired number of segments per collection when
+	// SegmentSizeBytes is AutoCloneSegmentSize. The actual segment count may
+	// differ due to the MinCloneSegmentSizeBytes floor and integer rounding.
+	AutoSegmentCount int
 }
 
 // NewSegmenter initializes a Segmenter for a given MongoDB namespace.
@@ -652,18 +655,24 @@ func NewSegmenter(
 		return nil, errEOC
 	}
 
-	// AvgObjSize must be less than or equal to 16MiB [config.MaxBSONSize]
+	// AvgObjSize must be less than or equal to 16MiB [config.MaxBSONSize].
 	var (
-		segmentSize int64
-		segmentMode string
+		segmentSizeBytes int64
+		segmentMode      string
 	)
 	if options.SegmentSizeBytes == config.AutoCloneSegmentSize {
-		segmentSize = max(stats.Size/int64(options.AutoNumSegment), config.MinCloneSegmentSizeBytes)
+		segmentSizeBytes = max(
+			stats.Size/int64(options.AutoSegmentCount),
+			config.MinCloneSegmentSizeBytes,
+		)
 		segmentMode = "auto"
 	} else {
-		segmentSize = options.SegmentSizeBytes / stats.AvgObjSize
+		segmentSizeBytes = options.SegmentSizeBytes
 		segmentMode = "explicit"
 	}
+	// Guard against AvgObjSize > segmentSizeBytes (tiny collection / huge docs)
+	// which would otherwise produce segmentSize = 0 and collapse segmentation.
+	segmentSize := max(segmentSizeBytes/stats.AvgObjSize, 1)
 
 	docCount := stats.Count
 	if docCount == 0 {

--- a/pcsm/clone/copy.go
+++ b/pcsm/clone/copy.go
@@ -984,7 +984,7 @@ func NewCappedSegmenter(
 		docCount = stats.Size / stats.AvgObjSize
 	}
 	log.Ctx(ctx).With(log.NS(ns.Database, ns.Collection)).Infof(
-		"Capped segmenter for %s.%s: %s (%d docs), copy sequentially",
+		"Capped segmenter for %s.%s: %s (%d docs), copy sequentially, single segment covering entire collection",
 		ns.Database, ns.Collection,
 		humanize.Bytes(uint64(stats.Size)), //nolint:gosec
 		docCount,

--- a/pcsm/clone/copy.go
+++ b/pcsm/clone/copy.go
@@ -333,9 +333,6 @@ func (cm *CopyManager) copyCollection(
 		}
 
 		nextSegment = segmenter.Next
-
-		log.New("clone").With(log.NS(namespace.Database, namespace.Collection)).
-			Debugf("Capped collection %q: copy sequentially", namespace)
 	} else {
 		segmenter, err := NewSegmenter(ctx, cm.source, namespace, SegmentOptions{
 			SegmentSizeBytes: cm.options.SegmentSizeBytes,
@@ -354,6 +351,8 @@ func (cm *CopyManager) copyCollection(
 
 		go segmenter.handleNanIDDoc(session)
 	}
+
+	log.Ctx(ctx).Infof("Starting collection copy: %s.%s", namespace.Database, namespace.Collection)
 
 	go cm.runReadDispatcher(session, nextSegment, progressUpdateCh)
 	go cm.runInsertDispatcher(session, progressUpdateCh)
@@ -654,15 +653,35 @@ func NewSegmenter(
 	}
 
 	// AvgObjSize must be less than or equal to 16MiB [config.MaxBSONSize]
-	var segmentSize int64
+	var (
+		segmentSize int64
+		segmentMode string
+	)
 	if options.SegmentSizeBytes == config.AutoCloneSegmentSize {
 		segmentSize = max(stats.Size/int64(options.AutoNumSegment), config.MinCloneSegmentSizeBytes)
-
-		log.Ctx(ctx).Debugf("SegmentSizeBytes (auto): %d (%s)",
-			segmentSize, humanize.Bytes(uint64(segmentSize))) //nolint:gosec
+		segmentMode = "auto"
 	} else {
 		segmentSize = options.SegmentSizeBytes / stats.AvgObjSize
+		segmentMode = "explicit"
 	}
+
+	docCount := stats.Count
+	if docCount == 0 {
+		docCount = stats.Size / stats.AvgObjSize
+	}
+	expectedSegments := int64(1)
+	if segmentSize > 0 {
+		expectedSegments = max(1, (docCount+segmentSize-1)/segmentSize)
+	}
+	log.Ctx(ctx).With(log.NS(ns.Database, ns.Collection)).Infof(
+		"Segmenter for %s.%s: %s (%d docs), segmentation: %s, segment size: %d docs, segments: ~%d",
+		ns.Database, ns.Collection,
+		humanize.Bytes(uint64(stats.Size)), //nolint:gosec
+		docCount,
+		segmentMode,
+		segmentSize,
+		expectedSegments,
+	)
 
 	//nolint:gosec
 	batchSize := int32(min(int64(options.BatchSizeBytes)/stats.AvgObjSize, math.MaxInt32))
@@ -950,6 +969,17 @@ func NewCappedSegmenter(
 	if stats.AvgObjSize == 0 {
 		return nil, errEOC
 	}
+
+	docCount := stats.Count
+	if docCount == 0 {
+		docCount = stats.Size / stats.AvgObjSize
+	}
+	log.Ctx(ctx).With(log.NS(ns.Database, ns.Collection)).Infof(
+		"Capped segmenter for %s.%s: %s (%d docs), copy sequentially",
+		ns.Database, ns.Collection,
+		humanize.Bytes(uint64(stats.Size)), //nolint:gosec
+		docCount,
+	)
 
 	batchSize := int32(min(int64(batchSizeBytes)/stats.AvgObjSize, math.MaxInt32)) //nolint:gosec
 	mcoll := m.Database(ns.Database).Collection(ns.Collection)

--- a/pcsm/clone/copy.go
+++ b/pcsm/clone/copy.go
@@ -823,13 +823,20 @@ func (seg *Segmenter) findSegmentMaxKey(
 	minKey segmentKey,
 	maxKey segmentKey,
 ) (segmentKey, error) {
-	raw, err := seg.mcoll.FindOne(ctx,
-		bson.D{{"_id", bson.D{{"$gt", minKey}, {"$lte", maxKey}}}},
-		options.FindOne().
-			SetSort(bson.D{{"_id", 1}}).
-			SetSkip(seg.segmentSize).
-			SetProjection(bson.D{{"_id", 1}}),
-	).Raw()
+	var raw bson.Raw
+
+	err := mdb.RunWithRetry(ctx, func(ctx context.Context) error {
+		var inner error
+		raw, inner = seg.mcoll.FindOne(ctx,
+			bson.D{{"_id", bson.D{{"$gt", minKey}, {"$lte", maxKey}}}},
+			options.FindOne().
+				SetSort(bson.D{{"_id", 1}}).
+				SetSkip(seg.segmentSize).
+				SetProjection(bson.D{{"_id", 1}}),
+		).Raw()
+
+		return inner //nolint:wrapcheck
+	}, mdb.DefaultRetryInterval, mdb.DefaultMaxRetries)
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
 			return maxKey, nil

--- a/tests/pcsm.py
+++ b/tests/pcsm.py
@@ -58,6 +58,7 @@ class PCSM:
         exclude_namespaces=None,
         pause_on_initial_sync=False,
         clone_segment_size=None,
+        clone_num_read_workers=None,
     ):
         """Start the PCSM service with the given parameters."""
         options = {"pauseOnInitialSync": pause_on_initial_sync}
@@ -67,6 +68,8 @@ class PCSM:
             options["excludeNamespaces"] = exclude_namespaces
         if clone_segment_size is not None:
             options["cloneSegmentSize"] = clone_segment_size
+        if clone_num_read_workers is not None:
+            options["cloneNumReadWorkers"] = clone_num_read_workers
 
         res = requests.post(f"{self.uri}/start", json=options, timeout=DFL_REQ_TIMEOUT)
         res.raise_for_status()

--- a/tests/pcsm.py
+++ b/tests/pcsm.py
@@ -52,13 +52,21 @@ class PCSM:
 
         return payload
 
-    def start(self, include_namespaces=None, exclude_namespaces=None, pause_on_initial_sync=False):
+    def start(
+        self,
+        include_namespaces=None,
+        exclude_namespaces=None,
+        pause_on_initial_sync=False,
+        clone_segment_size=None,
+    ):
         """Start the PCSM service with the given parameters."""
         options = {"pauseOnInitialSync": pause_on_initial_sync}
         if include_namespaces:
             options["includeNamespaces"] = include_namespaces
         if exclude_namespaces:
             options["excludeNamespaces"] = exclude_namespaces
+        if clone_segment_size is not None:
+            options["cloneSegmentSize"] = clone_segment_size
 
         res = requests.post(f"{self.uri}/start", json=options, timeout=DFL_REQ_TIMEOUT)
         res.raise_for_status()

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -663,10 +663,16 @@ def test_clone_auto_segment_size_not_byte_count(t: Testing):
         f"got {len(entries)} entries without skip"
     )
 
-    buggy = [s for s in skips if s > doc_count]
+    # The bug passes MinCloneSegmentSizeBytes (~480MB, in bytes) as the skip
+    # value for any small collection where the floor kicks in. With the fix,
+    # the skip value is a document count — at most MinCloneSegmentSizeBytes /
+    # AvgObjSize, which is strictly less than the byte floor for any
+    # AvgObjSize > 1. Use the floor as the cutoff to distinguish.
+    byte_floor = 479_994_880  # config.MinCloneSegmentSizeBytes
+    buggy = [s for s in skips if s >= byte_floor]
     assert not buggy, (
         f"segmenter passed byte count to find().skip(): {buggy}; "
-        f"collection has {doc_count} documents"
+        f"expected doc count strictly below the byte floor ({byte_floor})"
     )
 
     t.compare_all(sort=[("_id", pymongo.ASCENDING)])

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1,9 +1,11 @@
 # pylint: disable=missing-docstring,redefined-outer-name
+import random
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 
 import pymongo
 import pytest
+import testing
 from testing import Testing
 
 from pcsm import Runner
@@ -637,6 +639,43 @@ def test_id_type(t: Testing, phase: Runner.Phase):
         )
 
     t.compare_all()
+
+
+def test_clone_auto_segment_size_not_byte_count(t: Testing):
+    """Auto-mode segmenter must pass doc counts, not byte counts, to find().skip().
+
+    Detection: enable the MongoDB profiler on every source mongod (all RS members,
+    or all members of every shard for sharded clusters), run the clone, then
+    inspect system.profile for the segmenter's boundary query and assert its
+    `skip` value is bounded by the document count.
+    """
+    db, coll = "db_1", "coll_1"
+    doc_count = 50_000
+
+    t.source[db][coll].insert_many(
+        [{"s": random.randbytes(1024)} for _ in range(doc_count)],
+    )
+
+    with testing.enable_profiling(t.source, db) as profile_clients:
+        with t.run(phase=Runner.Phase.CLONE, wait_timeout=60):
+            pass
+        entries = testing.find_profile_entries(
+            profile_clients, db, {"ns": f"{db}.{coll}", "command.find": coll}
+        )
+
+    skips = [e["command"]["skip"] for e in entries if "skip" in e.get("command", {})]
+    assert skips, (
+        f"expected segmenter boundary find() with skip in system.profile; "
+        f"got {len(entries)} entries without skip"
+    )
+
+    buggy = [s for s in skips if s > doc_count]
+    assert not buggy, (
+        f"segmenter passed byte count to find().skip(): {buggy}; "
+        f"collection has {doc_count} documents"
+    )
+
+    t.compare_all(sort=[("_id", pymongo.ASCENDING)])
 
 
 @pytest.mark.timeout(180)

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -642,13 +642,7 @@ def test_id_type(t: Testing, phase: Runner.Phase):
 
 
 def test_clone_auto_segment_size_not_byte_count(t: Testing):
-    """Auto-mode segmenter must pass doc counts, not byte counts, to find().skip().
-
-    Detection: enable the MongoDB profiler on every source mongod (all RS members,
-    or all members of every shard for sharded clusters), run the clone, then
-    inspect system.profile for the segmenter's boundary query and assert its
-    `skip` value is bounded by the document count.
-    """
+    """Auto-mode segmenter must pass doc counts, not byte counts, to find().skip()."""
     db, coll = "db_1", "coll_1"
     doc_count = 50_000
 

--- a/tests/test_slow.py
+++ b/tests/test_slow.py
@@ -133,8 +133,8 @@ def test_slow_clone_2gb_capped_vary_id(t: Testing):
 
 @pytest.mark.slow
 @pytest.mark.timeout(600)
-def test_slow_clone_collection_with_multile_segments(t: Testing):
-    """Clone a collection large enough to be split into multiple segments.
+def test_slow_clone_collection_explicit_segmentation(t: Testing):
+    """Clone a large collection with explicit segmentation (with --clone-segment-size option).
 
     Uses an explicit cloneSegmentSize of 500MB against a ~1.6GB collection so
     the segmenter produces multiple segments. Asserts that source and target
@@ -154,6 +154,44 @@ def test_slow_clone_collection_with_multile_segments(t: Testing):
         phase=Runner.Phase.CLONE,
         wait_timeout=600,
         options={"clone_segment_size": "500MB"},
+    ):
+        pass  # data already populated; just run the clone
+
+    try:
+        source_count = t.source[db][coll].count_documents({})
+        target_count = t.target[db][coll].count_documents({})
+        assert source_count == doc_count, f"source has {source_count} docs, expected {doc_count}"
+        assert target_count == doc_count, f"target has {target_count} docs, expected {doc_count}"
+        t.compare_all(sort=[("_id", pymongo.ASCENDING)])
+    finally:
+        # clean up after to avoid consuming other tests running time
+        testing.drop_all_database(t.source)
+        testing.drop_all_database(t.target)
+
+
+@pytest.mark.slow
+@pytest.mark.timeout(600)
+def test_slow_clone_collection_auto_segmentation(t: Testing):
+    """Clone a large collection using auto segmentation.
+
+    worker count is pinned via cloneNumReadWorkers so the auto branch
+    produces multiple segments deterministically regardless of runner CPU
+    count.
+
+    Replica-set only.
+    """
+    db, coll = "db_0", "coll_0"
+    doc_count = 1_600_000  # ~1.6 GB at 1 KB per doc
+
+    for _ in range(160):  # 160 batches x 10,000 = 1.6M docs
+        t.source[db][coll].insert_many(
+            [{"s": random.randbytes(1024)} for _ in range(10000)],
+        )
+
+    with t.run(
+        phase=Runner.Phase.CLONE,
+        wait_timeout=600,
+        options={"clone_num_read_workers": 3},
     ):
         pass  # data already populated; just run the clone
 

--- a/tests/test_slow.py
+++ b/tests/test_slow.py
@@ -132,6 +132,44 @@ def test_slow_clone_2gb_capped_vary_id(t: Testing):
 
 
 @pytest.mark.slow
+@pytest.mark.timeout(600)
+def test_slow_clone_collection_with_multile_segments(t: Testing):
+    """Clone a collection large enough to be split into multiple segments.
+
+    Uses an explicit cloneSegmentSize of 500MB against a ~1.6GB collection so
+    the segmenter produces multiple segments. Asserts that source and target
+    have matching document counts and contents after the clone completes.
+
+    Replica-set only.
+    """
+    db, coll = "db_0", "coll_0"
+    doc_count = 1_600_000  # ~1.6 GB at 1 KB per doc
+
+    for _ in range(160):  # 160 batches x 10,000 = 1.6M docs
+        t.source[db][coll].insert_many(
+            [{"s": random.randbytes(1024)} for _ in range(10000)],
+        )
+
+    with t.run(
+        phase=Runner.Phase.CLONE,
+        wait_timeout=600,
+        options={"clone_segment_size": "500MB"},
+    ):
+        pass  # data already populated; just run the clone
+
+    try:
+        source_count = t.source[db][coll].count_documents({})
+        target_count = t.target[db][coll].count_documents({})
+        assert source_count == doc_count, f"source has {source_count} docs, expected {doc_count}"
+        assert target_count == doc_count, f"target has {target_count} docs, expected {doc_count}"
+        t.compare_all(sort=[("_id", pymongo.ASCENDING)])
+    finally:
+        # clean up after to avoid consuming other tests running time
+        testing.drop_all_database(t.source)
+        testing.drop_all_database(t.target)
+
+
+@pytest.mark.slow
 @pytest.mark.timeout(240)
 def test_slow_pcsm_119_clone_numerous_collections_deadlock(t: Testing):
     with t.run(phase=Runner.Phase.CLONE, wait_timeout=180):

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -1,4 +1,5 @@
 # pylint: disable=missing-docstring,redefined-outer-name
+import contextlib
 import hashlib
 import time
 
@@ -126,6 +127,65 @@ def compare_namespace(source: MongoClient, target: MongoClient, db: str, coll: s
     target_count, target_hash = _coll_content(target[db][coll], sort)
     assert source_count == target_count, f"{ns}: {source_count=} != {target_count=}"
     assert source_hash == target_hash, f"{ns}: {source_hash=} != {target_hash=}"
+
+
+def _profile_node_uris(client: MongoClient):
+    """Return mongodb:// URIs for every mongod where profiling must be set.
+
+    - Replica set: one URI per member (primary + secondaries).
+    - Sharded cluster: one URI per member of every shard. The `profile`
+      command cannot be issued through mongos.
+    """
+    hello = client.admin.command("hello")
+
+    if hello.get("msg") == "isdbgrid":
+        uris: list[str] = []
+        # `config.shards.host` is "<rsName>/<host1>,<host2>,...".
+        for shard in client["config"]["shards"].find({}):
+            host = shard.get("host", "")
+            hosts = host.split("/", 1)[1] if "/" in host else host
+            shard_client = MongoClient(f"mongodb://{hosts}")
+            try:
+                shard_hello = shard_client.admin.command("hello")
+                for h in shard_hello.get("hosts", []):
+                    uris.append(f"mongodb://{h}")
+            finally:
+                shard_client.close()
+        return uris
+
+    return [f"mongodb://{h}" for h in hello.get("hosts", [])]
+
+
+@contextlib.contextmanager
+def enable_profiling(client: MongoClient, db: str, level: int = 2):
+    """Enable the MongoDB profiler on every relevant mongod for `db`.
+
+    Yields a list of MongoClients pointing at each profiled node (one per
+    mongod). On exit, profiling is reset to 0 on each node and clients are
+    closed. Works for replica sets and sharded clusters.
+    """
+    members: list[MongoClient] = [
+        MongoClient(uri, directConnection=True) for uri in _profile_node_uris(client)
+    ]
+    try:
+        for m in members:
+            m[db].command("profile", level)
+        yield members
+    finally:
+        for m in members:
+            try:
+                m[db].command("profile", 0)
+            except Exception:  # noqa: BLE001 - best-effort cleanup
+                pass
+            m.close()
+
+
+def find_profile_entries(clients: list[MongoClient], db: str, filt: dict):
+    """Search `system.profile` across all given mongod clients."""
+    results = []
+    for c in clients:
+        results.extend(c[db]["system.profile"].find(filt))
+    return results
 
 
 def _coll_content(coll: Collection, sort=None):

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -129,43 +129,21 @@ def compare_namespace(source: MongoClient, target: MongoClient, db: str, coll: s
     assert source_hash == target_hash, f"{ns}: {source_hash=} != {target_hash=}"
 
 
-def _profile_node_uris(client: MongoClient):
-    """Return mongodb:// URIs for every mongod where profiling must be set.
-
-    - Replica set: one URI per member (primary + secondaries).
-    - Sharded cluster: one URI per member of every shard. The `profile`
-      command cannot be issued through mongos.
-    """
+def _replset_member_uris(client: MongoClient):
+    """Return mongodb:// URIs for every member of the replica set."""
     hello = client.admin.command("hello")
-
-    if hello.get("msg") == "isdbgrid":
-        uris: list[str] = []
-        # `config.shards.host` is "<rsName>/<host1>,<host2>,...".
-        for shard in client["config"]["shards"].find({}):
-            host = shard.get("host", "")
-            hosts = host.split("/", 1)[1] if "/" in host else host
-            shard_client = MongoClient(f"mongodb://{hosts}")
-            try:
-                shard_hello = shard_client.admin.command("hello")
-                for h in shard_hello.get("hosts", []):
-                    uris.append(f"mongodb://{h}")
-            finally:
-                shard_client.close()
-        return uris
-
     return [f"mongodb://{h}" for h in hello.get("hosts", [])]
 
 
 @contextlib.contextmanager
 def enable_profiling(client: MongoClient, db: str, level: int = 2):
-    """Enable the MongoDB profiler on every relevant mongod for `db`.
+    """Enable the MongoDB profiler on every replica-set member for `db`.
 
-    Yields a list of MongoClients pointing at each profiled node (one per
-    mongod). On exit, profiling is reset to 0 on each node and clients are
-    closed. Works for replica sets and sharded clusters.
+    Yields one direct-connection MongoClient per profiled mongod. Profiling
+    is reset and clients are closed on exit.
     """
     members: list[MongoClient] = [
-        MongoClient(uri, directConnection=True) for uri in _profile_node_uris(client)
+        MongoClient(uri, directConnection=True) for uri in _replset_member_uris(client)
     ]
     try:
         for m in members:
@@ -181,7 +159,7 @@ def enable_profiling(client: MongoClient, db: str, level: int = 2):
 
 
 def find_profile_entries(clients: list[MongoClient], db: str, filt: dict):
-    """Search `system.profile` across all given mongod clients."""
+    """Search system.profile across all given mongod clients."""
     results = []
     for c in clients:
         results.extend(c[db]["system.profile"].find(filt))

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -18,9 +18,11 @@ class Testing:
         self.target: MongoClient = target
         self.pcsm: PCSM = pcsm
 
-    def run(self, phase: Runner.Phase, wait_timeout=None):
+    def run(self, phase: Runner.Phase, wait_timeout=None, options=None):
         """Perform the PCSM operation for the given phase."""
-        return Runner(self.source, self.target, self.pcsm, phase, {}, wait_timeout=wait_timeout)
+        return Runner(
+            self.source, self.target, self.pcsm, phase, options or {}, wait_timeout=wait_timeout
+        )
 
     def compare_all(self, sort=None):
         """Compare all databases and collections between source and target MongoDB."""


### PR DESCRIPTION
[PCSM-323](https://perconadev.atlassian.net/browse/PCSM-323)

### Problem

In auto segmentation mode, PCSM computed each segment's size in bytes (`stats.Size / numWorkers`, clamped to a byte floor) but then passed that byte value verbatim to MongoDB's `find().skip()`, which expects a document count. On large collections this produced a skip value orders of magnitude larger than the document count, causing the boundary query to walk the entire `_id` index and time out — leaving the clone stuck with `clonedSizeBytes: 0`. On small collections the bug was silent: the impossible skip returned `ErrNoDocuments`, the segmenter collapsed to a single segment, and the clone succeeded single-threaded. The explicit segment-size branch already converted bytes to documents correctly, so only auto mode was affected.


### Solution

Compute the segment size in bytes in both branches, then perform the bytes-to-documents conversion (`/ stats.AvgObjSize`) once after the branch so there is a single source of truth for the unit. A small floor guards against the edge case where the average document is larger than the segment size, which would otherwise collapse segmentation. The segmenter's auto-mode field is renamed to `AutoSegmentCount` to reflect its actual role. 

Important side effect of this fix is that now clone for large collections will be faster, that is properly parallelized. Before the fix, since we passed bytes number instead of doc count, we essentially always got a single large segment for a collection, that is then handled by a single reader and sent to number of writers. Now auto segmentation actually works and so reading collections will happen in parallel for each segment (up to the number of available read workers).

Each collection clone now emits a one-line summary that exposes the segmenter inputs and the expected outcome:

```
INF Segmenter for db_0.coll0: 1.7 GB (1600000 docs), segmentation: auto, segment size: 533333 docs, segments: ~3 ns=db0.coll0 s=copy
INF Starting collection copy: db0.coll0                                                                            ns=db0.coll_0 s=copy

```

Capped collections get the equivalent line tagged for sequential copy:
```
INF Capped segmenter for db0.coll0: 53 MB (50000 docs), copy sequentially, single segment covering entire collection   ns=db0.coll0 s=copy
INF Starting collection copy: db0.coll0                                     ns=db0.coll0 s=copy
```

PR exposes previously hidden option so users can avoid auto segmentation and state their own segment size:
- `--clone-segment-size`: Segment size for clone operations (e.g. \"500MB\", \"1GiB\"). Empty = auto.



Added two `slow` e2e tests testing explicit and auto segmenters and that PCSM correctly segments large collection:
- tests/test_slow.py::test_slow_clone_collection_auto_segmentation
- tests/test_slow.py::test_slow_clone_collection_explicit_segmentation



[PCSM-323]: https://perconadev.atlassian.net/browse/PCSM-323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
