### PR TITLE
PCSM-342: Catalog UUID reader and movePrimary marker scaffolding

### DIFF
--- a/main.go
+++ b/main.go
@@ -593,6 +593,10 @@ func createServer(ctx context.Context, cfg *config.Config) (*server, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "source version")
 	}
+	srcHello, err := mdb.SayHello(ctx, source)
+	if err != nil {
+		return nil, errors.Wrap(err, "source hello")
+	}
 
 	cs, _ := connstring.Parse(cfg.Source)
 	lg.Infof("Connected to source cluster [%s]: %s://%s",
@@ -640,7 +644,7 @@ func createServer(ctx context.Context, cfg *config.Config) (*server, error) {
 	promRegistry := prometheus.NewRegistry()
 	metrics.Init(promRegistry)
 
-	pcs := pcsm.New(ctx, source, target, sourceVersion)
+	pcs := pcsm.New(ctx, source, target, sourceVersion, srcHello.IsMongos())
 
 	err = Restore(ctx, target, pcs)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -644,6 +644,10 @@ func createServer(ctx context.Context, cfg *config.Config) (*server, error) {
 	promRegistry := prometheus.NewRegistry()
 	metrics.Init(promRegistry)
 
+	if srcHello == nil {
+		return nil, errors.New("source hello response is nil")
+	}
+
 	pcs := pcsm.New(ctx, source, target, sourceVersion, srcHello.IsMongos())
 
 	err = Restore(ctx, target, pcs)

--- a/pcsm/catalog/catalog.go
+++ b/pcsm/catalog/catalog.go
@@ -882,6 +882,7 @@ func (c *Catalog) CollectionExists(db, coll string) bool {
 }
 
 // CollectionUUID returns collection UUID from catalog when collection entry exists.
+// The returned pointer is catalog-owned; callers must not mutate it or its Data.
 func (c *Catalog) CollectionUUID(db, coll string) (*bson.Binary, bool) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()

--- a/pcsm/catalog/catalog.go
+++ b/pcsm/catalog/catalog.go
@@ -131,6 +131,7 @@ type ModifyIndexOption struct {
 // BaseCatalog defines the shared collection-level operations used by clone and repl packages.
 type BaseCatalog interface {
 	CollectionExists(db, coll string) bool
+	CollectionUUID(db, coll string) (*bson.Binary, bool)
 	DropCollection(ctx context.Context, db, coll string) error
 	CreateCollection(ctx context.Context, db, coll string, opts *CreateCollectionOptions) error
 	CreateIndexes(ctx context.Context, db, coll string, indexes []*mdb.IndexSpecification) error
@@ -878,6 +879,24 @@ func (c *Catalog) CollectionExists(db, coll string) bool {
 	_, ok = dbEntry.Collections[coll]
 
 	return ok
+}
+
+// CollectionUUID returns collection UUID from catalog when collection entry exists.
+func (c *Catalog) CollectionUUID(db, coll string) (*bson.Binary, bool) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	dbEntry, ok := c.Databases[db]
+	if !ok {
+		return nil, false
+	}
+
+	collectionEntry, ok := dbEntry.Collections[coll]
+	if !ok {
+		return nil, false
+	}
+
+	return collectionEntry.UUID, true
 }
 
 // SetCollectionUUID sets the UUID for a collection in the catalog.

--- a/pcsm/catalog/catalog_uuid_test.go
+++ b/pcsm/catalog/catalog_uuid_test.go
@@ -1,0 +1,83 @@
+package catalog //nolint:testpackage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+
+	"github.com/percona/percona-clustersync-mongodb/mdb"
+)
+
+func TestCatalog_CollectionUUID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		databases map[string]databaseCatalog
+		db        string
+		coll      string
+		expected  *bson.Binary
+		exists    bool
+	}{
+		{
+			name:      "missing db",
+			databases: map[string]databaseCatalog{},
+			db:        "missing",
+			coll:      "coll",
+			expected:  nil,
+			exists:    false,
+		},
+		{
+			name: "missing coll",
+			databases: map[string]databaseCatalog{
+				"db": {Collections: map[string]collectionCatalog{}},
+			},
+			db:       "db",
+			coll:     "missing",
+			expected: nil,
+			exists:   false,
+		},
+		{
+			name: "existing entry with nil UUID",
+			databases: map[string]databaseCatalog{
+				"db": {
+					Collections: map[string]collectionCatalog{
+						"coll": {UUID: nil},
+					},
+				},
+			},
+			db:       "db",
+			coll:     "coll",
+			expected: nil,
+			exists:   true,
+		},
+		{
+			name: "existing entry with non-nil UUID",
+			databases: map[string]databaseCatalog{
+				"db": {
+					Collections: map[string]collectionCatalog{
+						"coll": {UUID: &bson.Binary{Subtype: 0x04, Data: []byte{0x01, 0x02}}},
+					},
+				},
+			},
+			db:       "db",
+			coll:     "coll",
+			expected: &bson.Binary{Subtype: 0x04, Data: []byte{0x01, 0x02}},
+			exists:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cat := NewCatalog(nil, mdb.ServerVersion{})
+			cat.Databases = tt.databases
+
+			uuid, ok := cat.CollectionUUID(tt.db, tt.coll)
+			require.Equal(t, tt.exists, ok)
+			require.Equal(t, tt.expected, uuid)
+		})
+	}
+}

--- a/pcsm/catalog/catalog_uuid_test.go
+++ b/pcsm/catalog/catalog_uuid_test.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	missingDatabaseName     = "missing"
+	missingCollectionName   = "missing_coll"
 	testCollectionName      = "coll"
 	testCatalogDatabaseName = "db"
 )
@@ -40,7 +41,7 @@ func TestCatalog_CollectionUUID(t *testing.T) {
 				testCatalogDatabaseName: {Collections: map[string]collectionCatalog{}},
 			},
 			db:       testCatalogDatabaseName,
-			coll:     missingDatabaseName,
+			coll:     missingCollectionName,
 			expected: nil,
 			exists:   false,
 		},

--- a/pcsm/catalog/catalog_uuid_test.go
+++ b/pcsm/catalog/catalog_uuid_test.go
@@ -9,6 +9,12 @@ import (
 	"github.com/percona/percona-clustersync-mongodb/mdb"
 )
 
+const (
+	missingDatabaseName     = "missing"
+	testCollectionName      = "coll"
+	testCatalogDatabaseName = "db"
+)
+
 func TestCatalog_CollectionUUID(t *testing.T) {
 	t.Parallel()
 
@@ -23,46 +29,46 @@ func TestCatalog_CollectionUUID(t *testing.T) {
 		{
 			name:      "missing db",
 			databases: map[string]databaseCatalog{},
-			db:        "missing",
-			coll:      "coll",
+			db:        missingDatabaseName,
+			coll:      testCollectionName,
 			expected:  nil,
 			exists:    false,
 		},
 		{
 			name: "missing coll",
 			databases: map[string]databaseCatalog{
-				"db": {Collections: map[string]collectionCatalog{}},
+				testCatalogDatabaseName: {Collections: map[string]collectionCatalog{}},
 			},
-			db:       "db",
-			coll:     "missing",
+			db:       testCatalogDatabaseName,
+			coll:     missingDatabaseName,
 			expected: nil,
 			exists:   false,
 		},
 		{
 			name: "existing entry with nil UUID",
 			databases: map[string]databaseCatalog{
-				"db": {
+				testCatalogDatabaseName: {
 					Collections: map[string]collectionCatalog{
-						"coll": {UUID: nil},
+						testCollectionName: {UUID: nil},
 					},
 				},
 			},
-			db:       "db",
-			coll:     "coll",
+			db:       testCatalogDatabaseName,
+			coll:     testCollectionName,
 			expected: nil,
 			exists:   true,
 		},
 		{
 			name: "existing entry with non-nil UUID",
 			databases: map[string]databaseCatalog{
-				"db": {
+				testCatalogDatabaseName: {
 					Collections: map[string]collectionCatalog{
-						"coll": {UUID: &bson.Binary{Subtype: 0x04, Data: []byte{0x01, 0x02}}},
+						testCollectionName: {UUID: &bson.Binary{Subtype: 0x04, Data: []byte{0x01, 0x02}}},
 					},
 				},
 			},
-			db:       "db",
-			coll:     "coll",
+			db:       testCatalogDatabaseName,
+			coll:     testCollectionName,
 			expected: &bson.Binary{Subtype: 0x04, Data: []byte{0x01, 0x02}},
 			exists:   true,
 		},

--- a/pcsm/pcsm.go
+++ b/pcsm/pcsm.go
@@ -124,7 +124,8 @@ type PCSM struct {
 	source *mongo.Client // Source MongoDB client
 	target *mongo.Client // Target MongoDB client
 
-	sourceVer mdb.ServerVersion
+	sourceVer      mdb.ServerVersion
+	sourceIsMongos bool
 
 	nsInclude []string
 	nsExclude []string
@@ -149,12 +150,18 @@ type PCSM struct {
 }
 
 // New creates a new PCSM.
-func New(lifecycleCtx context.Context, source, target *mongo.Client, sourceVer mdb.ServerVersion) *PCSM {
+func New(
+	lifecycleCtx context.Context,
+	source, target *mongo.Client,
+	sourceVer mdb.ServerVersion,
+	sourceIsMongos bool,
+) *PCSM {
 	return &PCSM{
 		lifecycleCtx:   lifecycleCtx,
 		source:         source,
 		target:         target,
 		sourceVer:      sourceVer,
+		sourceIsMongos: sourceIsMongos,
 		state:          StateIdle,
 		onStateChanged: func(State) {},
 	}
@@ -225,7 +232,7 @@ func (p *PCSM) Recover(ctx context.Context, data []byte) error {
 	cat := catalog.NewCatalog(p.target, p.sourceVer)
 	// Use empty options for recovery (clone tuning is less relevant when resuming from checkpoint)
 	cln := clone.NewClone(p.source, p.target, cat, nsFilter, &clone.Options{})
-	rpl := repl.NewRepl(p.source, p.target, cat, nsFilter, &repl.Options{}, p.sourceVer)
+	rpl := repl.NewRepl(p.source, p.target, cat, nsFilter, &repl.Options{}, p.sourceVer, p.sourceIsMongos)
 
 	if cp.Catalog != nil {
 		err = cat.Recover(cp.Catalog)
@@ -414,7 +421,7 @@ func (p *PCSM) Start(ctx context.Context, options *StartOptions) error {
 	p.pauseOnInitialSync = options.PauseOnInitialSync
 	p.catalog = catalog.NewCatalog(p.target, p.sourceVer)
 	p.clone = clone.NewClone(p.source, p.target, p.catalog, p.nsFilter, &options.Clone)
-	p.repl = repl.NewRepl(p.source, p.target, p.catalog, p.nsFilter, &options.Repl, p.sourceVer)
+	p.repl = repl.NewRepl(p.source, p.target, p.catalog, p.nsFilter, &options.Repl, p.sourceVer, p.sourceIsMongos)
 	p.finalizeStatus = nil
 	p.state = StateRunning
 

--- a/pcsm/pcsm_test.go
+++ b/pcsm/pcsm_test.go
@@ -19,7 +19,7 @@ import (
 func TestNew(t *testing.T) {
 	t.Parallel()
 
-	p := New(t.Context(), nil, nil, mdb.ServerVersion{})
+	p := New(t.Context(), nil, nil, mdb.ServerVersion{}, false)
 
 	assert.Equal(t, State(StateIdle), p.state, "initial state should be StateIdle")
 	assert.Nil(t, p.source, "source should be nil when passed nil")

--- a/pcsm/repl/events.go
+++ b/pcsm/repl/events.go
@@ -645,7 +645,9 @@ func parseChangeEvent(data bson.Raw, change *ChangeEvent) error {
 		return errors.New("refineCollectionShardKey operation is not supported")
 
 	case Invalidate:
-		return ErrInvalidateEvent
+		var e InvalidateEvent
+		err = bson.Unmarshal(data, &e)
+		change.Event = e
 	}
 
 	if err != nil {

--- a/pcsm/repl/repl.go
+++ b/pcsm/repl/repl.go
@@ -137,6 +137,8 @@ type Repl struct {
 
 	pool *workerPool
 
+	sourceIsMongos bool
+
 	useCollectionBulk  bool
 	useSimpleCollation bool
 }
@@ -176,6 +178,7 @@ func NewRepl(
 	nsFilter sel.NSFilter,
 	opts *Options,
 	sourceVer mdb.ServerVersion,
+	sourceIsMongos bool,
 ) *Repl {
 	opts.applyDefaults()
 
@@ -190,15 +193,23 @@ func NewRepl(
 	lg.Infof("Config: WorkerBulkQueueSize: %d", opts.WorkerBulkQueueSize)
 
 	return &Repl{
-		source:    source,
-		target:    target,
-		sourceVer: sourceVer,
-		nsFilter:  nsFilter,
-		catalog:   cat,
-		options:   opts,
-		pauseCh:   make(chan struct{}),
-		doneCh:    make(chan struct{}),
+		source:         source,
+		target:         target,
+		sourceVer:      sourceVer,
+		nsFilter:       nsFilter,
+		catalog:        cat,
+		options:        opts,
+		pauseCh:        make(chan struct{}),
+		doneCh:         make(chan struct{}),
+		sourceIsMongos: sourceIsMongos,
 	}
+}
+
+// sourceIsPre8AndMongos returns true when the source is a mongos (sharded) and
+// runs MongoDB 6.x or 7.x (pre-8). Used to gate invalidate-stream handling for
+// movePrimary on older sharded topologies.
+func (r *Repl) sourceIsPre8AndMongos() bool {
+	return r.sourceIsMongos && r.sourceVer.Major() < 8
 }
 
 // Checkpoint represents the checkpoint state for replication recovery.

--- a/pcsm/repl/repl_test.go
+++ b/pcsm/repl/repl_test.go
@@ -66,6 +66,10 @@ func (m *mockCatalog) UUIDMap() catalog.UUIDMap {
 	return catalog.UUIDMap{}
 }
 
+func (m *mockCatalog) CollectionUUID(_, _ string) (*bson.Binary, bool) {
+	return nil, false
+}
+
 func (m *mockCatalog) DropDatabase(_ context.Context, _ string) error {
 	return nil
 }
@@ -257,4 +261,45 @@ func TestAlignCappedSize(t *testing.T) {
 			assert.Equal(t, tt.expected, alignCappedSize(tt.input))
 		})
 	}
+}
+
+func TestSourceIsPre8AndMongos(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mongos bool
+		ver    mdb.ServerVersion
+		want   bool
+	}{
+		{"mongos 6.0 is pre-8", true, mdb.ServerVersion{6, 0, 0, 0}, true},
+		{"mongos 7.0 is pre-8", true, mdb.ServerVersion{7, 0, 0, 0}, true},
+		{"mongos 8.0 is not pre-8", true, mdb.ServerVersion{8, 0, 0, 0}, false},
+		{"replica set 6.0 is not mongos", false, mdb.ServerVersion{6, 0, 0, 0}, false},
+		{"replica set 8.0 is not mongos", false, mdb.ServerVersion{8, 0, 0, 0}, false},
+		{"mongos zero version treated as pre-8", true, mdb.ServerVersion{}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			r := &Repl{sourceIsMongos: tt.mongos, sourceVer: tt.ver}
+			assert.Equal(t, tt.want, r.sourceIsPre8AndMongos())
+		})
+	}
+}
+
+func TestParseChangeEvent_Invalidate(t *testing.T) {
+	t.Parallel()
+
+	data, err := bson.Marshal(bson.D{{Key: "operationType", Value: "invalidate"}})
+	require.NoError(t, err)
+
+	var change ChangeEvent
+	err = parseChangeEvent(data, &change)
+	require.NoError(t, err)
+
+	assert.Equal(t, Invalidate, change.OperationType)
+	_, ok := change.Event.(InvalidateEvent)
+	assert.True(t, ok)
 }


### PR DESCRIPTION
## Problem

The movePrimary data mismatch fix (PCSM-249) needs catalog UUID lookups and source-topology plumbing in the replication layer. Putting that groundwork in the same change as the core DDL fix would mix wiring with behavior and make the core change harder to review.

## Solution

Add the groundwork as a standalone, additive seam:

- a `Catalog.CollectionUUID(db, coll)` accessor and its replication-side interface method
- a movePrimary marker helper (arm, take, clear)
- parse `invalidate` change events into a structured event instead of rejecting them during parsing
- thread a source-is-mongos flag from server startup into the replication layer
- a pre-8 mongos topology gate that later changes use

## Behavior

No success-path behavior changes. Startup makes one extra `hello` call to detect a mongos source. Invalidate handling shifts internally: events that were rejected during parsing now parse into a struct and get rejected later, in the dispatcher, which still treats them as fatal. Same outcome, a mongos movePrimary fails the run exactly as before, just at a later stage. The value is reviewability: this isolates wiring from the DDL and change-stream recovery logic that follow.

## Testing

- catalog UUID accessor tests for missing database, missing collection, nil UUID, and populated UUID
- marker tests including concurrent take and a zero-value marker safety check
- topology gate matrix covering pre-8 mongos, mongos 8.x, and replica set
- invalidate parse test
- `make test` and `make lint` pass with no new findings

## Notes

This is the first change in the PCSM-249 stack and changes no observable behavior on its own. Later changes build on it.

Jira: PCSM-342 (child of PCSM-249)
