### PR TITLE
PCSM-321: Deflake manual TTL index test

### DIFF
--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -475,7 +475,8 @@ def test_manual_create_ttl(t: Testing):
         pcsm.start()
         t.source["db_1"]["coll_1"].create_index({"b": 1}, expireAfterSeconds=1)
         pcsm.wait_for_initial_sync()
-        t.source["db_1"]["coll_1"].create_index({"c": 1}, expireAfterSeconds=1)
+        index_name = t.source["db_1"]["coll_1"].create_index({"c": 1}, expireAfterSeconds=1)
+        t.wait_target_index("db_1", "coll_1", index_name)
         pcsm.finalize()
     except:
         pcsm.finalize(fast=True)

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -84,6 +84,18 @@ class Testing:
             f"target {db}.{coll}: expected {expected} docs, got {actual} after {timeout}s"
         )
 
+    def wait_target_index(self, db: str, coll: str, index_name: str, timeout: int = 30):
+        for _ in range(timeout * 2):
+            indexes = self.target[db][coll].index_information()
+            if index_name in indexes:
+                return
+            time.sleep(0.5)
+
+        indexes = sorted(self.target[db][coll].index_information())
+        raise AssertionError(
+            f"target {db}.{coll}: expected index {index_name}, got {indexes} after {timeout}s"
+        )
+
 
 def drop_all_database(source: MongoClient):
     """Drop all databases in the MongoDB."""


### PR DESCRIPTION
[PCSM-321](https://jira.percona.com/browse/PCSM-321)

### Problem

`test_manual_create_ttl` creates TTL index `c_1` after initial sync and then finalizes immediately. Finalize pauses change replication, so the `createIndexes` event can be present on source but not yet applied on target when the stream is stopped. `wait_for_current_optime()` is not enough here because reported optime can move through the sync-point path without proving this specific DDL is target-visible.

### Solution

Adds a bounded `Testing.wait_target_index()` helper that polls target `index_information()` for a named index. `test_manual_create_ttl` now waits for the returned index name to appear on target before calling finalize, which matches the expected workflow: stop source activity, drain replication, then finalize.

[PCSM-321]: https://perconadev.atlassian.net/browse/PCSM-321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ