### PR TITLE
PCSM-345: Make HTTP server bind host configurable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ Common runtime knobs. Every flag has a matching `PCSM_*` env var.
 | `PCSM_SOURCE_URI`                | `--source`                    |
 | `PCSM_TARGET_URI`                | `--target`                    |
 | `PCSM_PORT`                      | `--port` (default `2242`)     |
+| `PCSM_LISTEN_HOST`               | `--listen-host`               |
 | `PCSM_LOG_LEVEL`                 | `--log-level`                 |
 | `PCSM_MONGODB_OPERATION_TIMEOUT` | `--mongodb-operation-timeout` |
 | `PCSM_CLONE_SEGMENT_SIZE`        | `--clone-segment-size`        |

--- a/config/config.go
+++ b/config/config.go
@@ -20,9 +20,10 @@ import (
 
 // Config holds all PCSM configuration.
 type Config struct {
-	Port   int    `mapstructure:"port"`
-	Source string `mapstructure:"source"`
-	Target string `mapstructure:"target"`
+	Port       int    `mapstructure:"port"`
+	ListenHost string `mapstructure:"listen-host"`
+	Source     string `mapstructure:"source"`
+	Target     string `mapstructure:"target"`
 
 	Log LogConfig `mapstructure:",squash"`
 
@@ -154,6 +155,7 @@ func WarnDeprecatedEnvVars(ctx context.Context) {
 
 func bindEnvVars() {
 	_ = viper.BindEnv("port", "PCSM_PORT")
+	_ = viper.BindEnv("listen-host", "PCSM_LISTEN_HOST")
 
 	_ = viper.BindEnv("source", "PCSM_SOURCE_URI")
 	_ = viper.BindEnv("target", "PCSM_TARGET_URI")

--- a/config/validate.go
+++ b/config/validate.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"net"
+
 	"github.com/dustin/go-humanize"
 
 	"github.com/percona/percona-clustersync-mongodb/errors"
@@ -18,6 +20,11 @@ func Validate(cfg *Config) error {
 
 	if port <= 1024 || port > 65535 {
 		return errors.New("port value is outside the supported range [1024 - 65535]")
+	}
+
+	_, _, err := net.SplitHostPort(cfg.ListenHost)
+	if err == nil {
+		return errors.New("listen-host must not include a port")
 	}
 
 	switch {

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -174,6 +174,52 @@ func TestValidate_PortBoundaries(t *testing.T) {
 	}
 }
 
+func TestValidate_ListenHost(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		listenHost string
+		wantErr    bool
+	}{
+		// Accepted: empty (defaults to localhost at runtime), hostnames, IP literals without a port
+		{"empty - valid (defaults to localhost)", "", false},
+		{"localhost - valid", "localhost", false},
+		{"IPv4 loopback - valid", "127.0.0.1", false},
+		{"IPv4 all interfaces - valid", "0.0.0.0", false},
+		{"IPv6 loopback - valid", "::1", false},
+		{"IPv6 link-local - valid", "fe80::1", false},
+		{"DNS name - valid", "example.com", false},
+
+		// Rejected: host already contains a port
+		{"localhost with port - invalid", "localhost:2242", true},
+		{"IPv4 with port - invalid", "127.0.0.1:2242", true},
+		{"bracketed IPv6 with port - invalid", "[::1]:2242", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &config.Config{
+				Port:       8080,
+				Source:     "mongodb://source:27017",
+				Target:     "mongodb://target:27017",
+				ListenHost: tt.listenHost,
+			}
+
+			err := config.Validate(cfg)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "listen-host must not include a port")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestValidateCloneSegmentSize(t *testing.T) {
 	t.Parallel()
 

--- a/main.go
+++ b/main.go
@@ -6,11 +6,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/pprof"
 	"os"
 	"os/signal"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -136,6 +138,7 @@ func newRootCmd() *cobra.Command {
 	// Root command specific flags
 	rootCmd.Flags().String("source", "", "MongoDB connection string for the source")
 	rootCmd.Flags().String("target", "", "MongoDB connection string for the target")
+	rootCmd.Flags().String("listen-host", "localhost", "Host to bind the HTTP server")
 
 	rootCmd.Flags().StringSlice("source-client-compressors", nil,
 		fmt.Sprintf("Compressors for the source MongoDB client (comma-separated: zstd,zlib,snappy; default: %s)",
@@ -539,7 +542,12 @@ func runServer(cfg *config.Config) error {
 		port = config.DefaultServerPort
 	}
 
-	addr := fmt.Sprintf("localhost:%d", port)
+	host := cfg.ListenHost
+	if host == "" {
+		host = "localhost"
+	}
+
+	addr := net.JoinHostPort(host, strconv.Itoa(port))
 	httpServer := http.Server{
 		Addr:    addr,
 		Handler: srv.Handler(),


### PR DESCRIPTION
[PCSM-345](https://perconadev.atlassian.net/browse/PCSM-345)

### Problem

The HTTP server binds to a hardcoded `localhost:2242`, so it only listens on 127.0.0.1. `--port` changes the port but not the host. Docker hides this because the quickstart uses `--network host`. Under Kubernetes it breaks: the kubelet's httpGet probes hit the pod IP, get connection refused, and the pod ends up in CrashLoopBackOff.

### Solution

Add a server-only `--listen-host` flag and `PCSM_LISTEN_HOST` env var, default `localhost`, so current behavior is unchanged. Operators who need httpGet probes set it to `0.0.0.0`. `--port` stays the single source for the port, and the bind address is built with `net.JoinHostPort` so IPv6 hosts like `::1` produce a valid `[::1]:2242`. The CLI client keeps talking to localhost.

The default stays `localhost` on purpose. The control API and pprof endpoints are unauthenticated, so listening on all interfaces is opt-in. An empty host falls back to `localhost` at runtime, the same way an unset port falls back to the default, and validation rejects a host that already carries a port.


[PCSM-345]: https://perconadev.atlassian.net/browse/PCSM-345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ