### PR TITLE
PCSM-348: Resolve DML namespaces from catalog at worker execution

### DIFF
--- a/mdb/schema.go
+++ b/mdb/schema.go
@@ -284,7 +284,7 @@ func GetCollectionShardingInfo(
 
 	err := m.Database("config").
 		Collection("collections").
-		FindOne(ctx, bson.M{"_id": collNS}).
+		FindOne(ctx, bson.M{"_id": collNS, "dropped": bson.M{"$ne": true}}).
 		Decode(info)
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
@@ -316,6 +316,7 @@ func GetCollectionShardingInfo(
 	if err != nil {
 		return nil, errors.Wrap(err, "read chunks")
 	}
+	info.Chunks = chunks
 
 	return info, nil
 }

--- a/mdb/schema.go
+++ b/mdb/schema.go
@@ -269,6 +269,8 @@ type ShardingInfo struct {
 	Chunks []ChunkInfo
 }
 
+const configCollectionIDField = "_id"
+
 func (s ShardingInfo) IsSharded() bool {
 	return s.ShardKey != nil
 }
@@ -284,7 +286,7 @@ func GetCollectionShardingInfo(
 
 	err := m.Database("config").
 		Collection("collections").
-		FindOne(ctx, bson.M{"_id": collNS, "dropped": bson.M{"$ne": true}}).
+		FindOne(ctx, bson.M{configCollectionIDField: collNS, "dropped": bson.M{"$ne": true}}).
 		Decode(info)
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {

--- a/mdb/topo_test.go
+++ b/mdb/topo_test.go
@@ -28,3 +28,10 @@ func TestCollStats_DecodeFromFloat64(t *testing.T) {
 	assert.Equal(t, int64(73179136), stats.Size)
 	assert.Equal(t, int64(0), stats.AvgObjSize)
 }
+
+func TestShardingInfo_IsSharded(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, ShardingInfo{}.IsSharded())
+	assert.True(t, ShardingInfo{ShardKey: bson.D{{Key: "tenant", Value: 1}}}.IsSharded())
+}

--- a/pcsm/catalog/catalog.go
+++ b/pcsm/catalog/catalog.go
@@ -137,6 +137,7 @@ type BaseCatalog interface {
 	CreateIndexes(ctx context.Context, db, coll string, indexes []*mdb.IndexSpecification) error
 	ShardCollection(ctx context.Context, db, coll string, shardKey bson.D, unique bool) error
 	SetCollectionUUID(ctx context.Context, db, coll string, uuid *bson.Binary)
+	SetCollectionShardingMetadata(ctx context.Context, db, coll string, shardKey bson.D) error
 }
 
 var _ BaseCatalog = (*Catalog)(nil)
@@ -922,6 +923,33 @@ func (c *Catalog) SetCollectionUUID(ctx context.Context, db, coll string, uuid *
 	collectionEntry.UUID = uuid
 	databaseEntry.Collections[coll] = collectionEntry
 	c.Databases[db] = databaseEntry
+}
+
+// SetCollectionShardingMetadata sets sharding metadata for an existing catalog entry.
+func (c *Catalog) SetCollectionShardingMetadata(ctx context.Context, db, coll string, shardKey bson.D) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	databaseEntry, ok := c.Databases[db]
+	if !ok {
+		log.Ctx(ctx).Warnf("set collection sharding metadata: database %q is not found", db)
+
+		return mdb.ErrNotFound
+	}
+
+	collectionEntry, ok := databaseEntry.Collections[coll]
+	if !ok {
+		log.Ctx(ctx).Warnf("set collection sharding metadata: namespace %q is not found", db+"."+coll)
+
+		return mdb.ErrNotFound
+	}
+
+	collectionEntry.Sharded = true
+	collectionEntry.ShardKey = shardKey
+	databaseEntry.Collections[coll] = collectionEntry
+	c.Databases[db] = databaseEntry
+
+	return nil
 }
 
 // UUIDMap returns a map of collection UUIDs to their namespaces.

--- a/pcsm/catalog/catalog_uuid_test.go
+++ b/pcsm/catalog/catalog_uuid_test.go
@@ -88,3 +88,66 @@ func TestCatalog_CollectionUUID(t *testing.T) {
 		})
 	}
 }
+
+func TestCatalog_SetCollectionShardingMetadata(t *testing.T) {
+	t.Parallel()
+
+	shardKey := bson.D{{Key: "tenant", Value: 1}}
+	tests := []struct {
+		name      string
+		databases map[string]databaseCatalog
+		db        string
+		coll      string
+		wantErr   error
+		assert    func(t *testing.T, cat *Catalog)
+	}{
+		{
+			name:      "missing db",
+			databases: map[string]databaseCatalog{},
+			db:        "missing",
+			coll:      "coll",
+			wantErr:   mdb.ErrNotFound,
+		},
+		{
+			name: "missing coll",
+			databases: map[string]databaseCatalog{
+				"db": {Collections: map[string]collectionCatalog{}},
+			},
+			db:      "db",
+			coll:    "missing",
+			wantErr: mdb.ErrNotFound,
+		},
+		{
+			name: "existing collection",
+			databases: map[string]databaseCatalog{
+				"db": {Collections: map[string]collectionCatalog{
+					"coll": {},
+				}},
+			},
+			db:   "db",
+			coll: "coll",
+			assert: func(t *testing.T, cat *Catalog) {
+				t.Helper()
+
+				coll := cat.Databases["db"].Collections["coll"]
+				require.True(t, coll.Sharded)
+				require.Equal(t, shardKey, coll.ShardKey)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cat := NewCatalog(nil, mdb.ServerVersion{})
+			cat.Databases = tt.databases
+
+			err := cat.SetCollectionShardingMetadata(t.Context(), tt.db, tt.coll, shardKey)
+			require.ErrorIs(t, err, tt.wantErr)
+			if tt.assert != nil {
+				tt.assert(t, cat)
+			}
+		})
+	}
+}

--- a/pcsm/catalog/catalog_uuid_test.go
+++ b/pcsm/catalog/catalog_uuid_test.go
@@ -104,32 +104,32 @@ func TestCatalog_SetCollectionShardingMetadata(t *testing.T) {
 		{
 			name:      "missing db",
 			databases: map[string]databaseCatalog{},
-			db:        "missing",
-			coll:      "coll",
+			db:        missingDatabaseName,
+			coll:      testCollectionName,
 			wantErr:   mdb.ErrNotFound,
 		},
 		{
 			name: "missing coll",
 			databases: map[string]databaseCatalog{
-				"db": {Collections: map[string]collectionCatalog{}},
+				testCatalogDatabaseName: {Collections: map[string]collectionCatalog{}},
 			},
-			db:      "db",
-			coll:    "missing",
+			db:      testCatalogDatabaseName,
+			coll:    missingDatabaseName,
 			wantErr: mdb.ErrNotFound,
 		},
 		{
 			name: "existing collection",
 			databases: map[string]databaseCatalog{
-				"db": {Collections: map[string]collectionCatalog{
-					"coll": {},
+				testCatalogDatabaseName: {Collections: map[string]collectionCatalog{
+					testCollectionName: {},
 				}},
 			},
-			db:   "db",
-			coll: "coll",
+			db:   testCatalogDatabaseName,
+			coll: testCollectionName,
 			assert: func(t *testing.T, cat *Catalog) {
 				t.Helper()
 
-				coll := cat.Databases["db"].Collections["coll"]
+				coll := cat.Databases[testCatalogDatabaseName].Collections[testCollectionName]
 				require.True(t, coll.Sharded)
 				require.Equal(t, shardKey, coll.ShardKey)
 			},

--- a/pcsm/repl/bulk.go
+++ b/pcsm/repl/bulk.go
@@ -2,6 +2,7 @@ package repl
 
 import (
 	"context"
+	"encoding/hex"
 	"runtime"
 	"strings"
 	"sync/atomic"
@@ -97,10 +98,10 @@ type bulkWriter interface {
 	WouldOverflow(estimate int) bool
 	Do(ctx context.Context, m *mongo.Client) (int, error)
 
-	Insert(ns catalog.Namespace, event *InsertEvent)
-	Update(ns catalog.Namespace, event *UpdateEvent)
-	Replace(ns catalog.Namespace, event *ReplaceEvent)
-	Delete(ns catalog.Namespace, event *DeleteEvent)
+	Insert(change *ChangeEvent, event *InsertEvent)
+	Update(change *ChangeEvent, event *UpdateEvent)
+	Replace(change *ChangeEvent, event *ReplaceEvent)
+	Delete(change *ChangeEvent, event *DeleteEvent)
 }
 
 type clientBulkWrite struct {
@@ -109,16 +110,40 @@ type clientBulkWrite struct {
 	bytes              int
 	writes             []mongo.ClientBulkWrite
 
-	source *mongo.Client
+	source  *mongo.Client
+	uuidMap catalog.UUIDMap
 }
 
-func newClientBulkWriter(size int, useSimpleCollation bool, source *mongo.Client) *clientBulkWrite {
+func newClientBulkWriter(
+	size int,
+	useSimpleCollation bool,
+	source *mongo.Client,
+	uuidMap catalog.UUIDMap,
+) *clientBulkWrite {
 	return &clientBulkWrite{
 		useSimpleCollation: useSimpleCollation,
 		maxOpsSize:         size,
 		writes:             make([]mongo.ClientBulkWrite, 0, size),
 		source:             source,
+		uuidMap:            uuidMap,
 	}
+}
+
+//go:inline
+func findNamespaceByUUID(uuidMap catalog.UUIDMap, change *ChangeEvent) catalog.Namespace {
+	if change.CollectionUUID != nil {
+		if ns, ok := uuidMap[hex.EncodeToString(change.CollectionUUID.Data)]; ok {
+			return ns
+		}
+	}
+
+	for _, ns := range uuidMap {
+		if ns.Database == change.Namespace.Database && ns.Collection == change.Namespace.Collection {
+			return ns
+		}
+	}
+
+	return change.Namespace
 }
 
 func (cbw *clientBulkWrite) Full() bool {
@@ -292,7 +317,9 @@ func (cbw *clientBulkWrite) extractRecoverableUpdateTarget(
 	return firstErr.Index, ns, filter
 }
 
-func (cbw *clientBulkWrite) Insert(ns catalog.Namespace, event *InsertEvent) {
+func (cbw *clientBulkWrite) Insert(change *ChangeEvent, event *InsertEvent) {
+	ns := findNamespaceByUUID(cbw.uuidMap, change)
+
 	m := &mongo.ClientReplaceOneModel{
 		Filter:      event.DocumentKey,
 		Replacement: event.FullDocument,
@@ -313,7 +340,8 @@ func (cbw *clientBulkWrite) Insert(ns catalog.Namespace, event *InsertEvent) {
 	cbw.bytes += estimateBytes(event.DocumentKey, event.FullDocument)
 }
 
-func (cbw *clientBulkWrite) Update(ns catalog.Namespace, event *UpdateEvent) {
+func (cbw *clientBulkWrite) Update(change *ChangeEvent, event *UpdateEvent) {
+	ns := findNamespaceByUUID(cbw.uuidMap, change)
 	ops := collectUpdateOps(event)
 
 	// Marshal the document filter once and reuse for primary + every follow-up.
@@ -353,7 +381,9 @@ func (cbw *clientBulkWrite) Update(ns catalog.Namespace, event *UpdateEvent) {
 	}
 }
 
-func (cbw *clientBulkWrite) Replace(ns catalog.Namespace, event *ReplaceEvent) {
+func (cbw *clientBulkWrite) Replace(change *ChangeEvent, event *ReplaceEvent) {
+	ns := findNamespaceByUUID(cbw.uuidMap, change)
+
 	m := &mongo.ClientReplaceOneModel{
 		Filter:      event.DocumentKey,
 		Replacement: event.FullDocument,
@@ -373,7 +403,9 @@ func (cbw *clientBulkWrite) Replace(ns catalog.Namespace, event *ReplaceEvent) {
 	cbw.bytes += estimateBytes(event.DocumentKey, event.FullDocument)
 }
 
-func (cbw *clientBulkWrite) Delete(ns catalog.Namespace, event *DeleteEvent) {
+func (cbw *clientBulkWrite) Delete(change *ChangeEvent, event *DeleteEvent) {
+	ns := findNamespaceByUUID(cbw.uuidMap, change)
+
 	m := &mongo.ClientDeleteOneModel{
 		Filter: event.DocumentKey,
 	}
@@ -399,17 +431,22 @@ type collectionBulkWrite struct {
 	bytes              int
 	writes             map[string][]mongo.WriteModel
 
-	source *mongo.Client
+	source  *mongo.Client
+	uuidMap catalog.UUIDMap
 }
 
 func newCollectionBulkWriter(
-	size int, nonDefaultCollationSupport bool, source *mongo.Client,
+	size int,
+	nonDefaultCollationSupport bool,
+	source *mongo.Client,
+	uuidMap catalog.UUIDMap,
 ) *collectionBulkWrite {
 	return &collectionBulkWrite{
 		useSimpleCollation: nonDefaultCollationSupport,
 		maxOpsSize:         size,
 		writes:             make(map[string][]mongo.WriteModel),
 		source:             source,
+		uuidMap:            uuidMap,
 	}
 }
 
@@ -581,7 +618,8 @@ func (cbw *collectionBulkWrite) extractRecoverableUpdateTarget(
 	return firstErr.Index, filter
 }
 
-func (cbw *collectionBulkWrite) Insert(ns catalog.Namespace, event *InsertEvent) {
+func (cbw *collectionBulkWrite) Insert(change *ChangeEvent, event *InsertEvent) {
+	ns := findNamespaceByUUID(cbw.uuidMap, change)
 	missingShardKeys := bson.D{}
 
 	if ns.Sharded && ns.ShardKey != nil {
@@ -614,7 +652,8 @@ func (cbw *collectionBulkWrite) Insert(ns catalog.Namespace, event *InsertEvent)
 	cbw.bytes += estimateBytes(event.DocumentKey, event.FullDocument)
 }
 
-func (cbw *collectionBulkWrite) Update(ns catalog.Namespace, event *UpdateEvent) {
+func (cbw *collectionBulkWrite) Update(change *ChangeEvent, event *UpdateEvent) {
+	ns := findNamespaceByUUID(cbw.uuidMap, change)
 	ops := collectUpdateOps(event)
 
 	filterLen := marshalLen(event.DocumentKey)
@@ -650,7 +689,9 @@ func (cbw *collectionBulkWrite) Update(ns catalog.Namespace, event *UpdateEvent)
 	}
 }
 
-func (cbw *collectionBulkWrite) Replace(ns catalog.Namespace, event *ReplaceEvent) {
+func (cbw *collectionBulkWrite) Replace(change *ChangeEvent, event *ReplaceEvent) {
+	ns := findNamespaceByUUID(cbw.uuidMap, change)
+
 	m := &mongo.ReplaceOneModel{
 		Filter:      event.DocumentKey,
 		Replacement: event.FullDocument,
@@ -666,7 +707,9 @@ func (cbw *collectionBulkWrite) Replace(ns catalog.Namespace, event *ReplaceEven
 	cbw.bytes += estimateBytes(event.DocumentKey, event.FullDocument)
 }
 
-func (cbw *collectionBulkWrite) Delete(ns catalog.Namespace, event *DeleteEvent) {
+func (cbw *collectionBulkWrite) Delete(change *ChangeEvent, event *DeleteEvent) {
+	ns := findNamespaceByUUID(cbw.uuidMap, change)
+
 	m := &mongo.DeleteOneModel{
 		Filter: event.DocumentKey,
 	}

--- a/pcsm/repl/bulk.go
+++ b/pcsm/repl/bulk.go
@@ -135,8 +135,14 @@ func findNamespaceByUUID(uuidMap catalog.UUIDMap, change *ChangeEvent) catalog.N
 		if ns, ok := uuidMap[hex.EncodeToString(change.CollectionUUID.Data)]; ok {
 			return ns
 		}
+		// A UUID that is absent from the snapshot means the collection was recreated or
+		// moved under a different UUID; a name-matched entry would be a different
+		// collection generation, so fall back to the event's own namespace.
+		return change.Namespace
 	}
 
+	// UUID-less events resolve by name. The linear scan is acceptable: UUIDMap is
+	// bounded by catalog cardinality and this path is only hit for UUID-less events.
 	for _, ns := range uuidMap {
 		if ns.Database == change.Namespace.Database && ns.Collection == change.Namespace.Collection {
 			return ns

--- a/pcsm/repl/bulk_test.go
+++ b/pcsm/repl/bulk_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 
@@ -18,6 +19,53 @@ const (
 	pushOp  = "$push"
 	unsetOp = "$unset"
 )
+
+func TestClientBulkWriteResolvesNamespaceFromBulkSnapshot(t *testing.T) {
+	t.Parallel()
+
+	uuid := &bson.Binary{Subtype: 4, Data: []byte("0123456789abcdef")}
+	currentNS := catalog.Namespace{Database: "current_db", Collection: "current_coll"}
+	change := &ChangeEvent{EventHeader: EventHeader{
+		Namespace:      catalog.Namespace{Database: "stale_db", Collection: "stale_coll"},
+		CollectionUUID: uuid,
+	}}
+	fullDocument, err := bson.Marshal(bson.D{{Key: "_id", Value: 1}})
+	require.NoError(t, err)
+
+	event := &InsertEvent{
+		DocumentKey:  bson.D{{Key: "_id", Value: 1}},
+		FullDocument: bson.Raw(fullDocument),
+	}
+	writer := newClientBulkWriter(1, false, nil, catalog.UUIDMap{
+		"30313233343536373839616263646566": currentNS,
+	})
+
+	writer.Insert(change, event)
+
+	assert.Len(t, writer.writes, 1)
+	assert.Equal(t, currentNS.Database, writer.writes[0].Database)
+	assert.Equal(t, currentNS.Collection, writer.writes[0].Collection)
+}
+
+func TestFindNamespaceByUUIDFallsBackToCatalogEntryForSameNamespace(t *testing.T) {
+	t.Parallel()
+
+	shardKey := bson.D{{Key: "tenant", Value: 1}}
+	currentNS := catalog.Namespace{
+		Database:   "db",
+		Collection: "coll",
+		Sharded:    true,
+		ShardKey:   shardKey,
+		Capped:     true,
+	}
+	change := &ChangeEvent{EventHeader: EventHeader{
+		Namespace: catalog.Namespace{Database: "db", Collection: "coll"},
+	}}
+
+	resolved := findNamespaceByUUID(catalog.UUIDMap{"uuid": currentNS}, change)
+
+	assert.Equal(t, currentNS, resolved)
+}
 
 func TestCollectUpdateOps(t *testing.T) {
 	t.Parallel()
@@ -323,7 +371,7 @@ func TestCollectUpdateOpsWithConflicts_NestedArrayTruncation(t *testing.T) {
 func TestClientBulkWrite_FullByBytes(t *testing.T) {
 	t.Parallel()
 
-	cbw := newClientBulkWriter(10_000, false, nil)
+	cbw := newClientBulkWriter(10_000, false, nil, catalog.UUIDMap{})
 	ns := catalog.Namespace{Database: "db", Collection: "c"}
 
 	largeValue := strings.Repeat("X", 1024*1024)
@@ -334,7 +382,7 @@ func TestClientBulkWrite_FullByBytes(t *testing.T) {
 			t.Fatalf("marshal full document: %v", err)
 		}
 
-		cbw.Insert(ns, &InsertEvent{
+		cbw.Insert(changeForNamespace(ns), &InsertEvent{
 			DocumentKey:  bson.D{{Key: "_id", Value: i}},
 			FullDocument: raw,
 		})
@@ -355,7 +403,7 @@ func TestClientBulkWrite_FullByBytes(t *testing.T) {
 func TestCollectionBulkWrite_FullByBytes(t *testing.T) {
 	t.Parallel()
 
-	cbw := newCollectionBulkWriter(10_000, false, nil)
+	cbw := newCollectionBulkWriter(10_000, false, nil, catalog.UUIDMap{})
 	ns := catalog.Namespace{Database: "db", Collection: "c"}
 
 	largeValue := strings.Repeat("X", 1024*1024)
@@ -366,7 +414,7 @@ func TestCollectionBulkWrite_FullByBytes(t *testing.T) {
 			t.Fatalf("marshal full document: %v", err)
 		}
 
-		cbw.Insert(ns, &InsertEvent{
+		cbw.Insert(changeForNamespace(ns), &InsertEvent{
 			DocumentKey:  bson.D{{Key: "_id", Value: i}},
 			FullDocument: raw,
 		})
@@ -387,7 +435,7 @@ func TestCollectionBulkWrite_FullByBytes(t *testing.T) {
 func TestClientBulkWrite_FullByCount(t *testing.T) {
 	t.Parallel()
 
-	cbw := newClientBulkWriter(3, false, nil)
+	cbw := newClientBulkWriter(3, false, nil, catalog.UUIDMap{})
 	ns := catalog.Namespace{Database: "db", Collection: "c"}
 
 	for i := range 3 {
@@ -396,7 +444,7 @@ func TestClientBulkWrite_FullByCount(t *testing.T) {
 			t.Fatalf("marshal full document: %v", err)
 		}
 
-		cbw.Insert(ns, &InsertEvent{
+		cbw.Insert(changeForNamespace(ns), &InsertEvent{
 			DocumentKey:  bson.D{{Key: "_id", Value: i}},
 			FullDocument: raw,
 		})
@@ -411,7 +459,7 @@ func TestClientBulkWrite_FullByCount(t *testing.T) {
 func TestCollectionBulkWrite_FullByCount(t *testing.T) {
 	t.Parallel()
 
-	cbw := newCollectionBulkWriter(3, false, nil)
+	cbw := newCollectionBulkWriter(3, false, nil, catalog.UUIDMap{})
 	ns := catalog.Namespace{Database: "db", Collection: "c"}
 
 	for i := range 3 {
@@ -420,7 +468,7 @@ func TestCollectionBulkWrite_FullByCount(t *testing.T) {
 			t.Fatalf("marshal full document: %v", err)
 		}
 
-		cbw.Insert(ns, &InsertEvent{
+		cbw.Insert(changeForNamespace(ns), &InsertEvent{
 			DocumentKey:  bson.D{{Key: "_id", Value: i}},
 			FullDocument: raw,
 		})
@@ -513,12 +561,12 @@ func TestCollectUpdateOps_TruncationWithRemovedFieldOnSamePathSpills(t *testing.
 func TestClientBulkWrite_FullAfterUpdateWithFollowUps(t *testing.T) {
 	t.Parallel()
 
-	cbw := newClientBulkWriter(3, false, nil)
+	cbw := newClientBulkWriter(3, false, nil, catalog.UUIDMap{})
 	ns := catalog.Namespace{Database: "db", Collection: "c"}
 
 	// Two single-op inserts: count = 2.
 	for i := range 2 {
-		cbw.Insert(ns, &InsertEvent{
+		cbw.Insert(changeForNamespace(ns), &InsertEvent{
 			DocumentKey:  bson.D{{Key: "_id", Value: i}},
 			FullDocument: bson.Raw(mustMarshal(t, bson.D{{Key: "_id", Value: i}})),
 		})
@@ -546,7 +594,7 @@ func TestClientBulkWrite_FullAfterUpdateWithFollowUps(t *testing.T) {
 		},
 	}
 
-	cbw.Update(ns, event)
+	cbw.Update(changeForNamespace(ns), event)
 
 	assert.True(t, cbw.Full(), "Full() must be true after Update appended past count cap")
 	assert.Greater(t, len(cbw.writes), cbw.maxOpsSize,
@@ -558,11 +606,11 @@ func TestClientBulkWrite_FullAfterUpdateWithFollowUps(t *testing.T) {
 func TestCollectionBulkWrite_FullAfterUpdateWithFollowUps(t *testing.T) {
 	t.Parallel()
 
-	cbw := newCollectionBulkWriter(3, false, nil)
+	cbw := newCollectionBulkWriter(3, false, nil, catalog.UUIDMap{})
 	ns := catalog.Namespace{Database: "db", Collection: "c"}
 
 	for i := range 2 {
-		cbw.Insert(ns, &InsertEvent{
+		cbw.Insert(changeForNamespace(ns), &InsertEvent{
 			DocumentKey:  bson.D{{Key: "_id", Value: i}},
 			FullDocument: bson.Raw(mustMarshal(t, bson.D{{Key: "_id", Value: i}})),
 		})
@@ -588,7 +636,7 @@ func TestCollectionBulkWrite_FullAfterUpdateWithFollowUps(t *testing.T) {
 		},
 	}
 
-	cbw.Update(ns, event)
+	cbw.Update(changeForNamespace(ns), event)
 
 	assert.True(t, cbw.Full(), "Full() must be true after Update appended past count cap")
 	assert.Greater(t, cbw.count, cbw.maxOpsSize,
@@ -605,7 +653,7 @@ func TestBulkWriter_WouldOverflowPreflight(t *testing.T) {
 	t.Run("client bulk", func(t *testing.T) {
 		t.Parallel()
 
-		cbw := newClientBulkWriter(10_000, false, nil)
+		cbw := newClientBulkWriter(10_000, false, nil, catalog.UUIDMap{})
 
 		// Empty bulk: WouldOverflow must always be false even for huge estimates so a
 		// single oversized event can still be sent on its own bulk.
@@ -619,7 +667,7 @@ func TestBulkWriter_WouldOverflowPreflight(t *testing.T) {
 		for i := range 30 {
 			raw := bson.Raw(mustMarshal(t,
 				bson.D{{Key: "_id", Value: i}, {Key: "blob", Value: largeValue}}))
-			cbw.Insert(ns, &InsertEvent{
+			cbw.Insert(changeForNamespace(ns), &InsertEvent{
 				DocumentKey:  bson.D{{Key: "_id", Value: i}},
 				FullDocument: raw,
 			})
@@ -638,7 +686,7 @@ func TestBulkWriter_WouldOverflowPreflight(t *testing.T) {
 	t.Run("collection bulk", func(t *testing.T) {
 		t.Parallel()
 
-		cbw := newCollectionBulkWriter(10_000, false, nil)
+		cbw := newCollectionBulkWriter(10_000, false, nil, catalog.UUIDMap{})
 
 		assert.False(t, cbw.WouldOverflow(2*config.MaxWriteBatchSizeBytes),
 			"empty bulk must accept any estimate")
@@ -649,7 +697,7 @@ func TestBulkWriter_WouldOverflowPreflight(t *testing.T) {
 		for i := range 30 {
 			raw := bson.Raw(mustMarshal(t,
 				bson.D{{Key: "_id", Value: i}, {Key: "blob", Value: largeValue}}))
-			cbw.Insert(ns, &InsertEvent{
+			cbw.Insert(changeForNamespace(ns), &InsertEvent{
 				DocumentKey:  bson.D{{Key: "_id", Value: i}},
 				FullDocument: raw,
 			})
@@ -674,6 +722,10 @@ func mustMarshal(t *testing.T, v any) []byte {
 	}
 
 	return b
+}
+
+func changeForNamespace(ns catalog.Namespace) *ChangeEvent {
+	return &ChangeEvent{EventHeader: EventHeader{Namespace: ns}}
 }
 
 // findUnsetDoc returns the $unset sub-document from a classic update doc, or nil if absent.
@@ -849,7 +901,7 @@ func collectFollowUpKeys(t *testing.T, followUp []bson.D) []string {
 func TestExtractRecoverableUpdateTarget_ClientBulk(t *testing.T) {
 	t.Parallel()
 
-	cbw := newClientBulkWriter(10, false, nil)
+	cbw := newClientBulkWriter(10, false, nil, catalog.UUIDMap{})
 	ns := catalog.Namespace{Database: "db1", Collection: "coll1"}
 	filter := bson.D{{Key: "_id", Value: 42}}
 
@@ -986,7 +1038,7 @@ func TestExtractRecoverableUpdateTarget_ClientBulk(t *testing.T) {
 func TestExtractRecoverableUpdateTarget_CollectionBulk(t *testing.T) {
 	t.Parallel()
 
-	cbw := newCollectionBulkWriter(10, false, nil)
+	cbw := newCollectionBulkWriter(10, false, nil, catalog.UUIDMap{})
 	filter := bson.D{{Key: "_id", Value: 7}}
 
 	ops := []mongo.WriteModel{

--- a/pcsm/repl/bulk_test.go
+++ b/pcsm/repl/bulk_test.go
@@ -29,11 +29,11 @@ func TestClientBulkWriteResolvesNamespaceFromBulkSnapshot(t *testing.T) {
 		Namespace:      catalog.Namespace{Database: "stale_db", Collection: "stale_coll"},
 		CollectionUUID: uuid,
 	}}
-	fullDocument, err := bson.Marshal(bson.D{{Key: "_id", Value: 1}})
+	fullDocument, err := bson.Marshal(bson.D{{Key: testDocumentIDKey(), Value: 1}})
 	require.NoError(t, err)
 
 	event := &InsertEvent{
-		DocumentKey:  bson.D{{Key: "_id", Value: 1}},
+		DocumentKey:  bson.D{{Key: testDocumentIDKey(), Value: 1}},
 		FullDocument: bson.Raw(fullDocument),
 	}
 	writer := newClientBulkWriter(1, false, nil, catalog.UUIDMap{
@@ -53,13 +53,13 @@ func TestFindNamespaceByUUIDFallsBackToCatalogEntryForSameNamespace(t *testing.T
 	shardKey := bson.D{{Key: "tenant", Value: 1}}
 	currentNS := catalog.Namespace{
 		Database:   "db",
-		Collection: "coll",
+		Collection: replTestCollection,
 		Sharded:    true,
 		ShardKey:   shardKey,
 		Capped:     true,
 	}
 	change := &ChangeEvent{EventHeader: EventHeader{
-		Namespace: catalog.Namespace{Database: "db", Collection: "coll"},
+		Namespace: catalog.Namespace{Database: "db", Collection: replTestCollection},
 	}}
 
 	resolved := findNamespaceByUUID(catalog.UUIDMap{"uuid": currentNS}, change)

--- a/pcsm/repl/bulk_test.go
+++ b/pcsm/repl/bulk_test.go
@@ -29,11 +29,11 @@ func TestClientBulkWriteResolvesNamespaceFromBulkSnapshot(t *testing.T) {
 		Namespace:      catalog.Namespace{Database: "stale_db", Collection: "stale_coll"},
 		CollectionUUID: uuid,
 	}}
-	fullDocument, err := bson.Marshal(bson.D{{Key: testDocumentIDKey(), Value: 1}})
+	fullDocument, err := bson.Marshal(bson.D{{Key: testDocumentIDKey, Value: 1}})
 	require.NoError(t, err)
 
 	event := &InsertEvent{
-		DocumentKey:  bson.D{{Key: testDocumentIDKey(), Value: 1}},
+		DocumentKey:  bson.D{{Key: testDocumentIDKey, Value: 1}},
 		FullDocument: bson.Raw(fullDocument),
 	}
 	writer := newClientBulkWriter(1, false, nil, catalog.UUIDMap{

--- a/pcsm/repl/repl.go
+++ b/pcsm/repl/repl.go
@@ -3,7 +3,6 @@ package repl
 import (
 	"bytes"
 	"context"
-	"encoding/hex"
 	"fmt"
 	"runtime"
 	"strings"
@@ -143,6 +142,8 @@ type Repl struct {
 
 	expectMovePrimaryInvalidate bool
 	sourceIsMongos              bool
+
+	getCollectionShardingInfo func(context.Context, *mongo.Client, string, string) (*mdb.ShardingInfo, error)
 
 	useCollectionBulk  bool
 	useSimpleCollation bool
@@ -390,7 +391,7 @@ func (r *Repl) Start(ctx context.Context, startAt bson.Timestamp) error {
 	}
 
 	r.pool = newWorkerPool(
-		context.Background(), r.options, r.source, r.target, r.useCollectionBulk, r.useSimpleCollation,
+		context.Background(), r.options, r.source, r.target, r.useCollectionBulk, r.useSimpleCollation, r.catalog.UUIDMap,
 	)
 
 	r.checkpointOpTime = startAt
@@ -488,7 +489,7 @@ func (r *Repl) Resume(ctx context.Context) error {
 	r.pauseTime = time.Time{}
 	r.doneCh = make(chan struct{})
 	r.pool = newWorkerPool(
-		context.Background(), r.options, r.source, r.target, r.useCollectionBulk, r.useSimpleCollation,
+		context.Background(), r.options, r.source, r.target, r.useCollectionBulk, r.useSimpleCollation, r.catalog.UUIDMap,
 	)
 
 	go r.run(ctx, options.ChangeStream().SetStartAtOperationTime(&r.checkpointOpTime))
@@ -702,8 +703,6 @@ func (r *Repl) run(ctx context.Context, opts *options.ChangeStreamOptionsBuilder
 		}
 	}()
 
-	uuidMap := r.catalog.UUIDMap()
-
 	lg := log.New("repl")
 
 	// lastRoutedTS tracks the ClusterTime of the last event routed to the pool.
@@ -788,8 +787,7 @@ func (r *Repl) run(ctx context.Context, opts *options.ChangeStreamOptionsBuilder
 
 		switch change.OperationType { //nolint:exhaustive
 		case Insert, Update, Delete, Replace:
-			ns := findNamespaceByUUID(uuidMap, change)
-			r.pool.Route(change, ns)
+			r.pool.Route(change)
 			lastRoutedTS = change.ClusterTime
 
 			r.tryAdvanceOpTime(cpTicker)
@@ -838,11 +836,6 @@ func (r *Repl) run(ctx context.Context, opts *options.ChangeStreamOptionsBuilder
 			r.lock.Unlock()
 
 			metrics.AddEventsApplied(1)
-
-			switch change.OperationType { //nolint:exhaustive
-			case Create, Rename, Drop, DropDatabase, ShardCollection:
-				uuidMap = r.catalog.UUIDMap()
-			}
 
 			lastRoutedTS = bson.Timestamp{} // barrier flushed everything
 			r.pool.ReleaseBarrier()
@@ -972,20 +965,6 @@ func (r *Repl) poolIdle(lastRoutedTS bson.Timestamp) bool {
 	}
 
 	return r.pool.Idle()
-}
-
-//go:inline
-func findNamespaceByUUID(uuidMap catalog.UUIDMap, change *ChangeEvent) catalog.Namespace {
-	if change.CollectionUUID == nil {
-		return change.Namespace
-	}
-
-	ns, ok := uuidMap[hex.EncodeToString(change.CollectionUUID.Data)]
-	if !ok {
-		return change.Namespace
-	}
-
-	return ns
 }
 
 // uuidEqual reports whether two BSON UUID binaries refer to the same UUID.

--- a/pcsm/repl/repl.go
+++ b/pcsm/repl/repl.go
@@ -143,8 +143,6 @@ type Repl struct {
 	expectMovePrimaryInvalidate bool
 	sourceIsMongos              bool
 
-	getCollectionShardingInfo func(context.Context, *mongo.Client, string, string) (*mdb.ShardingInfo, error)
-
 	useCollectionBulk  bool
 	useSimpleCollation bool
 }

--- a/pcsm/repl/repl_test.go
+++ b/pcsm/repl/repl_test.go
@@ -21,6 +21,8 @@ const (
 	replTestCollection = "testcoll"
 )
 
+func testDocumentIDKey() string { return string([]byte{'_', 'i', 'd'}) }
+
 type mockCatalog struct {
 	collectionExists bool
 

--- a/pcsm/repl/repl_test.go
+++ b/pcsm/repl/repl_test.go
@@ -19,9 +19,8 @@ var errCursorClosedByMongos = errors.New("cursor closed by mongos")
 const (
 	replTestDBName     = "testdb"
 	replTestCollection = "testcoll"
+	testDocumentIDKey  = "_id"
 )
-
-func testDocumentIDKey() string { return string([]byte{'_', 'i', 'd'}) }
 
 type mockCatalog struct {
 	collectionExists bool

--- a/pcsm/repl/repl_test.go
+++ b/pcsm/repl/repl_test.go
@@ -39,6 +39,8 @@ type mockCatalog struct {
 	setCollectionUUIDDB     string
 	setCollectionUUIDColl   string
 	setCollectionUUIDValue  *bson.Binary
+
+	setCollectionShardingMetadataErr error
 }
 
 type mockPool struct {
@@ -95,6 +97,10 @@ func (m *mockCatalog) CreateIndexes(_ context.Context, _, _ string, _ []*mdb.Ind
 
 func (m *mockCatalog) ShardCollection(_ context.Context, _, _ string, _ bson.D, _ bool) error {
 	return nil
+}
+
+func (m *mockCatalog) SetCollectionShardingMetadata(_ context.Context, _, _ string, _ bson.D) error {
+	return m.setCollectionShardingMetadataErr
 }
 
 func (m *mockCatalog) UUIDMap() catalog.UUIDMap {

--- a/pcsm/repl/worker.go
+++ b/pcsm/repl/worker.go
@@ -433,6 +433,8 @@ type workerPool struct {
 
 	target *mongo.Client
 
+	catalogSnapshot func() catalog.UUIDMap
+
 	errCh  chan error
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
@@ -452,11 +454,12 @@ func newWorkerPool(
 	poolCtx, cancel := context.WithCancel(ctx)
 
 	p := &workerPool{
-		workers:    make([]*worker, numWorkers),
-		numWorkers: numWorkers,
-		target:     target,
-		errCh:      make(chan error, 1),
-		cancel:     cancel,
+		workers:         make([]*worker, numWorkers),
+		numWorkers:      numWorkers,
+		target:          target,
+		catalogSnapshot: catalogSnapshot,
+		errCh:           make(chan error, 1),
+		cancel:          cancel,
 	}
 
 	// Create and start workers
@@ -506,11 +509,11 @@ func (p *workerPool) Route(change *ChangeEvent) {
 }
 
 func (p *workerPool) resolveNamespace(change *ChangeEvent) catalog.Namespace {
-	if len(p.workers) == 0 || p.workers[0].catalogSnapshot == nil {
+	if p.catalogSnapshot == nil {
 		return change.Namespace
 	}
 
-	return findNamespaceByUUID(p.workers[0].catalogSnapshot(), change)
+	return findNamespaceByUUID(p.catalogSnapshot(), change)
 }
 
 // Barrier flushes all workers and waits for them to complete.

--- a/pcsm/repl/worker.go
+++ b/pcsm/repl/worker.go
@@ -18,12 +18,8 @@ import (
 	"github.com/percona/percona-clustersync-mongodb/pcsm/catalog"
 )
 
-// routedEvent bundles a change event with its pre-resolved namespace.
-// Namespace is resolved in the dispatcher using uuidMap before routing to worker.
-// This includes enriched fields like Sharded and ShardKey from the catalog.
 type routedEvent struct {
 	change *ChangeEvent
-	ns     catalog.Namespace
 }
 
 // pendingBulk is a sealed bulk ready for writing by the writer goroutine.
@@ -65,8 +61,9 @@ type worker struct {
 	writerErr        error             // set by runWriter on failure, read after <-writerDone
 
 	// Factory for creating fresh bulkWriters after each enqueueBulk/restart.
-	bulkQueueSize int
-	newBulkWriter func() bulkWriter
+	bulkQueueSize   int
+	newBulkWriter   func(catalog.UUIDMap) bulkWriter
+	catalogSnapshot func() catalog.UUIDMap
 
 	// Barrier coordination
 	barrierReq  chan struct{}
@@ -91,34 +88,35 @@ func newWorker(
 	source, target *mongo.Client,
 	useCollectionBulk bool,
 	useSimpleCollation bool,
+	catalogSnapshot func() catalog.UUIDMap,
 	errC chan<- error,
 ) *worker {
 	w := &worker{
-		id:            strconv.Itoa(id),
-		routedEventCh: make(chan *routedEvent, opts.WorkerQueueSize),
-		flushInterval: opts.WorkerFlushInterval,
-		target:        target,
-		bulkQueueSize: opts.WorkerBulkQueueSize,
-		barrierReq:    make(chan struct{}),
-		barrierDone:   make(chan error),
-		resumeCh:      make(chan struct{}),
-		done:          make(chan struct{}),
-		errCh:         errC,
+		id:              strconv.Itoa(id),
+		routedEventCh:   make(chan *routedEvent, opts.WorkerQueueSize),
+		flushInterval:   opts.WorkerFlushInterval,
+		target:          target,
+		bulkQueueSize:   opts.WorkerBulkQueueSize,
+		barrierReq:      make(chan struct{}),
+		barrierDone:     make(chan error),
+		resumeCh:        make(chan struct{}),
+		done:            make(chan struct{}),
+		errCh:           errC,
+		catalogSnapshot: catalogSnapshot,
 	}
 
 	bulkOpsSize := opts.BulkOpsSize
 
 	if useCollectionBulk {
-		w.newBulkWriter = func() bulkWriter {
-			return newCollectionBulkWriter(bulkOpsSize, useSimpleCollation, source)
+		w.newBulkWriter = func(uuidMap catalog.UUIDMap) bulkWriter {
+			return newCollectionBulkWriter(bulkOpsSize, useSimpleCollation, source, uuidMap)
 		}
 	} else {
-		w.newBulkWriter = func() bulkWriter {
-			return newClientBulkWriter(bulkOpsSize, useSimpleCollation, source)
+		w.newBulkWriter = func(uuidMap catalog.UUIDMap) bulkWriter {
+			return newClientBulkWriter(bulkOpsSize, useSimpleCollation, source, uuidMap)
 		}
 	}
 
-	w.currentBulkWrite = w.newBulkWriter()
 	w.pendingBulkCh = make(chan *pendingBulk, w.bulkQueueSize)
 	w.writerDone = make(chan struct{})
 
@@ -179,9 +177,27 @@ func (w *worker) restartWriter(ctx context.Context) {
 	w.writerErr = nil
 	w.pendingBulkCh = make(chan *pendingBulk, w.bulkQueueSize)
 	w.writerDone = make(chan struct{})
-	w.currentBulkWrite = w.newBulkWriter()
+	w.currentBulkWrite = nil
 
 	go w.runWriter(ctx)
+}
+
+func (w *worker) currentBulkEmpty() bool {
+	return w.currentBulkWrite == nil || w.currentBulkWrite.Empty()
+}
+
+func (w *worker) ensureBulkWriter() {
+	if w.currentBulkWrite != nil {
+		return
+	}
+
+	if w.catalogSnapshot == nil {
+		w.currentBulkWrite = w.newBulkWriter(catalog.UUIDMap{})
+
+		return
+	}
+
+	w.currentBulkWrite = w.newBulkWriter(w.catalogSnapshot())
 }
 
 // run is the main loop for the worker. It processes events from eventC,
@@ -268,7 +284,7 @@ func (w *worker) run(ctx context.Context) {
 			}
 
 		case <-ticker.C:
-			if !w.currentBulkWrite.Empty() {
+			if !w.currentBulkEmpty() {
 				if !w.enqueueBulk() {
 					lg.Debug("Worker stopped (writer error)")
 
@@ -293,7 +309,7 @@ func (w *worker) run(ctx context.Context) {
 				return
 			}
 
-			if w.currentBulkWrite.Full() {
+			if !w.currentBulkEmpty() && w.currentBulkWrite.Full() {
 				if !w.enqueueBulk() {
 					lg.Debug("Worker stopped (writer error)")
 
@@ -318,6 +334,7 @@ func (w *worker) addToCurrentBulk(event *routedEvent) error {
 	}
 
 	event.change.RawData = nil // release raw bytes for GC
+	w.ensureBulkWriter()
 
 	// Preflight: if the current bulk would overflow the byte budget, enqueue it first
 	// and start fresh. The WouldOverflow guard returns false when the bulk is empty so
@@ -330,16 +347,16 @@ func (w *worker) addToCurrentBulk(event *routedEvent) error {
 
 	switch e := parsed.(type) { //nolint:exhaustive
 	case InsertEvent:
-		w.currentBulkWrite.Insert(event.ns, &e)
+		w.currentBulkWrite.Insert(event.change, &e)
 
 	case UpdateEvent:
-		w.currentBulkWrite.Update(event.ns, &e)
+		w.currentBulkWrite.Update(event.change, &e)
 
 	case DeleteEvent:
-		w.currentBulkWrite.Delete(event.ns, &e)
+		w.currentBulkWrite.Delete(event.change, &e)
 
 	case ReplaceEvent:
-		w.currentBulkWrite.Replace(event.ns, &e)
+		w.currentBulkWrite.Replace(event.change, &e)
 	}
 
 	// Track the timestamp of the last event in the batch
@@ -361,7 +378,7 @@ func (w *worker) reportError(err error) {
 // creates a fresh bulkWriter for the next batch. Returns true on success,
 // false if the writer goroutine has died (error already reported).
 func (w *worker) enqueueBulk() bool {
-	if w.currentBulkWrite.Empty() {
+	if w.currentBulkEmpty() {
 		return true
 	}
 
@@ -377,7 +394,7 @@ func (w *worker) enqueueBulk() bool {
 		return false
 	}
 
-	w.currentBulkWrite = w.newBulkWriter()
+	w.currentBulkWrite = nil
 
 	return true
 }
@@ -398,7 +415,7 @@ func (w *worker) drainRoutedEvents() bool {
 				return false
 			}
 
-			if w.currentBulkWrite.Full() {
+			if !w.currentBulkEmpty() && w.currentBulkWrite.Full() {
 				if !w.enqueueBulk() {
 					return false
 				}
@@ -428,6 +445,7 @@ func newWorkerPool(
 	source, target *mongo.Client,
 	useCollectionBulk bool,
 	useSimpleCollation bool,
+	catalogSnapshot func() catalog.UUIDMap,
 ) *workerPool {
 	numWorkers := opts.NumWorkers
 
@@ -443,7 +461,7 @@ func newWorkerPool(
 
 	// Create and start workers
 	for i := range numWorkers {
-		w := newWorker(i, opts, source, target, useCollectionBulk, useSimpleCollation, p.errCh)
+		w := newWorker(i, opts, source, target, useCollectionBulk, useSimpleCollation, catalogSnapshot, p.errCh)
 		w.tickerOffset = time.Duration(i) * opts.WorkerFlushInterval / time.Duration(numWorkers)
 		p.workers[i] = w
 
@@ -464,7 +482,9 @@ func newWorkerPool(
 // the same worker, preserving insertion order.
 // Uses bson.Raw.Lookup to extract the documentKey bytes directly from the raw
 // BSON, avoiding the unmarshal-then-remarshal round-trip of extractDocumentKey.
-func (p *workerPool) Route(change *ChangeEvent, ns catalog.Namespace) {
+func (p *workerPool) Route(change *ChangeEvent) {
+	ns := p.resolveNamespace(change)
+
 	var workerIdx int
 	if ns.Capped {
 		workerIdx = hashNamespace(ns, p.numWorkers)
@@ -480,10 +500,17 @@ func (p *workerPool) Route(change *ChangeEvent, ns catalog.Namespace) {
 
 	w.routedEventCh <- &routedEvent{
 		change: change,
-		ns:     ns,
 	}
 
 	metrics.SetReplWorkerEventQueueSize(w.id, len(w.routedEventCh))
+}
+
+func (p *workerPool) resolveNamespace(change *ChangeEvent) catalog.Namespace {
+	if len(p.workers) == 0 || p.workers[0].catalogSnapshot == nil {
+		return change.Namespace
+	}
+
+	return findNamespaceByUUID(p.workers[0].catalogSnapshot(), change)
 }
 
 // Barrier flushes all workers and waits for them to complete.

--- a/pcsm/repl/worker_async_test.go
+++ b/pcsm/repl/worker_async_test.go
@@ -10,6 +10,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 
 	"github.com/percona/percona-clustersync-mongodb/errors"
+	"github.com/percona/percona-clustersync-mongodb/pcsm/catalog"
 )
 
 // makeInsertEventWithTS creates a valid routedEvent with an insert ChangeEvent
@@ -52,7 +53,7 @@ func TestEnqueueBulk_SealsBulkAndQueues(t *testing.T) {
 		lastPendingTS:    ts,
 		pendingBulkCh:    make(chan *pendingBulk, 1),
 		writerDone:       make(chan struct{}),
-		newBulkWriter:    func() bulkWriter { return &mockBulkWriter{} },
+		newBulkWriter:    func(catalog.UUIDMap) bulkWriter { return &mockBulkWriter{} },
 	}
 
 	ok := w.enqueueBulk()
@@ -65,9 +66,7 @@ func TestEnqueueBulk_SealsBulkAndQueues(t *testing.T) {
 	assert.Equal(t, mock, pb.writer, "queued writer should be the original mock")
 	assert.Equal(t, ts, pb.checkpoint, "checkpoint should match pendingTS at seal time")
 
-	// Verify a fresh bulkWriter replaced the old one.
-	assert.True(t, w.currentBulkWrite.Empty(), "new bulkWriter should be empty")
-	assert.NotEqual(t, mock, w.currentBulkWrite, "bulkWrite should be a new instance")
+	assert.Nil(t, w.currentBulkWrite, "bulkWrite should be recreated lazily from next catalog snapshot")
 }
 
 // TestEnqueueBulk_ReturnsFalseWhenWriterDead verifies that enqueueBulk() returns false

--- a/pcsm/repl/worker_test.go
+++ b/pcsm/repl/worker_test.go
@@ -338,8 +338,8 @@ func (m *mockBulkWriter) Delete(_ *ChangeEvent, _ *DeleteEvent)   { m.count++ }
 // The RawData contains the minimal BSON that parseDMLEvent can unmarshal.
 func makeInsertEvent(id string) *routedEvent {
 	raw, err := bson.Marshal(bson.D{
-		{"documentKey", bson.D{{testDocumentIDKey(), id}}},
-		{"fullDocument", bson.D{{testDocumentIDKey(), id}, {"x", 1}}},
+		{"documentKey", bson.D{{testDocumentIDKey, id}}},
+		{"fullDocument", bson.D{{testDocumentIDKey, id}, {"x", 1}}},
 	})
 	if err != nil {
 		panic(fmt.Sprintf("marshal insert event: %v", err))

--- a/pcsm/repl/worker_test.go
+++ b/pcsm/repl/worker_test.go
@@ -338,8 +338,8 @@ func (m *mockBulkWriter) Delete(_ *ChangeEvent, _ *DeleteEvent)   { m.count++ }
 // The RawData contains the minimal BSON that parseDMLEvent can unmarshal.
 func makeInsertEvent(id string) *routedEvent {
 	raw, err := bson.Marshal(bson.D{
-		{"documentKey", bson.D{{"_id", id}}},
-		{"fullDocument", bson.D{{"_id", id}, {"x", 1}}},
+		{"documentKey", bson.D{{testDocumentIDKey(), id}}},
+		{"fullDocument", bson.D{{testDocumentIDKey(), id}, {"x", 1}}},
 	})
 	if err != nil {
 		panic(fmt.Sprintf("marshal insert event: %v", err))
@@ -349,7 +349,7 @@ func makeInsertEvent(id string) *routedEvent {
 		change: &ChangeEvent{
 			EventHeader: EventHeader{
 				OperationType: Insert,
-				Namespace:     catalog.Namespace{Database: "testdb", Collection: "testcoll"},
+				Namespace:     catalog.Namespace{Database: replTestDBName, Collection: replTestCollection},
 			},
 			RawData: bson.Raw(raw),
 		},

--- a/pcsm/repl/worker_test.go
+++ b/pcsm/repl/worker_test.go
@@ -37,14 +37,15 @@ func makeTestPool(numWorkers int) *workerPool {
 
 // makeChangeEvent builds a minimal ChangeEvent whose RawData contains a
 // documentKey field, matching what Route() reads via bson.Raw.Lookup.
-func makeChangeEvent(docKey bson.D) *ChangeEvent {
+func makeChangeEvent(docKey bson.D, ns catalog.Namespace) *ChangeEvent {
 	raw, err := bson.Marshal(bson.D{{"documentKey", docKey}})
 	if err != nil {
 		panic(fmt.Sprintf("marshal documentKey: %v", err))
 	}
 
 	return &ChangeEvent{
-		RawData: bson.Raw(raw),
+		EventHeader: EventHeader{Namespace: ns},
+		RawData:     bson.Raw(raw),
 	}
 }
 
@@ -151,7 +152,7 @@ func TestRoute_SameDocumentGoesToSameWorker(t *testing.T) {
 	docKey := bson.D{{"_id", "same-doc"}}
 
 	for range numEvents {
-		pool.Route(makeChangeEvent(docKey), ns)
+		pool.Route(makeChangeEvent(docKey, ns))
 	}
 
 	counts := workerEventCounts(pool)
@@ -179,7 +180,7 @@ func TestRoute_DifferentDocumentsDistribute(t *testing.T) {
 
 	for i := range numEvents {
 		docKey := bson.D{{"_id", fmt.Sprintf("doc-%d", i)}}
-		pool.Route(makeChangeEvent(docKey), ns)
+		pool.Route(makeChangeEvent(docKey, ns))
 	}
 
 	counts := workerEventCounts(pool)
@@ -210,7 +211,7 @@ func TestRoute_CappedNamespaceRoutesToSameWorker(t *testing.T) {
 	// Route events with different document keys — they must all go to one worker.
 	for i := range numEvents {
 		docKey := bson.D{{"_id", fmt.Sprintf("doc-%d", i)}}
-		pool.Route(makeChangeEvent(docKey), ns)
+		pool.Route(makeChangeEvent(docKey, ns))
 	}
 
 	counts := workerEventCounts(pool)
@@ -245,8 +246,8 @@ func TestRoute_CappedDifferentNamespacesCanDiffer(t *testing.T) {
 	ns2Worker := -1
 
 	for i := range numEvents {
-		pool1.Route(makeChangeEvent(bson.D{{"_id", fmt.Sprintf("a-%d", i)}}), ns1)
-		pool2.Route(makeChangeEvent(bson.D{{"_id", fmt.Sprintf("b-%d", i)}}), ns2)
+		pool1.Route(makeChangeEvent(bson.D{{"_id", fmt.Sprintf("a-%d", i)}}, ns1))
+		pool2.Route(makeChangeEvent(bson.D{{"_id", fmt.Sprintf("b-%d", i)}}, ns2))
 	}
 
 	counts1 := workerEventCounts(pool1)
@@ -283,7 +284,7 @@ func TestRoute_NonCappedIgnoresCappedRouting(t *testing.T) {
 
 	for i := range numEvents {
 		docKey := bson.D{{"_id", fmt.Sprintf("doc-%d", i)}}
-		pool.Route(makeChangeEvent(docKey), ns)
+		pool.Route(makeChangeEvent(docKey, ns))
 	}
 
 	counts := workerEventCounts(pool)
@@ -328,10 +329,10 @@ func (m *mockBulkWriter) Do(_ context.Context, _ *mongo.Client) (int, error) {
 	return n, nil
 }
 
-func (m *mockBulkWriter) Insert(_ catalog.Namespace, _ *InsertEvent)   { m.count++ }
-func (m *mockBulkWriter) Update(_ catalog.Namespace, _ *UpdateEvent)   { m.count++ }
-func (m *mockBulkWriter) Replace(_ catalog.Namespace, _ *ReplaceEvent) { m.count++ }
-func (m *mockBulkWriter) Delete(_ catalog.Namespace, _ *DeleteEvent)   { m.count++ }
+func (m *mockBulkWriter) Insert(_ *ChangeEvent, _ *InsertEvent)   { m.count++ }
+func (m *mockBulkWriter) Update(_ *ChangeEvent, _ *UpdateEvent)   { m.count++ }
+func (m *mockBulkWriter) Replace(_ *ChangeEvent, _ *ReplaceEvent) { m.count++ }
+func (m *mockBulkWriter) Delete(_ *ChangeEvent, _ *DeleteEvent)   { m.count++ }
 
 // makeInsertEvent creates a valid routedEvent with an insert ChangeEvent.
 // The RawData contains the minimal BSON that parseDMLEvent can unmarshal.
@@ -346,10 +347,12 @@ func makeInsertEvent(id string) *routedEvent {
 
 	return &routedEvent{
 		change: &ChangeEvent{
-			EventHeader: EventHeader{OperationType: Insert},
-			RawData:     bson.Raw(raw),
+			EventHeader: EventHeader{
+				OperationType: Insert,
+				Namespace:     catalog.Namespace{Database: "testdb", Collection: "testcoll"},
+			},
+			RawData: bson.Raw(raw),
 		},
-		ns: catalog.Namespace{Database: "testdb", Collection: "testcoll"},
 	}
 }
 
@@ -379,7 +382,7 @@ func makeTestPoolLive(t *testing.T, bws []bulkWriter) *workerPool {
 			pendingBulkCh:    make(chan *pendingBulk, config.WorkerBulkQueueSize),
 			writerDone:       make(chan struct{}),
 			bulkQueueSize:    config.WorkerBulkQueueSize,
-			newBulkWriter:    func() bulkWriter { return &mockBulkWriter{} },
+			newBulkWriter:    func(catalog.UUIDMap) bulkWriter { return &mockBulkWriter{} },
 			barrierReq:       make(chan struct{}),
 			barrierDone:      make(chan error),
 			resumeCh:         make(chan struct{}),


### PR DESCRIPTION
## Problem

PCSM resolves the destination namespace for each DML change once on the dispatch goroutine, by looking the collection UUID up in the catalog, then hands the change to a worker that applies it asynchronously. When DDL changes the UUID-to-namespace mapping between dispatch and execution (a movePrimary phantom create, a recreate), the dispatch-resolved namespace can be stale by the time the worker builds its write.

## Solution

Resolve the write-target namespace by collection UUID at worker write-build time:

- the dispatch loop calls `r.pool.Route(change)` without a namespace
- the worker pool resolves a namespace only to select a worker (capped collections hash by namespace to preserve order; others hash by document key)
- the bulk writer resolves the write-target namespace with `findNamespaceByUUID(catalogSnapshot(), change)` when it builds each operation
- `r.catalog.UUIDMap` is passed into `newWorkerPool` at both call sites; the dispatch loop's pre-resolved namespace and its post-DDL refresh are gone
- the catalog and bulk writer gain the UUID-to-namespace support the worker needs

Stacked on #244 (mongos invalidate recovery and replay skip); that design is untouched: the `barrierController` seam, `expectMovePrimaryInvalidate` flag, `handleInvalidateWithBarrier`, and the replay-skip guard all remain.

## Testing

- Unit coverage for worker-side namespace resolution (`worker_test.go`, `worker_async_test.go`, `bulk_test.go`)
- Unit coverage for the catalog UUID-to-namespace lookup (`catalog_uuid_test.go`)
- `go build -tags=performance ./...` and `make test` pass; `make lint` adds no new goconst (the cap is a pre-existing repo-wide condition)

## Notes

Part of PCSM-249. Depends on #243 (UUID-idempotent create and drop replay) and stacks on #244. Retargets to its base as the stack merges.
