### PR TITLE
PCSM-346: Make create and drop replay UUID-idempotent

### DIFF
--- a/pcsm/repl/repl.go
+++ b/pcsm/repl/repl.go
@@ -855,7 +855,7 @@ func (r *Repl) applyDDLChange(ctx context.Context, change *ChangeEvent) error {
 
 			return nil
 
-		case exists && eventUUID != nil && !uuidEqual(catalogUUID, eventUUID):
+		case exists && catalogUUID != nil && eventUUID != nil:
 			lg.Info("phantom create from movePrimary, updating UUID; preserving Sharded/ShardKey/Indexes")
 			r.catalog.SetCollectionUUID(ctx, db, coll, eventUUID)
 

--- a/pcsm/repl/repl.go
+++ b/pcsm/repl/repl.go
@@ -827,6 +827,8 @@ func uuidEqual(a, b *bson.Binary) bool {
 }
 
 // applyDDLChange applies a schema change to the target MongoDB.
+//
+//nolint:gocyclo // PCSM-249: flat DDL dispatch switch, complexity is inherent; refactor deferred to final PR
 func (r *Repl) applyDDLChange(ctx context.Context, change *ChangeEvent) error {
 	lg := loggerForEvent(change)
 	ctx = lg.WithContext(ctx)
@@ -836,7 +838,46 @@ func (r *Repl) applyDDLChange(ctx context.Context, change *ChangeEvent) error {
 	switch change.OperationType { //nolint:exhaustive
 	case Create:
 		event := change.Event.(CreateEvent) //nolint:forcetypeassert
-		err = r.applyCreateDDLChange(ctx, change, &event, lg)
+		if event.IsTimeseries() {
+			lg.Warn("Timeseries is not supported. skipping")
+
+			return nil
+		}
+
+		db := change.Namespace.Database
+		coll := change.Namespace.Collection
+		eventUUID := change.CollectionUUID
+
+		catalogUUID, exists := r.catalog.CollectionUUID(db, coll)
+		switch {
+		case exists && uuidEqual(catalogUUID, eventUUID):
+			lg.Debug("create event replay detected, namespace already at this UUID; noop")
+
+			return nil
+
+		case exists && eventUUID != nil && !uuidEqual(catalogUUID, eventUUID):
+			lg.Info("phantom create from movePrimary, updating UUID; preserving Sharded/ShardKey/Indexes")
+			r.catalog.SetCollectionUUID(ctx, db, coll, eventUUID)
+
+			return nil
+		}
+
+		err = r.catalog.DropCollection(ctx, db, coll)
+		if err != nil {
+			err = errors.Wrap(err, "drop before create")
+
+			break
+		}
+
+		err = r.catalog.CreateCollection(ctx, db, coll, &event.OperationDescription)
+		if err != nil {
+			err = errors.Wrap(err, "create")
+
+			break
+		}
+
+		r.catalog.SetCollectionUUID(ctx, db, coll, eventUUID)
+		lg.Infof("Collection %q has been created", change.Namespace)
 
 	case Drop:
 		db := change.Namespace.Database
@@ -953,52 +994,6 @@ func (r *Repl) applyDDLChange(ctx context.Context, change *ChangeEvent) error {
 
 		return errors.Wrap(err, string(change.OperationType))
 	}
-
-	return nil
-}
-
-func (r *Repl) applyCreateDDLChange(
-	ctx context.Context,
-	change *ChangeEvent,
-	event *CreateEvent,
-	lg log.Logger,
-) error {
-	if event.IsTimeseries() {
-		lg.Warn("Timeseries is not supported. skipping")
-
-		return nil
-	}
-
-	db := change.Namespace.Database
-	coll := change.Namespace.Collection
-	eventUUID := change.CollectionUUID
-
-	catalogUUID, exists := r.catalog.CollectionUUID(db, coll)
-	switch {
-	case exists && uuidEqual(catalogUUID, eventUUID):
-		lg.Debug("create event replay detected, namespace already at this UUID; noop")
-
-		return nil
-
-	case exists && eventUUID != nil && !uuidEqual(catalogUUID, eventUUID):
-		lg.Info("phantom create from movePrimary, updating UUID; preserving Sharded/ShardKey/Indexes")
-		r.catalog.SetCollectionUUID(ctx, db, coll, eventUUID)
-
-		return nil
-	}
-
-	err := r.catalog.DropCollection(ctx, db, coll)
-	if err != nil {
-		return errors.Wrap(err, "drop before create")
-	}
-
-	err = r.catalog.CreateCollection(ctx, db, coll, &event.OperationDescription)
-	if err != nil {
-		return errors.Wrap(err, "create")
-	}
-
-	r.catalog.SetCollectionUUID(ctx, db, coll, eventUUID)
-	lg.Infof("Collection %q has been created", change.Namespace)
 
 	return nil
 }

--- a/pcsm/repl/repl.go
+++ b/pcsm/repl/repl.go
@@ -1,6 +1,7 @@
 package repl
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"runtime"
@@ -815,6 +816,16 @@ func findNamespaceByUUID(uuidMap catalog.UUIDMap, change *ChangeEvent) catalog.N
 	return ns
 }
 
+// uuidEqual reports whether two BSON UUID binaries refer to the same UUID.
+// Returns false if either pointer is nil.
+func uuidEqual(a, b *bson.Binary) bool {
+	if a == nil || b == nil {
+		return false
+	}
+
+	return bytes.Equal(a.Data, b.Data)
+}
+
 // applyDDLChange applies a schema change to the target MongoDB.
 func (r *Repl) applyDDLChange(ctx context.Context, change *ChangeEvent) error {
 	lg := loggerForEvent(change)
@@ -825,42 +836,26 @@ func (r *Repl) applyDDLChange(ctx context.Context, change *ChangeEvent) error {
 	switch change.OperationType { //nolint:exhaustive
 	case Create:
 		event := change.Event.(CreateEvent) //nolint:forcetypeassert
-		if event.IsTimeseries() {
-			lg.Warn("Timeseries is not supported. skipping")
+		err = r.applyCreateDDLChange(ctx, change, &event, lg)
+
+	case Drop:
+		db := change.Namespace.Database
+		coll := change.Namespace.Collection
+		eventUUID := change.CollectionUUID
+		catalogUUID, _ := r.catalog.CollectionUUID(db, coll)
+
+		// PCSM-249: stale phantom drop from movePrimary is suppressed.
+		// The catalog has the new UUID (assigned by phantom create handler); this drop
+		// carries the old UUID. SERVER-120349: phantom create is not marked fromMigrate.
+		// UUID comparison only suppresses when both sides are present and differ; views
+		// and other untracked namespaces fall through to the real drop, which is idempotent.
+		if eventUUID != nil && catalogUUID != nil && !uuidEqual(catalogUUID, eventUUID) {
+			lg.Infof("stale phantom drop suppressed (event UUID does not match catalog)")
 
 			return nil
 		}
 
-		err = r.catalog.DropCollection(ctx,
-			change.Namespace.Database,
-			change.Namespace.Collection)
-		if err != nil {
-			err = errors.Wrap(err, "drop before create")
-
-			break
-		}
-
-		err = r.catalog.CreateCollection(ctx,
-			change.Namespace.Database,
-			change.Namespace.Collection,
-			&event.OperationDescription)
-		if err != nil {
-			err = errors.Wrap(err, "create")
-
-			break
-		}
-
-		r.catalog.SetCollectionUUID(ctx,
-			change.Namespace.Database,
-			change.Namespace.Collection,
-			change.CollectionUUID)
-
-		lg.Infof("Collection %q has been created", change.Namespace)
-
-	case Drop:
-		err = r.catalog.DropCollection(ctx,
-			change.Namespace.Database,
-			change.Namespace.Collection)
+		err = r.catalog.DropCollection(ctx, db, coll)
 		if err != nil {
 			break
 		}
@@ -958,6 +953,52 @@ func (r *Repl) applyDDLChange(ctx context.Context, change *ChangeEvent) error {
 
 		return errors.Wrap(err, string(change.OperationType))
 	}
+
+	return nil
+}
+
+func (r *Repl) applyCreateDDLChange(
+	ctx context.Context,
+	change *ChangeEvent,
+	event *CreateEvent,
+	lg log.Logger,
+) error {
+	if event.IsTimeseries() {
+		lg.Warn("Timeseries is not supported. skipping")
+
+		return nil
+	}
+
+	db := change.Namespace.Database
+	coll := change.Namespace.Collection
+	eventUUID := change.CollectionUUID
+
+	catalogUUID, exists := r.catalog.CollectionUUID(db, coll)
+	switch {
+	case exists && uuidEqual(catalogUUID, eventUUID):
+		lg.Debug("create event replay detected, namespace already at this UUID; noop")
+
+		return nil
+
+	case exists && eventUUID != nil && !uuidEqual(catalogUUID, eventUUID):
+		lg.Info("phantom create from movePrimary, updating UUID; preserving Sharded/ShardKey/Indexes")
+		r.catalog.SetCollectionUUID(ctx, db, coll, eventUUID)
+
+		return nil
+	}
+
+	err := r.catalog.DropCollection(ctx, db, coll)
+	if err != nil {
+		return errors.Wrap(err, "drop before create")
+	}
+
+	err = r.catalog.CreateCollection(ctx, db, coll, &event.OperationDescription)
+	if err != nil {
+		return errors.Wrap(err, "create")
+	}
+
+	r.catalog.SetCollectionUUID(ctx, db, coll, eventUUID)
+	lg.Infof("Collection %q has been created", change.Namespace)
 
 	return nil
 }

--- a/pcsm/repl/repl_test.go
+++ b/pcsm/repl/repl_test.go
@@ -36,6 +36,7 @@ type mockCatalog struct {
 	setCollectionUUIDCalled bool
 	setCollectionUUIDDB     string
 	setCollectionUUIDColl   string
+	setCollectionUUIDValue  *bson.Binary
 }
 
 func (m *mockCatalog) CollectionExists(_, _ string) bool {
@@ -56,10 +57,11 @@ func (m *mockCatalog) CreateCollection(_ context.Context, _, _ string, _ *catalo
 	return m.createCollectionErr
 }
 
-func (m *mockCatalog) SetCollectionUUID(_ context.Context, db, coll string, _ *bson.Binary) {
+func (m *mockCatalog) SetCollectionUUID(_ context.Context, db, coll string, uuid *bson.Binary) {
 	m.setCollectionUUIDCalled = true
 	m.setCollectionUUIDDB = db
 	m.setCollectionUUIDColl = coll
+	m.setCollectionUUIDValue = uuid
 }
 
 func (m *mockCatalog) CreateIndexes(_ context.Context, _, _ string, _ []*mdb.IndexSpecification) error {
@@ -160,6 +162,14 @@ func TestApplyCreateDDLChange(t *testing.T) {
 			expectSetUUID:     true,
 		},
 		{
+			name:              "nil catalog UUID applies real create",
+			catalogUUIDExists: true,
+			eventUUID:         eventUUID,
+			expectDrop:        true,
+			expectCreate:      true,
+			expectSetUUID:     true,
+		},
+		{
 			name:              "timeseries create returns without catalog changes",
 			catalogUUIDExists: false,
 			eventUUID:         eventUUID,
@@ -201,6 +211,7 @@ func TestApplyCreateDDLChange(t *testing.T) {
 			if tt.expectSetUUID {
 				assert.Equal(t, ns.Database, cat.setCollectionUUIDDB)
 				assert.Equal(t, ns.Collection, cat.setCollectionUUIDColl)
+				assert.Equal(t, tt.eventUUID, cat.setCollectionUUIDValue)
 			}
 		})
 	}

--- a/pcsm/repl/repl_test.go
+++ b/pcsm/repl/repl_test.go
@@ -14,6 +14,11 @@ import (
 	"github.com/percona/percona-clustersync-mongodb/pcsm/catalog"
 )
 
+const (
+	replTestDBName     = "testdb"
+	replTestCollection = "testcoll"
+)
+
 type mockCatalog struct {
 	collectionExists bool
 
@@ -113,7 +118,7 @@ func TestApplyCreateDDLChange(t *testing.T) {
 
 	eventUUID := &bson.Binary{Subtype: 4, Data: []byte("0123456789abcdef")}
 	differentUUID := &bson.Binary{Subtype: 4, Data: []byte("fedcba9876543210")}
-	ns := catalog.Namespace{Database: "testdb", Collection: "testcoll"}
+	ns := catalog.Namespace{Database: replTestDBName, Collection: replTestCollection}
 
 	tests := []struct {
 		name              string
@@ -159,7 +164,7 @@ func TestApplyCreateDDLChange(t *testing.T) {
 			catalogUUIDExists: false,
 			eventUUID:         eventUUID,
 			createEvent: CreateEvent{
-				OperationDescription: catalog.CreateCollectionOptions{ViewOn: catalog.TimeseriesPrefix + "testcoll"},
+				OperationDescription: catalog.CreateCollectionOptions{ViewOn: catalog.TimeseriesPrefix + replTestCollection},
 			},
 		},
 	}
@@ -206,7 +211,7 @@ func TestApplyDropDDLChange(t *testing.T) {
 
 	eventUUID := &bson.Binary{Subtype: 4, Data: []byte("0123456789abcdef")}
 	differentUUID := &bson.Binary{Subtype: 4, Data: []byte("fedcba9876543210")}
-	ns := catalog.Namespace{Database: "testdb", Collection: "testcoll"}
+	ns := catalog.Namespace{Database: replTestDBName, Collection: replTestCollection}
 
 	tests := []struct {
 		name              string

--- a/pcsm/repl/repl_test.go
+++ b/pcsm/repl/repl_test.go
@@ -17,6 +17,9 @@ import (
 type mockCatalog struct {
 	collectionExists bool
 
+	collectionUUIDResult *bson.Binary
+	collectionUUIDExists bool
+
 	dropCollectionCalled bool
 	dropCollectionDB     string
 	dropCollectionColl   string
@@ -67,7 +70,7 @@ func (m *mockCatalog) UUIDMap() catalog.UUIDMap {
 }
 
 func (m *mockCatalog) CollectionUUID(_, _ string) (*bson.Binary, bool) {
-	return nil, false
+	return m.collectionUUIDResult, m.collectionUUIDExists
 }
 
 func (m *mockCatalog) DropDatabase(_ context.Context, _ string) error {
@@ -105,30 +108,168 @@ func (m *mockCatalog) ModifyValidation(
 	return nil
 }
 
-func TestApplyDDLChange_Create(t *testing.T) {
+func TestApplyCreateDDLChange(t *testing.T) {
 	t.Parallel()
 
-	cat := &mockCatalog{}
-	r := &Repl{catalog: cat}
+	eventUUID := &bson.Binary{Subtype: 4, Data: []byte("0123456789abcdef")}
+	differentUUID := &bson.Binary{Subtype: 4, Data: []byte("fedcba9876543210")}
+	ns := catalog.Namespace{Database: "testdb", Collection: "testcoll"}
 
-	change := &ChangeEvent{
-		EventHeader: EventHeader{
-			OperationType: Create,
-			Namespace: catalog.Namespace{
-				Database:   "testdb",
-				Collection: "testcoll",
-			},
-			CollectionUUID: &bson.Binary{Subtype: 4, Data: []byte("0123456789abcdef")},
+	tests := []struct {
+		name              string
+		catalogUUID       *bson.Binary
+		catalogUUIDExists bool
+		eventUUID         *bson.Binary
+		createEvent       CreateEvent
+		expectDrop        bool
+		expectCreate      bool
+		expectSetUUID     bool
+	}{
+		{
+			name:              "same UUID replay noops",
+			catalogUUID:       eventUUID,
+			catalogUUIDExists: true,
+			eventUUID:         eventUUID,
 		},
-		Event: CreateEvent{},
+		{
+			name:              "different UUID phantom create updates catalog only",
+			catalogUUID:       differentUUID,
+			catalogUUIDExists: true,
+			eventUUID:         eventUUID,
+			expectSetUUID:     true,
+		},
+		{
+			name:              "nil event UUID applies real create",
+			catalogUUID:       differentUUID,
+			catalogUUIDExists: true,
+			expectDrop:        true,
+			expectCreate:      true,
+			expectSetUUID:     true,
+		},
+		{
+			name:              "missing catalog entry applies real create",
+			catalogUUIDExists: false,
+			eventUUID:         eventUUID,
+			expectDrop:        true,
+			expectCreate:      true,
+			expectSetUUID:     true,
+		},
+		{
+			name:              "timeseries create returns without catalog changes",
+			catalogUUIDExists: false,
+			eventUUID:         eventUUID,
+			createEvent: CreateEvent{
+				OperationDescription: catalog.CreateCollectionOptions{ViewOn: catalog.TimeseriesPrefix + "testcoll"},
+			},
+		},
 	}
 
-	err := r.applyDDLChange(context.Background(), change)
-	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	assert.True(t, cat.dropCollectionCalled)
-	assert.True(t, cat.createCollectionCalled)
-	assert.True(t, cat.setCollectionUUIDCalled)
+			cat := &mockCatalog{
+				collectionUUIDResult: tt.catalogUUID,
+				collectionUUIDExists: tt.catalogUUIDExists,
+			}
+			r := &Repl{catalog: cat}
+
+			change := &ChangeEvent{
+				EventHeader: EventHeader{
+					OperationType:  Create,
+					Namespace:      ns,
+					CollectionUUID: tt.eventUUID,
+				},
+				Event: tt.createEvent,
+			}
+
+			err := r.applyDDLChange(context.Background(), change)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expectDrop, cat.dropCollectionCalled)
+			assert.Equal(t, tt.expectCreate, cat.createCollectionCalled)
+			assert.Equal(t, tt.expectSetUUID, cat.setCollectionUUIDCalled)
+			if tt.expectDrop {
+				assert.Equal(t, ns.Database, cat.dropCollectionDB)
+				assert.Equal(t, ns.Collection, cat.dropCollectionColl)
+			}
+			if tt.expectSetUUID {
+				assert.Equal(t, ns.Database, cat.setCollectionUUIDDB)
+				assert.Equal(t, ns.Collection, cat.setCollectionUUIDColl)
+			}
+		})
+	}
+}
+
+func TestApplyDropDDLChange(t *testing.T) {
+	t.Parallel()
+
+	eventUUID := &bson.Binary{Subtype: 4, Data: []byte("0123456789abcdef")}
+	differentUUID := &bson.Binary{Subtype: 4, Data: []byte("fedcba9876543210")}
+	ns := catalog.Namespace{Database: "testdb", Collection: "testcoll"}
+
+	tests := []struct {
+		name              string
+		catalogUUID       *bson.Binary
+		catalogUUIDExists bool
+		eventUUID         *bson.Binary
+		expectDrop        bool
+	}{
+		{
+			name:              "missing catalog entry applies real drop",
+			catalogUUIDExists: false,
+			eventUUID:         eventUUID,
+			expectDrop:        true,
+		},
+		{
+			name:              "UUID mismatch suppresses phantom drop",
+			catalogUUID:       differentUUID,
+			catalogUUIDExists: true,
+			eventUUID:         eventUUID,
+		},
+		{
+			name:              "UUID match applies drop",
+			catalogUUID:       eventUUID,
+			catalogUUIDExists: true,
+			eventUUID:         eventUUID,
+			expectDrop:        true,
+		},
+		{
+			name:              "nil UUIDs apply drop through default branch",
+			catalogUUIDExists: true,
+			expectDrop:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cat := &mockCatalog{
+				collectionUUIDResult: tt.catalogUUID,
+				collectionUUIDExists: tt.catalogUUIDExists,
+			}
+			r := &Repl{catalog: cat}
+
+			change := &ChangeEvent{
+				EventHeader: EventHeader{
+					OperationType:  Drop,
+					Namespace:      ns,
+					CollectionUUID: tt.eventUUID,
+				},
+				Event: DropEvent{},
+			}
+
+			err := r.applyDDLChange(context.Background(), change)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expectDrop, cat.dropCollectionCalled)
+			if tt.expectDrop {
+				assert.Equal(t, ns.Database, cat.dropCollectionDB)
+				assert.Equal(t, ns.Collection, cat.dropCollectionColl)
+			}
+		})
+	}
 }
 
 func TestIsChangeStreamUnrecoverable(t *testing.T) {


### PR DESCRIPTION
## Problem

PCSM treated every change-stream `create` and `drop` as real DDL. That is unsafe during a sharded `movePrimary`, because MongoDB can emit phantom DDL events for the moved collection without tagging them `fromMigrate` (SERVER-120349).

The visible failure is data loss on the target: PCSM drops the collection and recreates it empty. The reported symptom was a 10-document source collection landing as 0 documents on the target.

## Solution

Compare the change event UUID against the catalog UUID before replaying a create or drop.

For `create`:

- same UUID: the collection is already correct, so the create is a no-op
- different UUID with an event UUID: phantom `movePrimary` create, so update the catalog UUID and keep the target data
- no catalog entry, or no event UUID: real create, so run the existing drop-before-create path

For `drop`:

- event UUID and catalog UUID both exist and differ: suppress the stale phantom drop
- matching UUID, missing catalog entry, or nil UUID: run the normal drop path

Time-series create handling stays unchanged. This is the core data-preservation part of the PCSM-249 fix.

## Testing

- `TestApplyCreateDDLChange` covers same-UUID no-op, different-UUID phantom create (catalog UUID update only), nil event UUID real create, missing catalog entry real create, and the timeseries skip
- `TestApplyDropDDLChange` covers UUID-mismatch suppression, UUID-match real drop, missing catalog entry real drop, and nil-UUID real drop

## Notes

Part of PCSM-249. Depends on #242 (catalog UUID reader and movePrimary marker scaffolding). This PR is stacked on that branch and will retarget to `main` once #242 merges.
