### PR TITLE
PCSM-282: PCSM packaging add SBOM

### DIFF
--- a/packaging/debian/install
+++ b/packaging/debian/install
@@ -2,3 +2,4 @@ debian/tmp/pcsm /usr/bin/
 debian/tmp/default/pcsm /etc/default/
 debian/tmp/pcsm.service /lib/systemd/system/
 debian/tmp/LICENSE /usr/share/doc/percona-clustersync-mongodb/
+debian/tmp/percona-clustersync-mongodb-*.cdx.json /usr/share/doc/percona-clustersync-mongodb/

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -56,6 +56,23 @@ override_dh_auto_install:
 	cp -f packaging/conf/pcsm.env  $(TMP)/default/pcsm
 	cp -f packaging/conf/pcsm.service $(TMP)/pcsm.service
 	cp -f LICENSE $(TMP)/LICENSE
+	# CycloneDX 1.6 SBOM for the .deb. Scope = Go binaries in $(TMP); filename
+	# is self-identifying when extracted from /usr/share/doc/. Catalogers
+	# limited to go-module-binary-cataloger (tarball-equivalent scope); file
+	# catalogers disabled to keep package-level granularity.
+	syft scan "dir:$(TMP)" \
+		--override-default-catalogers go-module-binary-cataloger \
+		--select-catalogers "-file" \
+		--source-name "percona-clustersync-mongodb" \
+		--source-version "$(VERSION)" \
+		-o "cyclonedx-json@1.6=$(TMP)/percona-clustersync-mongodb-$(VERSION).cdx.json"
+	# Overwrite syft's auto-generated metadata.component (type=file, opaque
+	# bom-ref) with a proper application identity including a deb PURL.
+	jq --arg purl "pkg:deb/percona-clustersync-mongodb@$(VERSION)" --arg ver "$(VERSION)" '.metadata.component = {"bom-ref": $$purl, "type": "application", "name": "percona-clustersync-mongodb", "version": $$ver, "purl": $$purl}' \
+		$(TMP)/percona-clustersync-mongodb-$(VERSION).cdx.json > $(TMP)/sbom.tmp \
+		&& mv $(TMP)/sbom.tmp $(TMP)/percona-clustersync-mongodb-$(VERSION).cdx.json
+	test "$$(jq '.components | length' $(TMP)/percona-clustersync-mongodb-$(VERSION).cdx.json)" -ge 10 \
+		|| { echo "ERROR: DEB SBOM has too few components" >&2; exit 1; }
 	ls -la $(TMP)
 
 override_dh_systemd_start:

--- a/packaging/rpm/percona-clustersync-mongodb.spec
+++ b/packaging/rpm/percona-clustersync-mongodb.spec
@@ -10,7 +10,7 @@ Group:  Applications/Databases
 License: ASL 2.0
 Source0: percona-clustersync-mongodb-%{version}.tar.gz
 
-BuildRequires: golang make git
+BuildRequires: golang make git jq
 BuildRequires:  systemd
 BuildRequires:  pkgconfig(systemd)
 Requires(pre): /usr/sbin/useradd, /usr/bin/getent
@@ -68,6 +68,31 @@ install -D -m 0640 github.com/percona/percona-clustersync-mongodb/packaging/conf
 install -m 0755 -d $RPM_BUILD_ROOT/%{_unitdir}
 install -m 0644 github.com/percona/percona-clustersync-mongodb/packaging/conf/pcsm.service $RPM_BUILD_ROOT/%{_unitdir}/pcsm.service
 
+# CycloneDX 1.6 SBOM for the .rpm. Scope = Go binaries in %{_bindir}; filename
+# is self-identifying when extracted from /usr/share/doc/. Catalogers limited
+# to go-module-binary-cataloger (tarball-equivalent scope); file catalogers
+# disabled to keep package-level granularity.
+install -m 0755 -d $RPM_BUILD_ROOT/%{_docdir}/percona-clustersync-mongodb
+SBOM_PATH=$RPM_BUILD_ROOT/%{_docdir}/percona-clustersync-mongodb/percona-clustersync-mongodb-%{version}.cdx.json
+syft scan "dir:$RPM_BUILD_ROOT/%{_bindir}" \
+    --override-default-catalogers go-module-binary-cataloger \
+    --select-catalogers "-file" \
+    --source-name "percona-clustersync-mongodb" \
+    --source-version "%{version}" \
+    -o "cyclonedx-json@1.6=$SBOM_PATH"
+# Overwrite syft's auto-generated metadata.component (type=file, opaque
+# bom-ref) with a proper application identity including an rpm PURL.
+SBOM_PURL="pkg:rpm/percona-clustersync-mongodb@%{version}"
+jq --arg purl "$SBOM_PURL" --arg ver "%{version}" '.metadata.component = {
+    "bom-ref": $purl,
+    "type": "application",
+    "name": "percona-clustersync-mongodb",
+    "version": $ver,
+    "purl": $purl
+}' "$SBOM_PATH" > "$SBOM_PATH.tmp" && mv "$SBOM_PATH.tmp" "$SBOM_PATH"
+test "$(jq '.components | length' $SBOM_PATH)" -ge 10 \
+    || { echo "ERROR: RPM SBOM has too few components" >&2; exit 1; }
+
 %pre -n percona-clustersync-mongodb
 	/usr/bin/getent group mongod || /usr/sbin/groupadd -r mongod
 	/usr/bin/getent passwd mongod || /usr/sbin/useradd -M -r -g mongod -d /var/lib/mongo -s /bin/false -c mongod mongod
@@ -103,6 +128,8 @@ esac
 
 %files -n percona-clustersync-mongodb
 %{_bindir}/pcsm
+%dir %{_docdir}/percona-clustersync-mongodb
+%{_docdir}/percona-clustersync-mongodb/percona-clustersync-mongodb-%{version}.cdx.json
 %config(noreplace) %attr(0640,root,root) /%{_sysconfdir}/sysconfig/pcsm
 %{_unitdir}/pcsm.service
 

--- a/packaging/scripts/percona-clustersync-mongodb_builder.sh
+++ b/packaging/scripts/percona-clustersync-mongodb_builder.sh
@@ -227,7 +227,9 @@ install_deps() {
 }
 
 get_tar() {
-    TARBALL=$1
+    # `local` keeps TARBALL from clobbering the global flag that controls
+    # whether build_tarball runs at the end of the main flow.
+    local TARBALL=$1
     TARFILE=$(basename $(find $WORKDIR/$TARBALL -name 'percona-clustersync-mongodb*.tar.gz' | sort | tail -n1))
     if [ -z $TARFILE ]; then
         TARFILE=$(basename $(find $CURDIR/$TARBALL -name 'percona-clustersync-mongodb*.tar.gz' | sort | tail -n1))
@@ -244,9 +246,9 @@ get_tar() {
 }
 
 get_deb_sources() {
-    param=$1
+    local param=$1
     echo $param
-    FILE=$(basename $(find $WORKDIR/source_deb -name "percona-clustersync-mongodb*.$param" | sort | tail -n1))
+    local FILE=$(basename $(find $WORKDIR/source_deb -name "percona-clustersync-mongodb*.$param" | sort | tail -n1))
     if [ -z $FILE ]; then
         FILE=$(basename $(find $CURDIR/source_deb -name "percona-clustersync-mongodb*.$param" | sort | tail -n1))
         if [ -z $FILE ]; then
@@ -548,8 +550,8 @@ check_workdir
 get_system
 install_deps
 get_sources
+build_tarball
 build_srpm
 build_source_deb
 build_rpm
 build_deb
-build_tarball

--- a/packaging/scripts/percona-clustersync-mongodb_builder.sh
+++ b/packaging/scripts/percona-clustersync-mongodb_builder.sh
@@ -168,6 +168,26 @@ install_golang() {
     ln -s /usr/local/go${GO_VERSION} /usr/local/go
 }
 
+install_sbom_tools() {
+    # Install Syft (SBOM generator) and Grype (vulnerability scanner) on the
+    # build host.
+    #
+    # Use the official Anchore installer scripts because they auto-detect the
+    # host architecture (x86_64 -> amd64, aarch64 -> arm64) and OS.
+    # No pinned version yet.
+    for tool in syft grype; do
+        url="https://raw.githubusercontent.com/anchore/${tool}/main/install.sh"
+        for i in {1..3}; do
+            curl -fsSL "$url" | sh -s -- -b /usr/local/bin && break
+            sleep 10
+        done
+        command -v "$tool" >/dev/null \
+            || { echo "ERROR: ${tool} not installed after 3 attempts" >&2; exit 1; }
+    done
+    syft version
+    grype version
+}
+
 install_deps() {
     if [ $INSTALL = 0 ]; then
         echo "Dependencies will not be installed"
@@ -184,7 +204,7 @@ install_deps() {
         if [ "x${RHEL}" != "x2023" ]; then
             yum -y install epel-release
         fi
-        yum -y install git wget
+        yum -y install git wget jq
         yum -y install rpm-build make rpmdevtools golang systemd
         install_golang
     else
@@ -195,13 +215,14 @@ install_deps() {
         DEBIAN_FRONTEND=noninteractive apt-get -y install lsb-release
         export DEBIAN=$(lsb_release -sc)
         export ARCH=$(echo $(uname -m) | sed -e 's:i686:i386:g')
-        INSTALL_LIST="wget devscripts debhelper debconf pkg-config curl make golang git systemd"
+        INSTALL_LIST="wget devscripts debhelper debconf pkg-config curl make golang git systemd jq"
         until DEBIAN_FRONTEND=noninteractive apt-get -y install ${INSTALL_LIST}; do
             sleep 1
             echo "waiting"
         done
         install_golang
     fi
+    install_sbom_tools
     return
 }
 
@@ -456,6 +477,41 @@ build_tarball() {
     export GITCOMMIT
     make build
     cp ./bin/pcsm ${WORKDIR}/${PCSMDIR}/
+
+    # Place SBOM at the root of the tarball staging dir so it will be packed
+    # in the archive root.
+    # Scope = ./bin only (the pcsm Go binary that goes into the tarball).
+    # Catalogers limited to go-module-binary-cataloger because a tarball is
+    # OS-agnostic; the "file" cataloger group is disabled to keep package
+    # granularity (no per-file hashes/metadata).
+    # The jq count below guards against silent syft failures.
+    SBOM_FILE="${WORKDIR}/${PCSMDIR}/${PRODUCT}-${VERSION}.cdx.json"
+    echo "Generating CycloneDX 1.6 SBOM for binary tarball..."
+    syft scan "dir:./bin" \
+        --override-default-catalogers go-module-binary-cataloger \
+        --select-catalogers "-file" \
+        --source-name "percona-clustersync-mongodb" \
+        --source-version "${VERSION}" \
+        -o "cyclonedx-json@1.6=${SBOM_FILE}" \
+        || { echo "ERROR: syft scan failed for binary tarball" >&2; exit 1; }
+    # Overwrite syft's auto-generated metadata.component (type=file, opaque
+    # bom-ref) with a proper application identity including a PURL. Tarball is
+    # OS-agnostic, so PURL type is "generic".
+    SBOM_PURL="pkg:generic/percona-clustersync-mongodb@${VERSION}"
+    jq --arg purl "${SBOM_PURL}" --arg ver "${VERSION}" '.metadata.component = {
+        "bom-ref": $purl,
+        "type": "application",
+        "name": "percona-clustersync-mongodb",
+        "version": $ver,
+        "purl": $purl
+    }' "${SBOM_FILE}" > "${SBOM_FILE}.tmp" && mv "${SBOM_FILE}.tmp" "${SBOM_FILE}"
+    COMPONENT_COUNT=$(jq '.components | length' "${SBOM_FILE}")
+    if [ "$COMPONENT_COUNT" -lt 10 ]; then
+        echo "ERROR: tarball SBOM has only ${COMPONENT_COUNT} components" >&2
+        exit 1
+    fi
+    echo "Tarball SBOM: ${SBOM_FILE} (${COMPONENT_COUNT} components)"
+
     cd ${WORKDIR}/
 
     tar --owner=0 --group=0 -czf ${WORKDIR}/${PCSMDIR}-${ARCH}.tar.gz ${PCSMDIR}


### PR DESCRIPTION
[PCSM-282](https://perconadev.atlassian.net/browse/PCSM-282)

**Main:**
Generate a distribution SBOM during build and ship it with each artifact:

- Binary tarball: ships <product>-<version>.cdx.json at the archive root
  via build_tarball() in the builder script.
- RPM: install -> /usr/share/doc/percona-clustersync-mongodb/ via spec
  %install + %files; jq used to enrich metadata.component with a proper
  pkg:rpm PURL.
- DEB: install -> /usr/share/doc/percona-clustersync-mongodb/ via
  debian/rules override_dh_auto_install + debian/install glob; jq used
  to enrich metadata.component with a proper pkg:deb PURL.
  
**Side change:**
  build_tarball() is the last call in the main flow and is guarded by
[ $TARBALL = 0 ]. Previously get_tar() assigned $1 to TARBALL without
the local keyword, so any earlier call (e.g. via build_source_deb)
overwrote the global flag with the string "source_tarball". The guard
then evaluated false and build_tarball ran in stages where it must not.

Before this commit the unwanted build_tarball call failed silently
(no set -e, garbage tar archive was created in WORKDIR and ignored by
the source_deb Jenkins stage which only pushes source_deb/). The new
SBOM block introduced an explicit `exit 1` on syft failure, turning the
silent failure into a hard Jenkins FAIL.

Fixes:
- get_tar(): declare TARBALL as local.
- get_deb_sources(): declare param and FILE as local (same pattern).
- Move build_tarball before build_srpm/build_source_deb in the main
  flow, mirroring common builder script layout.


[PCSM-282]: https://perconadev.atlassian.net/browse/PCSM-282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ