### PR TITLE
PCSM-328: Wrap remaining MongoDB operations with a retry wrapper

### DIFF
--- a/mdb/errors.go
+++ b/mdb/errors.go
@@ -91,8 +91,8 @@ func IsTransient(err error) bool {
 		return true
 	}
 
-	le, ok := err.(mongo.LabeledError) //nolint:errorlint
-	if ok && le.HasErrorLabel("RetryableWriteError") {
+	var le mongo.LabeledError
+	if errors.As(err, &le) && le.HasErrorLabel("RetryableWriteError") {
 		return true
 	}
 

--- a/mdb/errors_test.go
+++ b/mdb/errors_test.go
@@ -1,6 +1,7 @@
 package mdb_test
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,6 +30,56 @@ func TestIsDatabaseDropPending(t *testing.T) {
 			t.Parallel()
 
 			assert.Equal(t, tt.expected, mdb.IsDatabaseDropPending(tt.err))
+		})
+	}
+}
+
+// labeledError is a minimal mongo.LabeledError implementation used to verify
+// that IsTransient detects retryable write labels through error wrapping.
+type labeledError struct {
+	labels []string
+}
+
+func (e labeledError) Error() string { return "labeled error" }
+
+func (e labeledError) HasErrorLabel(label string) bool {
+	return slices.Contains(e.labels, label)
+}
+
+// TestIsTransient_RetryableWriteLabel locks the fix that detects the
+// RetryableWriteError label via errors.As so it survives error wrapping inside
+// retry closures (previously a direct type assertion hid the label once
+// wrapped).
+func TestIsTransient_RetryableWriteLabel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			"unwrapped retryable-write label",
+			labeledError{labels: []string{"RetryableWriteError"}},
+			true,
+		},
+		{
+			"wrapped retryable-write label",
+			errors.Wrap(labeledError{labels: []string{"RetryableWriteError"}}, "insert batch"),
+			true,
+		},
+		{
+			"wrapped without retryable-write label",
+			errors.Wrap(labeledError{labels: []string{"SomeOtherLabel"}}, "insert batch"),
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.expected, mdb.IsTransient(tt.err))
 		})
 	}
 }

--- a/mdb/retry.go
+++ b/mdb/retry.go
@@ -46,11 +46,18 @@ func RunWithRetry(
 			return err
 		}
 
-		log.Ctx(ctx).Warnf("Transient error: %v, retry attempt %d retrying in %s",
-			err, attempt, currentInterval)
+		if attempt < maxRetries {
+			log.Ctx(ctx).Warnf("Transient error: %v, retry attempt %d retrying in %s",
+				err, attempt, currentInterval)
 
-		time.Sleep(currentInterval)
-		currentInterval *= 2
+			select {
+			case <-time.After(currentInterval):
+			case <-ctx.Done():
+				return errors.Wrap(ctx.Err(), "retry wait")
+			}
+
+			currentInterval *= 2
+		}
 	}
 
 	return err

--- a/mdb/retry.go
+++ b/mdb/retry.go
@@ -56,6 +56,28 @@ func RunWithRetry(
 	return err
 }
 
+// RunWithRetryVal is the value-returning variant of RunWithRetry. It runs fn
+// under the same transient-error retry logic and returns fn's value on success.
+//
+//nolint:ireturn // Generic retry helper must return caller-selected value type.
+func RunWithRetryVal[T any](
+	ctx context.Context,
+	fn func(context.Context) (T, error),
+	retryInterval time.Duration,
+	maxRetries int,
+) (T, error) {
+	var result T
+
+	err := RunWithRetry(ctx, func(ctx context.Context) error {
+		var inner error
+		result, inner = fn(ctx)
+
+		return inner //nolint:wrapcheck
+	}, retryInterval, maxRetries)
+
+	return result, err //nolint:wrapcheck
+}
+
 // RetryWithBackoff retries fn with exponential backoff. When maxRetries > 0 it
 // stops after that many attempts. When maxRetries <= 0 it retries indefinitely
 // until the context is canceled or isUnrecoverable classifies the error as

--- a/mdb/retry_test.go
+++ b/mdb/retry_test.go
@@ -200,3 +200,90 @@ func TestRetryWithBackoff_UnlimitedRetriesUntilSuccess(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int32(10), calls.Load())
 }
+
+func TestRunWithRetry_FirstAttemptSuccess(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+
+	fn := func(_ context.Context) error {
+		calls++
+
+		return nil
+	}
+
+	err := RunWithRetry(t.Context(), fn, 1*time.Millisecond, 3)
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+}
+
+// TestRunWithRetry_NoSleepAfterFinalAttempt locks the fix that removes the
+// wasted backoff wait following the last failed attempt. Backoff waits occur
+// only between attempts, so with a 1s base interval and 3 attempts the total
+// elapsed fake time is 1s + 2s = 3s, not 1s + 2s + 4s = 7s.
+func TestRunWithRetry_NoSleepAfterFinalAttempt(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		transientErr := mongo.WriteException{
+			WriteErrors: []mongo.WriteError{
+				{
+					Code:    91, // ShutdownInProgress
+					Message: "transient error",
+				},
+			},
+		}
+
+		calls := 0
+
+		fn := func(_ context.Context) error {
+			calls++
+
+			return transientErr
+		}
+
+		start := time.Now()
+		err := RunWithRetry(t.Context(), fn, time.Second, 3)
+		elapsed := time.Since(start)
+
+		require.ErrorAs(t, err, &transientErr)
+		assert.Equal(t, 3, calls)
+		assert.Equal(t, 3*time.Second, elapsed)
+	})
+}
+
+// TestRunWithRetry_ContextCanceledDuringBackoff locks the fix that makes the
+// backoff wait cancellable: canceling the context while RunWithRetry is
+// sleeping between attempts returns promptly with the wrapped context error.
+func TestRunWithRetry_ContextCanceledDuringBackoff(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+
+		transientErr := mongo.WriteException{
+			WriteErrors: []mongo.WriteError{
+				{
+					Code:    91, // ShutdownInProgress
+					Message: "transient error",
+				},
+			},
+		}
+
+		fn := func(_ context.Context) error {
+			return transientErr
+		}
+
+		var err error
+
+		go func() {
+			err = RunWithRetry(ctx, fn, time.Second, 3)
+		}()
+
+		synctest.Wait()
+		cancel()
+		synctest.Wait()
+
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}

--- a/mdb/schema.go
+++ b/mdb/schema.go
@@ -22,15 +22,6 @@ const (
 	TypeView       = "view"
 )
 
-const (
-	currentOpStage      = "$currentOp"
-	indexStatsOpenStage = "$indexStats"
-	cursorAllStage      = "cursor: all"
-	chunksFindStage     = "find"
-	chunksReadStage     = "read"
-	chunksErrorStage    = "iterate"
-)
-
 // IndexSpecification contains all index options.
 //
 // NOTE: [mongo.IndexView.CreateMany] and [mongo.IndexView.CreateOne] use [mongo.IndexModel]
@@ -188,6 +179,11 @@ func ListInProgressIndexBuilds(
 		Name string `bson:"name"`
 	}
 
+	const (
+		currentOpStage = "$currentOp"
+		cursorAllStage = "cursor: all"
+	)
+
 	indexBuildsStage := currentOpStage
 	err := RunWithRetry(ctx, func(ctx context.Context) error {
 		indexBuildsStage = currentOpStage
@@ -249,6 +245,11 @@ func ListInconsistentIndexes(
 		Name string              `bson:"name"`
 		Spec *IndexSpecification `bson:"spec"`
 	}
+
+	const (
+		indexStatsOpenStage = "$indexStats"
+		cursorAllStage      = "cursor: all"
+	)
 
 	indexStatsStage := indexStatsOpenStage
 	err := RunWithRetry(ctx, func(ctx context.Context) error {
@@ -368,6 +369,12 @@ func GetCollectionShardingInfo(
 	chunksColl := m.Database("config").Collection("chunks")
 
 	var chunks []ChunkInfo
+
+	const (
+		chunksFindStage  = "find"
+		chunksErrorStage = "iterate"
+		chunksReadStage  = "read"
+	)
 
 	chunksStage := chunksFindStage
 	err = RunWithRetry(ctx, func(ctx context.Context) error {

--- a/mdb/schema.go
+++ b/mdb/schema.go
@@ -60,16 +60,32 @@ func (s *IndexSpecification) IsClustered() bool {
 }
 
 func ListDatabaseNames(ctx context.Context, m *mongo.Client) ([]string, error) {
-	//nolint:wrapcheck
-	return m.ListDatabaseNames(ctx,
-		bson.D{{"name", bson.D{{"$nin", bson.A{"admin", "config", "local"}}}}})
+	var names []string
+
+	err := RunWithRetry(ctx, func(ctx context.Context) error {
+		var inner error
+		names, inner = m.ListDatabaseNames(ctx,
+			bson.D{{"name", bson.D{{"$nin", bson.A{"admin", "config", "local"}}}}})
+
+		return inner //nolint:wrapcheck
+	}, DefaultRetryInterval, DefaultMaxRetries)
+
+	return names, err //nolint:wrapcheck
 }
 
 // ListCollectionNames returns a list of non-system collection names in the specified database.
 func ListCollectionNames(ctx context.Context, m *mongo.Client, dbName string) ([]string, error) {
-	//nolint:wrapcheck
-	return m.Database(dbName).ListCollectionNames(ctx,
-		bson.D{{"name", bson.D{{"$not", bson.D{{"$regex", "^system\\."}}}}}})
+	var names []string
+
+	err := RunWithRetry(ctx, func(ctx context.Context) error {
+		var inner error
+		names, inner = m.Database(dbName).ListCollectionNames(ctx,
+			bson.D{{"name", bson.D{{"$not", bson.D{{"$regex", "^system\\."}}}}}})
+
+		return inner //nolint:wrapcheck
+	}, DefaultRetryInterval, DefaultMaxRetries)
+
+	return names, err //nolint:wrapcheck
 }
 
 var ErrNotFound = errors.New("not found")
@@ -80,9 +96,17 @@ func ListCollectionSpecs(
 	m *mongo.Client,
 	dbName string,
 ) ([]CollectionSpecification, error) {
-	//nolint:wrapcheck
-	return m.Database(dbName).ListCollectionSpecifications(ctx,
-		bson.D{{"name", bson.D{{"$not", bson.D{{"$regex", "^system\\."}}}}}})
+	var specs []CollectionSpecification
+
+	err := RunWithRetry(ctx, func(ctx context.Context) error {
+		var inner error
+		specs, inner = m.Database(dbName).ListCollectionSpecifications(ctx,
+			bson.D{{"name", bson.D{{"$not", bson.D{{"$regex", "^system\\."}}}}}})
+
+		return inner //nolint:wrapcheck
+	}, DefaultRetryInterval, DefaultMaxRetries)
+
+	return specs, err //nolint:wrapcheck
 }
 
 // GetCollectionSpec retrieves the specification of a collection.
@@ -92,7 +116,14 @@ func GetCollectionSpec(
 	dbName string,
 	collName string,
 ) (*CollectionSpecification, error) {
-	colls, err := m.Database(dbName).ListCollectionSpecifications(ctx, bson.D{{"name", collName}})
+	var colls []CollectionSpecification
+
+	err := RunWithRetry(ctx, func(ctx context.Context) error {
+		var inner error
+		colls, inner = m.Database(dbName).ListCollectionSpecifications(ctx, bson.D{{"name", collName}})
+
+		return inner //nolint:wrapcheck
+	}, DefaultRetryInterval, DefaultMaxRetries)
 	if err != nil {
 		if IsNamespaceNotFound(err) {
 			err = ErrNotFound
@@ -117,7 +148,14 @@ func GetCollectionNameByUUID(
 	dbName string,
 	uuid bson.Binary,
 ) (string, error) {
-	specs, err := m.Database(dbName).ListCollectionSpecifications(ctx, bson.D{{"info.uuid", uuid}})
+	var specs []CollectionSpecification
+
+	err := RunWithRetry(ctx, func(ctx context.Context) error {
+		var inner error
+		specs, inner = m.Database(dbName).ListCollectionSpecifications(ctx, bson.D{{"info.uuid", uuid}})
+
+		return inner //nolint:wrapcheck
+	}, DefaultRetryInterval, DefaultMaxRetries)
 	if err != nil {
 		return "", errors.Wrap(err, "listCollections")
 	}
@@ -136,14 +174,16 @@ func ListIndexes(
 	db string,
 	coll string,
 ) ([]*IndexSpecification, error) {
-	cur, err := m.Database(db).Collection(coll).Indexes().List(ctx)
-	if err != nil {
-		return nil, errors.Wrap(err, "list indexes")
-	}
-
 	var indexes []*IndexSpecification
 
-	err = cur.All(ctx, &indexes)
+	err := RunWithRetry(ctx, func(ctx context.Context) error {
+		cur, err := m.Database(db).Collection(coll).Indexes().List(ctx)
+		if err != nil {
+			return err //nolint:wrapcheck
+		}
+
+		return cur.All(ctx, &indexes) //nolint:wrapcheck
+	}, DefaultRetryInterval, DefaultMaxRetries)
 	if err != nil {
 		return nil, errors.Wrap(err, "list indexes")
 	}
@@ -160,28 +200,30 @@ func ListInProgressIndexBuilds(
 	opts := options.Database().
 		SetReadPreference(readpref.Primary()).
 		SetReadConcern(readconcern.Local())
-	cur, err := m.Database("admin", opts).Aggregate(ctx, mongo.Pipeline{
-		{{"$currentOp", bson.D{{"allUsers", true}}}},
-		{{"$match", bson.D{
-			{"op", "command"},
-			{"command.createIndexes", coll},
-			{"command.$db", db},
-		}}},
-		{{"$unwind", "$command.indexes"}},
-		{{"$replaceRoot", bson.D{{"newRoot", "$command.indexes"}}}},
-		{{"$project", bson.D{{"name", 1}}}},
-	})
-	if err != nil {
-		return nil, errors.Wrap(err, "$currentOp")
-	}
-
 	var indexBuilds []struct {
 		Name string `bson:"name"`
 	}
 
-	err = cur.All(ctx, &indexBuilds)
+	err := RunWithRetry(ctx, func(ctx context.Context) error {
+		cur, err := m.Database("admin", opts).Aggregate(ctx, mongo.Pipeline{
+			{{"$currentOp", bson.D{{"allUsers", true}}}},
+			{{"$match", bson.D{
+				{"op", "command"},
+				{"command.createIndexes", coll},
+				{"command.$db", db},
+			}}},
+			{{"$unwind", "$command.indexes"}},
+			{{"$replaceRoot", bson.D{{"newRoot", "$command.indexes"}}}},
+			{{"$project", bson.D{{"name", 1}}}},
+		})
+		if err != nil {
+			return err //nolint:wrapcheck
+		}
+
+		return cur.All(ctx, &indexBuilds) //nolint:wrapcheck
+	}, DefaultRetryInterval, DefaultMaxRetries)
 	if err != nil {
-		return nil, errors.Wrap(err, "cursor: all")
+		return nil, errors.Wrap(err, "$currentOp")
 	}
 
 	if len(indexBuilds) == 0 {
@@ -215,25 +257,27 @@ func ListInconsistentIndexes(
 	db string,
 	coll string,
 ) ([]*IndexSpecification, error) {
-	cur, err := m.Database(db).Collection(coll).Aggregate(ctx, mongo.Pipeline{
-		{{"$indexStats", bson.D{}}},
-	})
+	var indexStats []struct {
+		Name string              `bson:"name"`
+		Spec *IndexSpecification `bson:"spec"`
+	}
+
+	err := RunWithRetry(ctx, func(ctx context.Context) error {
+		cur, err := m.Database(db).Collection(coll).Aggregate(ctx, mongo.Pipeline{
+			{{"$indexStats", bson.D{}}},
+		})
+		if err != nil {
+			return err //nolint:wrapcheck
+		}
+
+		return cur.All(ctx, &indexStats) //nolint:wrapcheck
+	}, DefaultRetryInterval, DefaultMaxRetries)
 	if err != nil {
 		if IsIndexNotFound(err) {
 			return nil, nil
 		}
 
 		return nil, errors.Wrap(err, "$indexStats")
-	}
-
-	var indexStats []struct {
-		Name string              `bson:"name"`
-		Spec *IndexSpecification `bson:"spec"`
-	}
-
-	err = cur.All(ctx, &indexStats)
-	if err != nil {
-		return nil, errors.Wrap(err, "cursor: all")
 	}
 
 	if len(indexStats) == 0 {
@@ -310,10 +354,12 @@ func GetCollectionShardingInfo(
 
 	info := &ShardingInfo{}
 
-	err := m.Database("config").
-		Collection("collections").
-		FindOne(ctx, bson.M{"_id": collNS}).
-		Decode(info)
+	err := RunWithRetry(ctx, func(ctx context.Context) error {
+		return m.Database("config").
+			Collection("collections").
+			FindOne(ctx, bson.M{"_id": collNS}).
+			Decode(info) //nolint:wrapcheck
+	}, DefaultRetryInterval, DefaultMaxRetries)
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
 			return nil, ErrNotFound
@@ -328,21 +374,24 @@ func GetCollectionShardingInfo(
 
 	chunksColl := m.Database("config").Collection("chunks")
 
-	cur, err := chunksColl.Find(ctx, bson.M{"ns": collNS})
-	if err != nil {
-		return nil, errors.Wrapf(err, "find chunks for %s", collNS)
-	}
-	defer cur.Close(ctx)
-
-	if err := cur.Err(); err != nil { //nolint:noinlineerr
-		return nil, errors.Wrap(err, "iterate chunks")
-	}
-
 	var chunks []ChunkInfo
 
-	err = cur.All(ctx, &chunks)
+	err = RunWithRetry(ctx, func(ctx context.Context) error {
+		cur, err := chunksColl.Find(ctx, bson.M{"ns": collNS})
+		if err != nil {
+			return err //nolint:wrapcheck
+		}
+		defer cur.Close(ctx)
+
+		cerr := cur.Err()
+		if cerr != nil {
+			return cerr //nolint:wrapcheck
+		}
+
+		return cur.All(ctx, &chunks) //nolint:wrapcheck
+	}, DefaultRetryInterval, DefaultMaxRetries)
 	if err != nil {
-		return nil, errors.Wrap(err, "read chunks")
+		return nil, errors.Wrapf(err, "read chunks for %s", collNS)
 	}
 
 	return info, nil

--- a/mdb/schema.go
+++ b/mdb/schema.go
@@ -69,20 +69,16 @@ func (s *IndexSpecification) IsClustered() bool {
 }
 
 func ListDatabaseNames(ctx context.Context, m *mongo.Client) ([]string, error) {
-	names, err := RunWithRetryVal(ctx, func(ctx context.Context) ([]string, error) {
-		return m.ListDatabaseNames(ctx,
-			bson.D{{"name", bson.D{{"$nin", bson.A{"admin", "config", "local"}}}}}) //nolint:wrapcheck
-	}, DefaultRetryInterval, DefaultMaxRetries)
+	names, err := m.ListDatabaseNames(ctx,
+		bson.D{{"name", bson.D{{"$nin", bson.A{"admin", "config", "local"}}}}})
 
 	return names, err //nolint:wrapcheck
 }
 
 // ListCollectionNames returns a list of non-system collection names in the specified database.
 func ListCollectionNames(ctx context.Context, m *mongo.Client, dbName string) ([]string, error) {
-	names, err := RunWithRetryVal(ctx, func(ctx context.Context) ([]string, error) {
-		return m.Database(dbName).ListCollectionNames(ctx,
-			bson.D{{"name", bson.D{{"$not", bson.D{{"$regex", "^system\\."}}}}}}) //nolint:wrapcheck
-	}, DefaultRetryInterval, DefaultMaxRetries)
+	names, err := m.Database(dbName).ListCollectionNames(ctx,
+		bson.D{{"name", bson.D{{"$not", bson.D{{"$regex", "^system\\."}}}}}})
 
 	return names, err //nolint:wrapcheck
 }
@@ -95,10 +91,8 @@ func ListCollectionSpecs(
 	m *mongo.Client,
 	dbName string,
 ) ([]CollectionSpecification, error) {
-	specs, err := RunWithRetryVal(ctx, func(ctx context.Context) ([]CollectionSpecification, error) {
-		return m.Database(dbName).ListCollectionSpecifications(ctx,
-			bson.D{{"name", bson.D{{"$not", bson.D{{"$regex", "^system\\."}}}}}}) //nolint:wrapcheck
-	}, DefaultRetryInterval, DefaultMaxRetries)
+	specs, err := m.Database(dbName).ListCollectionSpecifications(ctx,
+		bson.D{{"name", bson.D{{"$not", bson.D{{"$regex", "^system\\."}}}}}})
 
 	return specs, err //nolint:wrapcheck
 }
@@ -110,9 +104,7 @@ func GetCollectionSpec(
 	dbName string,
 	collName string,
 ) (*CollectionSpecification, error) {
-	colls, err := RunWithRetryVal(ctx, func(ctx context.Context) ([]CollectionSpecification, error) {
-		return m.Database(dbName).ListCollectionSpecifications(ctx, bson.D{{"name", collName}}) //nolint:wrapcheck
-	}, DefaultRetryInterval, DefaultMaxRetries)
+	colls, err := m.Database(dbName).ListCollectionSpecifications(ctx, bson.D{{"name", collName}})
 	if err != nil {
 		if IsNamespaceNotFound(err) {
 			err = ErrNotFound
@@ -137,9 +129,7 @@ func GetCollectionNameByUUID(
 	dbName string,
 	uuid bson.Binary,
 ) (string, error) {
-	specs, err := RunWithRetryVal(ctx, func(ctx context.Context) ([]CollectionSpecification, error) {
-		return m.Database(dbName).ListCollectionSpecifications(ctx, bson.D{{"info.uuid", uuid}}) //nolint:wrapcheck
-	}, DefaultRetryInterval, DefaultMaxRetries)
+	specs, err := m.Database(dbName).ListCollectionSpecifications(ctx, bson.D{{"info.uuid", uuid}})
 	if err != nil {
 		return "", errors.Wrap(err, "listCollections")
 	}
@@ -160,14 +150,10 @@ func ListIndexes(
 ) ([]*IndexSpecification, error) {
 	var indexes []*IndexSpecification
 
-	err := RunWithRetry(ctx, func(ctx context.Context) error {
-		cur, err := m.Database(db).Collection(coll).Indexes().List(ctx)
-		if err != nil {
-			return err //nolint:wrapcheck
-		}
-
-		return cur.All(ctx, &indexes) //nolint:wrapcheck
-	}, DefaultRetryInterval, DefaultMaxRetries)
+	cur, err := m.Database(db).Collection(coll).Indexes().List(ctx)
+	if err == nil {
+		err = cur.All(ctx, &indexes)
+	}
 	if err != nil {
 		return nil, errors.Wrap(err, "list indexes")
 	}
@@ -189,27 +175,21 @@ func ListInProgressIndexBuilds(
 	}
 
 	indexBuildsStage := currentOpStage
-	err := RunWithRetry(ctx, func(ctx context.Context) error {
-		indexBuildsStage = currentOpStage
-
-		cur, err := m.Database("admin", opts).Aggregate(ctx, mongo.Pipeline{
-			{{currentOpStage, bson.D{{"allUsers", true}}}},
-			{{"$match", bson.D{
-				{"op", "command"},
-				{"command.createIndexes", coll},
-				{"command.$db", db},
-			}}},
-			{{"$unwind", "$command.indexes"}},
-			{{"$replaceRoot", bson.D{{"newRoot", "$command.indexes"}}}},
-			{{"$project", bson.D{{"name", 1}}}},
-		})
-		if err != nil {
-			return err //nolint:wrapcheck
-		}
+	cur, err := m.Database("admin", opts).Aggregate(ctx, mongo.Pipeline{
+		{{currentOpStage, bson.D{{"allUsers", true}}}},
+		{{"$match", bson.D{
+			{"op", "command"},
+			{"command.createIndexes", coll},
+			{"command.$db", db},
+		}}},
+		{{"$unwind", "$command.indexes"}},
+		{{"$replaceRoot", bson.D{{"newRoot", "$command.indexes"}}}},
+		{{"$project", bson.D{{"name", 1}}}},
+	})
+	if err == nil {
 		indexBuildsStage = cursorAllStage
-
-		return cur.All(ctx, &indexBuilds) //nolint:wrapcheck
-	}, DefaultRetryInterval, DefaultMaxRetries)
+		err = cur.All(ctx, &indexBuilds)
+	}
 	if err != nil {
 		return nil, errors.Wrap(err, indexBuildsStage)
 	}
@@ -251,19 +231,13 @@ func ListInconsistentIndexes(
 	}
 
 	indexStatsStage := indexStatsOpenStage
-	err := RunWithRetry(ctx, func(ctx context.Context) error {
-		indexStatsStage = indexStatsOpenStage
-
-		cur, err := m.Database(db).Collection(coll).Aggregate(ctx, mongo.Pipeline{
-			{{indexStatsOpenStage, bson.D{}}},
-		})
-		if err != nil {
-			return err //nolint:wrapcheck
-		}
+	cur, err := m.Database(db).Collection(coll).Aggregate(ctx, mongo.Pipeline{
+		{{indexStatsOpenStage, bson.D{}}},
+	})
+	if err == nil {
 		indexStatsStage = cursorAllStage
-
-		return cur.All(ctx, &indexStats) //nolint:wrapcheck
-	}, DefaultRetryInterval, DefaultMaxRetries)
+		err = cur.All(ctx, &indexStats)
+	}
 	if err != nil {
 		if IsIndexNotFound(err) {
 			return nil, nil
@@ -344,15 +318,11 @@ func GetCollectionShardingInfo(
 ) (*ShardingInfo, error) {
 	collNS := dbName + "." + collName
 
-	info, err := RunWithRetryVal(ctx, func(ctx context.Context) (*ShardingInfo, error) {
-		info := &ShardingInfo{}
-		err := m.Database("config").
-			Collection("collections").
-			FindOne(ctx, bson.M{"_id": collNS}).
-			Decode(info)
-
-		return info, err //nolint:wrapcheck
-	}, DefaultRetryInterval, DefaultMaxRetries)
+	info := &ShardingInfo{}
+	err := m.Database("config").
+		Collection("collections").
+		FindOne(ctx, bson.M{"_id": collNS}).
+		Decode(info)
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
 			return nil, ErrNotFound
@@ -370,25 +340,17 @@ func GetCollectionShardingInfo(
 	var chunks []ChunkInfo
 
 	chunksStage := chunksFindStage
-	err = RunWithRetry(ctx, func(ctx context.Context) error {
-		chunksStage = chunksFindStage
-
-		cur, err := chunksColl.Find(ctx, bson.M{"ns": collNS})
-		if err != nil {
-			return err //nolint:wrapcheck
-		}
+	cur, err := chunksColl.Find(ctx, bson.M{"ns": collNS})
+	if err == nil {
 		defer cur.Close(ctx)
 
 		chunksStage = chunksErrorStage
-		cerr := cur.Err()
-		if cerr != nil {
-			return cerr //nolint:wrapcheck
-		}
-
+		err = cur.Err()
+	}
+	if err == nil {
 		chunksStage = chunksReadStage
-
-		return cur.All(ctx, &chunks) //nolint:wrapcheck
-	}, DefaultRetryInterval, DefaultMaxRetries)
+		err = cur.All(ctx, &chunks)
+	}
 	if err != nil {
 		switch chunksStage {
 		case chunksFindStage:

--- a/mdb/schema.go
+++ b/mdb/schema.go
@@ -69,16 +69,20 @@ func (s *IndexSpecification) IsClustered() bool {
 }
 
 func ListDatabaseNames(ctx context.Context, m *mongo.Client) ([]string, error) {
-	names, err := m.ListDatabaseNames(ctx,
-		bson.D{{"name", bson.D{{"$nin", bson.A{"admin", "config", "local"}}}}})
+	names, err := RunWithRetryVal(ctx, func(ctx context.Context) ([]string, error) {
+		return m.ListDatabaseNames(ctx,
+			bson.D{{"name", bson.D{{"$nin", bson.A{"admin", "config", "local"}}}}}) //nolint:wrapcheck
+	}, DefaultRetryInterval, DefaultMaxRetries)
 
 	return names, err //nolint:wrapcheck
 }
 
 // ListCollectionNames returns a list of non-system collection names in the specified database.
 func ListCollectionNames(ctx context.Context, m *mongo.Client, dbName string) ([]string, error) {
-	names, err := m.Database(dbName).ListCollectionNames(ctx,
-		bson.D{{"name", bson.D{{"$not", bson.D{{"$regex", "^system\\."}}}}}})
+	names, err := RunWithRetryVal(ctx, func(ctx context.Context) ([]string, error) {
+		return m.Database(dbName).ListCollectionNames(ctx,
+			bson.D{{"name", bson.D{{"$not", bson.D{{"$regex", "^system\\."}}}}}}) //nolint:wrapcheck
+	}, DefaultRetryInterval, DefaultMaxRetries)
 
 	return names, err //nolint:wrapcheck
 }
@@ -91,8 +95,10 @@ func ListCollectionSpecs(
 	m *mongo.Client,
 	dbName string,
 ) ([]CollectionSpecification, error) {
-	specs, err := m.Database(dbName).ListCollectionSpecifications(ctx,
-		bson.D{{"name", bson.D{{"$not", bson.D{{"$regex", "^system\\."}}}}}})
+	specs, err := RunWithRetryVal(ctx, func(ctx context.Context) ([]CollectionSpecification, error) {
+		return m.Database(dbName).ListCollectionSpecifications(ctx,
+			bson.D{{"name", bson.D{{"$not", bson.D{{"$regex", "^system\\."}}}}}}) //nolint:wrapcheck
+	}, DefaultRetryInterval, DefaultMaxRetries)
 
 	return specs, err //nolint:wrapcheck
 }
@@ -104,7 +110,9 @@ func GetCollectionSpec(
 	dbName string,
 	collName string,
 ) (*CollectionSpecification, error) {
-	colls, err := m.Database(dbName).ListCollectionSpecifications(ctx, bson.D{{"name", collName}})
+	colls, err := RunWithRetryVal(ctx, func(ctx context.Context) ([]CollectionSpecification, error) {
+		return m.Database(dbName).ListCollectionSpecifications(ctx, bson.D{{"name", collName}}) //nolint:wrapcheck
+	}, DefaultRetryInterval, DefaultMaxRetries)
 	if err != nil {
 		if IsNamespaceNotFound(err) {
 			err = ErrNotFound
@@ -129,7 +137,9 @@ func GetCollectionNameByUUID(
 	dbName string,
 	uuid bson.Binary,
 ) (string, error) {
-	specs, err := m.Database(dbName).ListCollectionSpecifications(ctx, bson.D{{"info.uuid", uuid}})
+	specs, err := RunWithRetryVal(ctx, func(ctx context.Context) ([]CollectionSpecification, error) {
+		return m.Database(dbName).ListCollectionSpecifications(ctx, bson.D{{"info.uuid", uuid}}) //nolint:wrapcheck
+	}, DefaultRetryInterval, DefaultMaxRetries)
 	if err != nil {
 		return "", errors.Wrap(err, "listCollections")
 	}
@@ -150,10 +160,14 @@ func ListIndexes(
 ) ([]*IndexSpecification, error) {
 	var indexes []*IndexSpecification
 
-	cur, err := m.Database(db).Collection(coll).Indexes().List(ctx)
-	if err == nil {
-		err = cur.All(ctx, &indexes)
-	}
+	err := RunWithRetry(ctx, func(ctx context.Context) error {
+		cur, err := m.Database(db).Collection(coll).Indexes().List(ctx)
+		if err != nil {
+			return err //nolint:wrapcheck
+		}
+
+		return cur.All(ctx, &indexes) //nolint:wrapcheck
+	}, DefaultRetryInterval, DefaultMaxRetries)
 	if err != nil {
 		return nil, errors.Wrap(err, "list indexes")
 	}
@@ -175,21 +189,27 @@ func ListInProgressIndexBuilds(
 	}
 
 	indexBuildsStage := currentOpStage
-	cur, err := m.Database("admin", opts).Aggregate(ctx, mongo.Pipeline{
-		{{currentOpStage, bson.D{{"allUsers", true}}}},
-		{{"$match", bson.D{
-			{"op", "command"},
-			{"command.createIndexes", coll},
-			{"command.$db", db},
-		}}},
-		{{"$unwind", "$command.indexes"}},
-		{{"$replaceRoot", bson.D{{"newRoot", "$command.indexes"}}}},
-		{{"$project", bson.D{{"name", 1}}}},
-	})
-	if err == nil {
+	err := RunWithRetry(ctx, func(ctx context.Context) error {
+		indexBuildsStage = currentOpStage
+
+		cur, err := m.Database("admin", opts).Aggregate(ctx, mongo.Pipeline{
+			{{currentOpStage, bson.D{{"allUsers", true}}}},
+			{{"$match", bson.D{
+				{"op", "command"},
+				{"command.createIndexes", coll},
+				{"command.$db", db},
+			}}},
+			{{"$unwind", "$command.indexes"}},
+			{{"$replaceRoot", bson.D{{"newRoot", "$command.indexes"}}}},
+			{{"$project", bson.D{{"name", 1}}}},
+		})
+		if err != nil {
+			return err //nolint:wrapcheck
+		}
 		indexBuildsStage = cursorAllStage
-		err = cur.All(ctx, &indexBuilds)
-	}
+
+		return cur.All(ctx, &indexBuilds) //nolint:wrapcheck
+	}, DefaultRetryInterval, DefaultMaxRetries)
 	if err != nil {
 		return nil, errors.Wrap(err, indexBuildsStage)
 	}
@@ -231,13 +251,19 @@ func ListInconsistentIndexes(
 	}
 
 	indexStatsStage := indexStatsOpenStage
-	cur, err := m.Database(db).Collection(coll).Aggregate(ctx, mongo.Pipeline{
-		{{indexStatsOpenStage, bson.D{}}},
-	})
-	if err == nil {
+	err := RunWithRetry(ctx, func(ctx context.Context) error {
+		indexStatsStage = indexStatsOpenStage
+
+		cur, err := m.Database(db).Collection(coll).Aggregate(ctx, mongo.Pipeline{
+			{{indexStatsOpenStage, bson.D{}}},
+		})
+		if err != nil {
+			return err //nolint:wrapcheck
+		}
 		indexStatsStage = cursorAllStage
-		err = cur.All(ctx, &indexStats)
-	}
+
+		return cur.All(ctx, &indexStats) //nolint:wrapcheck
+	}, DefaultRetryInterval, DefaultMaxRetries)
 	if err != nil {
 		if IsIndexNotFound(err) {
 			return nil, nil
@@ -318,11 +344,15 @@ func GetCollectionShardingInfo(
 ) (*ShardingInfo, error) {
 	collNS := dbName + "." + collName
 
-	info := &ShardingInfo{}
-	err := m.Database("config").
-		Collection("collections").
-		FindOne(ctx, bson.M{"_id": collNS}).
-		Decode(info)
+	info, err := RunWithRetryVal(ctx, func(ctx context.Context) (*ShardingInfo, error) {
+		info := &ShardingInfo{}
+		err := m.Database("config").
+			Collection("collections").
+			FindOne(ctx, bson.M{"_id": collNS}).
+			Decode(info)
+
+		return info, err //nolint:wrapcheck
+	}, DefaultRetryInterval, DefaultMaxRetries)
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
 			return nil, ErrNotFound
@@ -340,17 +370,25 @@ func GetCollectionShardingInfo(
 	var chunks []ChunkInfo
 
 	chunksStage := chunksFindStage
-	cur, err := chunksColl.Find(ctx, bson.M{"ns": collNS})
-	if err == nil {
+	err = RunWithRetry(ctx, func(ctx context.Context) error {
+		chunksStage = chunksFindStage
+
+		cur, err := chunksColl.Find(ctx, bson.M{"ns": collNS})
+		if err != nil {
+			return err //nolint:wrapcheck
+		}
 		defer cur.Close(ctx)
 
 		chunksStage = chunksErrorStage
-		err = cur.Err()
-	}
-	if err == nil {
+		cerr := cur.Err()
+		if cerr != nil {
+			return cerr //nolint:wrapcheck
+		}
+
 		chunksStage = chunksReadStage
-		err = cur.All(ctx, &chunks)
-	}
+
+		return cur.All(ctx, &chunks) //nolint:wrapcheck
+	}, DefaultRetryInterval, DefaultMaxRetries)
 	if err != nil {
 		switch chunksStage {
 		case chunksFindStage:

--- a/mdb/schema.go
+++ b/mdb/schema.go
@@ -22,6 +22,15 @@ const (
 	TypeView       = "view"
 )
 
+const (
+	currentOpStage      = "$currentOp"
+	indexStatsOpenStage = "$indexStats"
+	cursorAllStage      = "cursor: all"
+	chunksFindStage     = "find"
+	chunksReadStage     = "read"
+	chunksErrorStage    = "iterate"
+)
+
 // IndexSpecification contains all index options.
 //
 // NOTE: [mongo.IndexView.CreateMany] and [mongo.IndexView.CreateOne] use [mongo.IndexModel]
@@ -60,14 +69,9 @@ func (s *IndexSpecification) IsClustered() bool {
 }
 
 func ListDatabaseNames(ctx context.Context, m *mongo.Client) ([]string, error) {
-	var names []string
-
-	err := RunWithRetry(ctx, func(ctx context.Context) error {
-		var inner error
-		names, inner = m.ListDatabaseNames(ctx,
-			bson.D{{"name", bson.D{{"$nin", bson.A{"admin", "config", "local"}}}}})
-
-		return inner //nolint:wrapcheck
+	names, err := RunWithRetryVal(ctx, func(ctx context.Context) ([]string, error) {
+		return m.ListDatabaseNames(ctx,
+			bson.D{{"name", bson.D{{"$nin", bson.A{"admin", "config", "local"}}}}}) //nolint:wrapcheck
 	}, DefaultRetryInterval, DefaultMaxRetries)
 
 	return names, err //nolint:wrapcheck
@@ -75,14 +79,9 @@ func ListDatabaseNames(ctx context.Context, m *mongo.Client) ([]string, error) {
 
 // ListCollectionNames returns a list of non-system collection names in the specified database.
 func ListCollectionNames(ctx context.Context, m *mongo.Client, dbName string) ([]string, error) {
-	var names []string
-
-	err := RunWithRetry(ctx, func(ctx context.Context) error {
-		var inner error
-		names, inner = m.Database(dbName).ListCollectionNames(ctx,
-			bson.D{{"name", bson.D{{"$not", bson.D{{"$regex", "^system\\."}}}}}})
-
-		return inner //nolint:wrapcheck
+	names, err := RunWithRetryVal(ctx, func(ctx context.Context) ([]string, error) {
+		return m.Database(dbName).ListCollectionNames(ctx,
+			bson.D{{"name", bson.D{{"$not", bson.D{{"$regex", "^system\\."}}}}}}) //nolint:wrapcheck
 	}, DefaultRetryInterval, DefaultMaxRetries)
 
 	return names, err //nolint:wrapcheck
@@ -96,14 +95,9 @@ func ListCollectionSpecs(
 	m *mongo.Client,
 	dbName string,
 ) ([]CollectionSpecification, error) {
-	var specs []CollectionSpecification
-
-	err := RunWithRetry(ctx, func(ctx context.Context) error {
-		var inner error
-		specs, inner = m.Database(dbName).ListCollectionSpecifications(ctx,
-			bson.D{{"name", bson.D{{"$not", bson.D{{"$regex", "^system\\."}}}}}})
-
-		return inner //nolint:wrapcheck
+	specs, err := RunWithRetryVal(ctx, func(ctx context.Context) ([]CollectionSpecification, error) {
+		return m.Database(dbName).ListCollectionSpecifications(ctx,
+			bson.D{{"name", bson.D{{"$not", bson.D{{"$regex", "^system\\."}}}}}}) //nolint:wrapcheck
 	}, DefaultRetryInterval, DefaultMaxRetries)
 
 	return specs, err //nolint:wrapcheck
@@ -116,13 +110,8 @@ func GetCollectionSpec(
 	dbName string,
 	collName string,
 ) (*CollectionSpecification, error) {
-	var colls []CollectionSpecification
-
-	err := RunWithRetry(ctx, func(ctx context.Context) error {
-		var inner error
-		colls, inner = m.Database(dbName).ListCollectionSpecifications(ctx, bson.D{{"name", collName}})
-
-		return inner //nolint:wrapcheck
+	colls, err := RunWithRetryVal(ctx, func(ctx context.Context) ([]CollectionSpecification, error) {
+		return m.Database(dbName).ListCollectionSpecifications(ctx, bson.D{{"name", collName}}) //nolint:wrapcheck
 	}, DefaultRetryInterval, DefaultMaxRetries)
 	if err != nil {
 		if IsNamespaceNotFound(err) {
@@ -148,13 +137,8 @@ func GetCollectionNameByUUID(
 	dbName string,
 	uuid bson.Binary,
 ) (string, error) {
-	var specs []CollectionSpecification
-
-	err := RunWithRetry(ctx, func(ctx context.Context) error {
-		var inner error
-		specs, inner = m.Database(dbName).ListCollectionSpecifications(ctx, bson.D{{"info.uuid", uuid}})
-
-		return inner //nolint:wrapcheck
+	specs, err := RunWithRetryVal(ctx, func(ctx context.Context) ([]CollectionSpecification, error) {
+		return m.Database(dbName).ListCollectionSpecifications(ctx, bson.D{{"info.uuid", uuid}}) //nolint:wrapcheck
 	}, DefaultRetryInterval, DefaultMaxRetries)
 	if err != nil {
 		return "", errors.Wrap(err, "listCollections")
@@ -204,9 +188,12 @@ func ListInProgressIndexBuilds(
 		Name string `bson:"name"`
 	}
 
+	indexBuildsStage := currentOpStage
 	err := RunWithRetry(ctx, func(ctx context.Context) error {
+		indexBuildsStage = currentOpStage
+
 		cur, err := m.Database("admin", opts).Aggregate(ctx, mongo.Pipeline{
-			{{"$currentOp", bson.D{{"allUsers", true}}}},
+			{{currentOpStage, bson.D{{"allUsers", true}}}},
 			{{"$match", bson.D{
 				{"op", "command"},
 				{"command.createIndexes", coll},
@@ -219,11 +206,12 @@ func ListInProgressIndexBuilds(
 		if err != nil {
 			return err //nolint:wrapcheck
 		}
+		indexBuildsStage = cursorAllStage
 
 		return cur.All(ctx, &indexBuilds) //nolint:wrapcheck
 	}, DefaultRetryInterval, DefaultMaxRetries)
 	if err != nil {
-		return nil, errors.Wrap(err, "$currentOp")
+		return nil, errors.Wrap(err, indexBuildsStage)
 	}
 
 	if len(indexBuilds) == 0 {
@@ -262,13 +250,17 @@ func ListInconsistentIndexes(
 		Spec *IndexSpecification `bson:"spec"`
 	}
 
+	indexStatsStage := indexStatsOpenStage
 	err := RunWithRetry(ctx, func(ctx context.Context) error {
+		indexStatsStage = indexStatsOpenStage
+
 		cur, err := m.Database(db).Collection(coll).Aggregate(ctx, mongo.Pipeline{
-			{{"$indexStats", bson.D{}}},
+			{{indexStatsOpenStage, bson.D{}}},
 		})
 		if err != nil {
 			return err //nolint:wrapcheck
 		}
+		indexStatsStage = cursorAllStage
 
 		return cur.All(ctx, &indexStats) //nolint:wrapcheck
 	}, DefaultRetryInterval, DefaultMaxRetries)
@@ -277,7 +269,7 @@ func ListInconsistentIndexes(
 			return nil, nil
 		}
 
-		return nil, errors.Wrap(err, "$indexStats")
+		return nil, errors.Wrap(err, indexStatsStage)
 	}
 
 	if len(indexStats) == 0 {
@@ -352,13 +344,14 @@ func GetCollectionShardingInfo(
 ) (*ShardingInfo, error) {
 	collNS := dbName + "." + collName
 
-	info := &ShardingInfo{}
-
-	err := RunWithRetry(ctx, func(ctx context.Context) error {
-		return m.Database("config").
+	info, err := RunWithRetryVal(ctx, func(ctx context.Context) (*ShardingInfo, error) {
+		info := &ShardingInfo{}
+		err := m.Database("config").
 			Collection("collections").
 			FindOne(ctx, bson.M{"_id": collNS}).
-			Decode(info) //nolint:wrapcheck
+			Decode(info)
+
+		return info, err //nolint:wrapcheck
 	}, DefaultRetryInterval, DefaultMaxRetries)
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
@@ -376,22 +369,35 @@ func GetCollectionShardingInfo(
 
 	var chunks []ChunkInfo
 
+	chunksStage := chunksFindStage
 	err = RunWithRetry(ctx, func(ctx context.Context) error {
+		chunksStage = chunksFindStage
+
 		cur, err := chunksColl.Find(ctx, bson.M{"ns": collNS})
 		if err != nil {
 			return err //nolint:wrapcheck
 		}
 		defer cur.Close(ctx)
 
+		chunksStage = chunksErrorStage
 		cerr := cur.Err()
 		if cerr != nil {
 			return cerr //nolint:wrapcheck
 		}
 
+		chunksStage = chunksReadStage
+
 		return cur.All(ctx, &chunks) //nolint:wrapcheck
 	}, DefaultRetryInterval, DefaultMaxRetries)
 	if err != nil {
-		return nil, errors.Wrapf(err, "read chunks for %s", collNS)
+		switch chunksStage {
+		case chunksFindStage:
+			return nil, errors.Wrapf(err, "find chunks for %s", collNS)
+		case chunksErrorStage:
+			return nil, errors.Wrap(err, "iterate chunks")
+		default:
+			return nil, errors.Wrap(err, "read chunks")
+		}
 	}
 
 	return info, nil

--- a/mdb/topo.go
+++ b/mdb/topo.go
@@ -198,9 +198,11 @@ func collStatsFromStorageStats(ctx context.Context, m *mongo.Client, db, coll st
 		}}},
 	}
 
-	stats := &CollStats{}
+	var stats *CollStats
 
 	err := RunWithRetry(ctx, func(ctx context.Context) error {
+		stats = &CollStats{}
+
 		cur, err := m.Database(db).Collection(coll).Aggregate(ctx, p)
 		if err != nil {
 			return err //nolint:wrapcheck
@@ -256,10 +258,11 @@ func collStatsFromDocsAggregation(ctx context.Context, m *mongo.Client, db, coll
 		}}},
 	}
 
-	stats := &CollStats{}
+	var stats *CollStats
 	empty := false
 
 	err := RunWithRetry(ctx, func(ctx context.Context) error {
+		stats = &CollStats{}
 		empty = false
 
 		cur, err := m.Database(db).Collection(coll).Aggregate(ctx, p)

--- a/mdb/topo.go
+++ b/mdb/topo.go
@@ -207,7 +207,7 @@ func collStatsFromStorageStats(ctx context.Context, m *mongo.Client, db, coll st
 
 	stats := &CollStats{}
 
-	err := RunWithRetry(ctx, func(ctx context.Context) error {
+	err := func() error {
 		cur, err := m.Database(db).Collection(coll).Aggregate(ctx, p)
 		if err != nil {
 			return err //nolint:wrapcheck
@@ -231,7 +231,7 @@ func collStatsFromStorageStats(ctx context.Context, m *mongo.Client, db, coll st
 		}
 
 		return cur.Decode(stats) //nolint:wrapcheck
-	}, DefaultRetryInterval, DefaultMaxRetries)
+	}()
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return nil, ErrNotFound
@@ -266,9 +266,7 @@ func collStatsFromDocsAggregation(ctx context.Context, m *mongo.Client, db, coll
 	stats := &CollStats{}
 	empty := false
 
-	err := RunWithRetry(ctx, func(ctx context.Context) error {
-		empty = false
-
+	err := func() error {
 		cur, err := m.Database(db).Collection(coll).Aggregate(ctx, p)
 		if err != nil {
 			return err //nolint:wrapcheck
@@ -294,7 +292,7 @@ func collStatsFromDocsAggregation(ctx context.Context, m *mongo.Client, db, coll
 		}
 
 		return cur.Decode(stats) //nolint:wrapcheck
-	}, DefaultRetryInterval, DefaultMaxRetries)
+	}()
 	if err != nil {
 		if IsNamespaceNotFound(err) {
 			err = ErrNotFound

--- a/mdb/topo.go
+++ b/mdb/topo.go
@@ -18,7 +18,17 @@ var errMissingClusterTime = errors.New("missig clusterTime")
 
 // ClusterTime retrieves the cluster time from the MongoDB client.
 func ClusterTime(ctx context.Context, m *mongo.Client) (bson.Timestamp, error) {
-	raw, err := m.Database("admin").RunCommand(ctx, bson.D{{"ping", 1}}).Raw()
+	var raw bson.Raw
+
+	// RunWithRetry caps PCSM retries at DefaultMaxRetries; the mongo-go-driver also
+	// applies its own adaptive retries (default 2) per operation, so worst-case wire
+	// attempts compound multiplicatively rather than being a flat sum.
+	err := RunWithRetry(ctx, func(ctx context.Context) error {
+		var inner error
+		raw, inner = m.Database("admin").RunCommand(ctx, bson.D{{"ping", 1}}).Raw()
+
+		return inner //nolint:wrapcheck
+	}, DefaultRetryInterval, DefaultMaxRetries)
 	if err != nil {
 		return bson.Timestamp{}, err //nolint:wrapcheck
 	}
@@ -33,10 +43,17 @@ func ClusterTime(ctx context.Context, m *mongo.Client) (bson.Timestamp, error) {
 
 // AdvanceClusterTime advances the cluster time of a MongoDB deployment by appending an oplog note.
 func AdvanceClusterTime(ctx context.Context, m *mongo.Client) (bson.Timestamp, error) {
-	raw, err := m.Database("admin").RunCommand(ctx, bson.D{
-		{"appendOplogNote", 1},
-		{"data", bson.D{{"msg", "pcsm:tick"}}},
-	}).Raw()
+	var raw bson.Raw
+
+	err := RunWithRetry(ctx, func(ctx context.Context) error {
+		var inner error
+		raw, inner = m.Database("admin").RunCommand(ctx, bson.D{
+			{"appendOplogNote", 1},
+			{"data", bson.D{{"msg", "pcsm:tick"}}},
+		}).Raw()
+
+		return inner //nolint:wrapcheck
+	}, DefaultRetryInterval, DefaultMaxRetries)
 	if err != nil {
 		return bson.Timestamp{}, err //nolint:wrapcheck
 	}
@@ -138,7 +155,9 @@ type CollStats struct {
 func SayHello(ctx context.Context, m *mongo.Client) (*Hello, error) {
 	var result *Hello
 
-	err := m.Database("admin").RunCommand(ctx, bson.D{{"hello", 1}}).Decode(&result)
+	err := RunWithRetry(ctx, func(ctx context.Context) error {
+		return m.Database("admin").RunCommand(ctx, bson.D{{"hello", 1}}).Decode(&result) //nolint:wrapcheck
+	}, DefaultRetryInterval, DefaultMaxRetries)
 
 	return result, err //nolint:wrapcheck
 }
@@ -147,7 +166,9 @@ func SayHello(ctx context.Context, m *mongo.Client) (*Hello, error) {
 func GetDBStats(ctx context.Context, m *mongo.Client, dbName string) (*DBStats, error) {
 	var result *DBStats
 
-	err := m.Database(dbName).RunCommand(ctx, bson.D{{"dbStats", 1}}).Decode(&result)
+	err := RunWithRetry(ctx, func(ctx context.Context) error {
+		return m.Database(dbName).RunCommand(ctx, bson.D{{"dbStats", 1}}).Decode(&result) //nolint:wrapcheck
+	}, DefaultRetryInterval, DefaultMaxRetries)
 
 	return result, err //nolint:wrapcheck
 }
@@ -188,37 +209,43 @@ func collStatsFromStorageStats(ctx context.Context, m *mongo.Client, db, coll st
 		}}},
 	}
 
-	cur, err := m.Database(db).Collection(coll).Aggregate(ctx, p)
-	if err != nil {
-		if IsNamespaceNotFound(err) {
-			err = ErrNotFound
-		}
-
-		return nil, errors.Wrap(err, "$collStats")
-	}
-
-	defer func() {
-		//nolint:contextcheck // fresh context for cleanup
-		err := util.CtxWithTimeout(context.Background(), config.CloseCursorTimeout, cur.Close)
-		if err != nil {
-			log.Ctx(ctx).Errorf(err, "$collStas: %s: close cursor", db)
-		}
-	}()
-
 	stats := &CollStats{}
 
-	if !cur.Next(ctx) {
-		err = cur.Err()
-		if err == nil {
+	err := RunWithRetry(ctx, func(ctx context.Context) error {
+		cur, err := m.Database(db).Collection(coll).Aggregate(ctx, p)
+		if err != nil {
+			return err //nolint:wrapcheck
+		}
+
+		defer func() {
+			//nolint:contextcheck // fresh context for cleanup
+			cerr := util.CtxWithTimeout(context.Background(), config.CloseCursorTimeout, cur.Close)
+			if cerr != nil {
+				log.Ctx(ctx).Errorf(cerr, "$collStas: %s: close cursor", db)
+			}
+		}()
+
+		if !cur.Next(ctx) {
+			cerr := cur.Err()
+			if cerr != nil {
+				return cerr //nolint:wrapcheck
+			}
+
+			return ErrNotFound
+		}
+
+		return cur.Decode(stats) //nolint:wrapcheck
+	}, DefaultRetryInterval, DefaultMaxRetries)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
 			return nil, ErrNotFound
 		}
 
-		return nil, errors.Wrap(err, "$collStas: cursor")
-	}
+		if IsNamespaceNotFound(err) {
+			return nil, errors.Wrap(ErrNotFound, "$collStats")
+		}
 
-	err = cur.Decode(stats)
-	if err != nil {
-		return nil, errors.Wrap(err, "decode")
+		return nil, errors.Wrap(err, "$collStats")
 	}
 
 	return stats, nil
@@ -240,7 +267,38 @@ func collStatsFromDocsAggregation(ctx context.Context, m *mongo.Client, db, coll
 		}}},
 	}
 
-	cur, err := m.Database(db).Collection(coll).Aggregate(ctx, p)
+	stats := &CollStats{}
+	empty := false
+
+	err := RunWithRetry(ctx, func(ctx context.Context) error {
+		empty = false
+
+		cur, err := m.Database(db).Collection(coll).Aggregate(ctx, p)
+		if err != nil {
+			return err //nolint:wrapcheck
+		}
+
+		defer func() {
+			//nolint:contextcheck // fresh context for cleanup
+			cerr := util.CtxWithTimeout(context.Background(), config.CloseCursorTimeout, cur.Close)
+			if cerr != nil {
+				log.Ctx(ctx).Errorf(cerr, "aggregate coll stats: %s: close cursor", db)
+			}
+		}()
+
+		if !cur.Next(ctx) {
+			cerr := cur.Err()
+			if cerr != nil {
+				return cerr //nolint:wrapcheck
+			}
+
+			empty = true
+
+			return nil
+		}
+
+		return cur.Decode(stats) //nolint:wrapcheck
+	}, DefaultRetryInterval, DefaultMaxRetries)
 	if err != nil {
 		if IsNamespaceNotFound(err) {
 			err = ErrNotFound
@@ -249,28 +307,8 @@ func collStatsFromDocsAggregation(ctx context.Context, m *mongo.Client, db, coll
 		return nil, errors.Wrap(err, "aggregate coll stats")
 	}
 
-	defer func() {
-		//nolint:contextcheck // fresh context for cleanup
-		err := util.CtxWithTimeout(context.Background(), config.CloseCursorTimeout, cur.Close)
-		if err != nil {
-			log.Ctx(ctx).Errorf(err, "aggregate coll stats: %s: close cursor", db)
-		}
-	}()
-
-	stats := &CollStats{}
-
-	if !cur.Next(ctx) {
-		err = cur.Err()
-		if err == nil {
-			return &CollStats{Count: 0, Size: 0, AvgObjSize: 0}, nil
-		}
-
-		return nil, errors.Wrap(err, "cursor")
-	}
-
-	err = cur.Decode(stats)
-	if err != nil {
-		return nil, errors.Wrap(err, "decode")
+	if empty {
+		return &CollStats{Count: 0, Size: 0, AvgObjSize: 0}, nil
 	}
 
 	return stats, nil

--- a/mdb/topo.go
+++ b/mdb/topo.go
@@ -18,16 +18,11 @@ var errMissingClusterTime = errors.New("missig clusterTime")
 
 // ClusterTime retrieves the cluster time from the MongoDB client.
 func ClusterTime(ctx context.Context, m *mongo.Client) (bson.Timestamp, error) {
-	var raw bson.Raw
-
 	// RunWithRetry caps PCSM retries at DefaultMaxRetries; the mongo-go-driver also
 	// applies its own adaptive retries (default 2) per operation, so worst-case wire
 	// attempts compound multiplicatively rather than being a flat sum.
-	err := RunWithRetry(ctx, func(ctx context.Context) error {
-		var inner error
-		raw, inner = m.Database("admin").RunCommand(ctx, bson.D{{"ping", 1}}).Raw()
-
-		return inner //nolint:wrapcheck
+	raw, err := RunWithRetryVal(ctx, func(ctx context.Context) (bson.Raw, error) {
+		return m.Database("admin").RunCommand(ctx, bson.D{{"ping", 1}}).Raw() //nolint:wrapcheck
 	}, DefaultRetryInterval, DefaultMaxRetries)
 	if err != nil {
 		return bson.Timestamp{}, err //nolint:wrapcheck
@@ -43,16 +38,11 @@ func ClusterTime(ctx context.Context, m *mongo.Client) (bson.Timestamp, error) {
 
 // AdvanceClusterTime advances the cluster time of a MongoDB deployment by appending an oplog note.
 func AdvanceClusterTime(ctx context.Context, m *mongo.Client) (bson.Timestamp, error) {
-	var raw bson.Raw
-
-	err := RunWithRetry(ctx, func(ctx context.Context) error {
-		var inner error
-		raw, inner = m.Database("admin").RunCommand(ctx, bson.D{
+	raw, err := RunWithRetryVal(ctx, func(ctx context.Context) (bson.Raw, error) {
+		return m.Database("admin").RunCommand(ctx, bson.D{
 			{"appendOplogNote", 1},
 			{"data", bson.D{{"msg", "pcsm:tick"}}},
-		}).Raw()
-
-		return inner //nolint:wrapcheck
+		}).Raw() //nolint:wrapcheck
 	}, DefaultRetryInterval, DefaultMaxRetries)
 	if err != nil {
 		return bson.Timestamp{}, err //nolint:wrapcheck
@@ -153,24 +143,30 @@ type CollStats struct {
 
 // SayHello runs the db.hello() command and returns the [Hello].
 func SayHello(ctx context.Context, m *mongo.Client) (*Hello, error) {
-	var result *Hello
+	return RunWithRetryVal(ctx, func(ctx context.Context) (*Hello, error) {
+		result := &Hello{}
 
-	err := RunWithRetry(ctx, func(ctx context.Context) error {
-		return m.Database("admin").RunCommand(ctx, bson.D{{"hello", 1}}).Decode(&result) //nolint:wrapcheck
+		err := m.Database("admin").RunCommand(ctx, bson.D{{"hello", 1}}).Decode(result)
+		if err != nil {
+			return nil, err //nolint:wrapcheck
+		}
+
+		return result, nil
 	}, DefaultRetryInterval, DefaultMaxRetries)
-
-	return result, err //nolint:wrapcheck
 }
 
 // GetDBStats runs the dbStats command.
 func GetDBStats(ctx context.Context, m *mongo.Client, dbName string) (*DBStats, error) {
-	var result *DBStats
+	return RunWithRetryVal(ctx, func(ctx context.Context) (*DBStats, error) {
+		result := &DBStats{}
 
-	err := RunWithRetry(ctx, func(ctx context.Context) error {
-		return m.Database(dbName).RunCommand(ctx, bson.D{{"dbStats", 1}}).Decode(&result) //nolint:wrapcheck
+		err := m.Database(dbName).RunCommand(ctx, bson.D{{"dbStats", 1}}).Decode(result)
+		if err != nil {
+			return nil, err //nolint:wrapcheck
+		}
+
+		return result, nil
 	}, DefaultRetryInterval, DefaultMaxRetries)
-
-	return result, err //nolint:wrapcheck
 }
 
 // GetCollStats retrieves statistics for a specific collection.

--- a/mdb/topo.go
+++ b/mdb/topo.go
@@ -18,12 +18,7 @@ var errMissingClusterTime = errors.New("missig clusterTime")
 
 // ClusterTime retrieves the cluster time from the MongoDB client.
 func ClusterTime(ctx context.Context, m *mongo.Client) (bson.Timestamp, error) {
-	// RunWithRetry caps PCSM retries at DefaultMaxRetries; the mongo-go-driver also
-	// applies its own adaptive retries (default 2) per operation, so worst-case wire
-	// attempts compound multiplicatively rather than being a flat sum.
-	raw, err := RunWithRetryVal(ctx, func(ctx context.Context) (bson.Raw, error) {
-		return m.Database("admin").RunCommand(ctx, bson.D{{"ping", 1}}).Raw() //nolint:wrapcheck
-	}, DefaultRetryInterval, DefaultMaxRetries)
+	raw, err := m.Database("admin").RunCommand(ctx, bson.D{{"ping", 1}}).Raw() //nolint:wrapcheck
 	if err != nil {
 		return bson.Timestamp{}, err //nolint:wrapcheck
 	}
@@ -38,12 +33,10 @@ func ClusterTime(ctx context.Context, m *mongo.Client) (bson.Timestamp, error) {
 
 // AdvanceClusterTime advances the cluster time of a MongoDB deployment by appending an oplog note.
 func AdvanceClusterTime(ctx context.Context, m *mongo.Client) (bson.Timestamp, error) {
-	raw, err := RunWithRetryVal(ctx, func(ctx context.Context) (bson.Raw, error) {
-		return m.Database("admin").RunCommand(ctx, bson.D{
-			{"appendOplogNote", 1},
-			{"data", bson.D{{"msg", "pcsm:tick"}}},
-		}).Raw() //nolint:wrapcheck
-	}, DefaultRetryInterval, DefaultMaxRetries)
+	raw, err := m.Database("admin").RunCommand(ctx, bson.D{
+		{"appendOplogNote", 1},
+		{"data", bson.D{{"msg", "pcsm:tick"}}},
+	}).Raw() //nolint:wrapcheck
 	if err != nil {
 		return bson.Timestamp{}, err //nolint:wrapcheck
 	}

--- a/mdb/topo.go
+++ b/mdb/topo.go
@@ -207,7 +207,7 @@ func collStatsFromStorageStats(ctx context.Context, m *mongo.Client, db, coll st
 
 	stats := &CollStats{}
 
-	err := func() error {
+	err := RunWithRetry(ctx, func(ctx context.Context) error {
 		cur, err := m.Database(db).Collection(coll).Aggregate(ctx, p)
 		if err != nil {
 			return err //nolint:wrapcheck
@@ -231,7 +231,7 @@ func collStatsFromStorageStats(ctx context.Context, m *mongo.Client, db, coll st
 		}
 
 		return cur.Decode(stats) //nolint:wrapcheck
-	}()
+	}, DefaultRetryInterval, DefaultMaxRetries)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return nil, ErrNotFound
@@ -266,7 +266,9 @@ func collStatsFromDocsAggregation(ctx context.Context, m *mongo.Client, db, coll
 	stats := &CollStats{}
 	empty := false
 
-	err := func() error {
+	err := RunWithRetry(ctx, func(ctx context.Context) error {
+		empty = false
+
 		cur, err := m.Database(db).Collection(coll).Aggregate(ctx, p)
 		if err != nil {
 			return err //nolint:wrapcheck
@@ -292,7 +294,7 @@ func collStatsFromDocsAggregation(ctx context.Context, m *mongo.Client, db, coll
 		}
 
 		return cur.Decode(stats) //nolint:wrapcheck
-	}()
+	}, DefaultRetryInterval, DefaultMaxRetries)
 	if err != nil {
 		if IsNamespaceNotFound(err) {
 			err = ErrNotFound

--- a/mdb/version.go
+++ b/mdb/version.go
@@ -52,13 +52,8 @@ func (v ServerVersion) FullString() string {
 }
 
 func Version(ctx context.Context, m *mongo.Client) (ServerVersion, error) {
-	var raw bson.Raw
-
-	err := RunWithRetry(ctx, func(ctx context.Context) error {
-		var inner error
-		raw, inner = m.Database("admin").RunCommand(ctx, bson.D{{"buildInfo", 1}}).Raw()
-
-		return inner //nolint:wrapcheck
+	raw, err := RunWithRetryVal(ctx, func(ctx context.Context) (bson.Raw, error) {
+		return m.Database("admin").RunCommand(ctx, bson.D{{"buildInfo", 1}}).Raw() //nolint:wrapcheck
 	}, DefaultRetryInterval, DefaultMaxRetries)
 	if err != nil {
 		return ServerVersion{}, errors.Wrap(err, "$buildInfo")

--- a/mdb/version.go
+++ b/mdb/version.go
@@ -52,7 +52,14 @@ func (v ServerVersion) FullString() string {
 }
 
 func Version(ctx context.Context, m *mongo.Client) (ServerVersion, error) {
-	raw, err := m.Database("admin").RunCommand(ctx, bson.D{{"buildInfo", 1}}).Raw()
+	var raw bson.Raw
+
+	err := RunWithRetry(ctx, func(ctx context.Context) error {
+		var inner error
+		raw, inner = m.Database("admin").RunCommand(ctx, bson.D{{"buildInfo", 1}}).Raw()
+
+		return inner //nolint:wrapcheck
+	}, DefaultRetryInterval, DefaultMaxRetries)
 	if err != nil {
 		return ServerVersion{}, errors.Wrap(err, "$buildInfo")
 	}

--- a/pcsm/clone/copy.go
+++ b/pcsm/clone/copy.go
@@ -815,9 +815,18 @@ func (seg *Segmenter) doNext(ctx context.Context) (*mongo.Cursor, error) {
 	log.New("seg").With(log.NS(seg.mcoll.Database().Name(), seg.mcoll.Name())).
 		Tracef("[%v <=> %v]", seg.currIDRange.Min, maxKey)
 
-	cur, err := seg.mcoll.Find(ctx,
-		bson.D{{"_id", bson.D{{"$gte", seg.currIDRange.Min}, {"$lte", maxKey}}}},
-		options.Find().SetSort(bson.D{{"_id", 1}}).SetBatchSize(seg.batchSize))
+	// Only the cursor-open Find is retried here; mid-cursor getMore failures during
+	// segment iteration are out of scope for PCSM-328 (tracked as a follow-up).
+	var cur *mongo.Cursor
+
+	err = mdb.RunWithRetry(ctx, func(ctx context.Context) error {
+		var inner error
+		cur, inner = seg.mcoll.Find(ctx,
+			bson.D{{"_id", bson.D{{"$gte", seg.currIDRange.Min}, {"$lte", maxKey}}}},
+			options.Find().SetSort(bson.D{{"_id", 1}}).SetBatchSize(seg.batchSize))
+
+		return inner //nolint:wrapcheck
+	}, mdb.DefaultRetryInterval, mdb.DefaultMaxRetries)
 	if err != nil {
 		return nil, errors.Wrap(err, "query")
 	}
@@ -887,7 +896,14 @@ func (seg *Segmenter) handleNanIDDoc(
 func getIDKeyRange(ctx context.Context, mcoll *mongo.Collection) (keyRange, *bson.Raw, error) {
 	minIDOptions := options.FindOne().SetSort(bson.D{{"_id", 1}}).SetProjection(bson.D{{"_id", 1}})
 
-	minRaw, err := mcoll.FindOne(ctx, bson.D{}, minIDOptions).Raw()
+	var minRaw bson.Raw
+
+	err := mdb.RunWithRetry(ctx, func(ctx context.Context) error {
+		var inner error
+		minRaw, inner = mcoll.FindOne(ctx, bson.D{}, minIDOptions).Raw()
+
+		return inner //nolint:wrapcheck
+	}, mdb.DefaultRetryInterval, mdb.DefaultMaxRetries)
 	if err != nil {
 		return keyRange{}, nil, errors.Wrap(err, "min _id")
 	}
@@ -897,7 +913,12 @@ func getIDKeyRange(ctx context.Context, mcoll *mongo.Collection) (keyRange, *bso
 	if strings.Contains(minRaw.Lookup("_id").DebugString(), "NaN") {
 		nanDoc = minRaw
 
-		minRaw, err = mcoll.FindOne(ctx, bson.D{}, minIDOptions.SetSkip(1)).Raw()
+		err = mdb.RunWithRetry(ctx, func(ctx context.Context) error {
+			var inner error
+			minRaw, inner = mcoll.FindOne(ctx, bson.D{}, minIDOptions.SetSkip(1)).Raw()
+
+			return inner //nolint:wrapcheck
+		}, mdb.DefaultRetryInterval, mdb.DefaultMaxRetries)
 		if err != nil {
 			return keyRange{}, nil, errors.Wrap(err, "min _id (skip NaN)")
 		}
@@ -905,7 +926,14 @@ func getIDKeyRange(ctx context.Context, mcoll *mongo.Collection) (keyRange, *bso
 
 	maxIDOptions := options.FindOne().SetSort(bson.D{{"_id", -1}}).SetProjection(bson.D{{"_id", 1}})
 
-	maxRaw, err := mcoll.FindOne(ctx, bson.D{}, maxIDOptions).Raw()
+	var maxRaw bson.Raw
+
+	err = mdb.RunWithRetry(ctx, func(ctx context.Context) error {
+		var inner error
+		maxRaw, inner = mcoll.FindOne(ctx, bson.D{}, maxIDOptions).Raw()
+
+		return inner //nolint:wrapcheck
+	}, mdb.DefaultRetryInterval, mdb.DefaultMaxRetries)
 	if err != nil {
 		return keyRange{}, nil, errors.Wrap(err, "max _id")
 	}
@@ -913,7 +941,12 @@ func getIDKeyRange(ctx context.Context, mcoll *mongo.Collection) (keyRange, *bso
 	if strings.Contains(maxRaw.Lookup("_id").DebugString(), "NaN") {
 		nanDoc = maxRaw
 
-		maxRaw, err = mcoll.FindOne(ctx, bson.D{}, maxIDOptions.SetSkip(1)).Raw()
+		err = mdb.RunWithRetry(ctx, func(ctx context.Context) error {
+			var inner error
+			maxRaw, inner = mcoll.FindOne(ctx, bson.D{}, maxIDOptions.SetSkip(1)).Raw()
+
+			return inner //nolint:wrapcheck
+		}, mdb.DefaultRetryInterval, mdb.DefaultMaxRetries)
 		if err != nil {
 			return keyRange{}, nil, errors.Wrap(err, "max _id (skip NaN)")
 		}
@@ -932,31 +965,33 @@ func getIDKeyRange(ctx context.Context, mcoll *mongo.Collection) (keyRange, *bso
 // for each group. This allows the Segmenter to handle collections with heterogeneous _id types
 // by processing each type range sequentially.
 func getMultiTypeIDKeyRanges(ctx context.Context, mcoll *mongo.Collection) ([]keyRange, error) {
-	cur, err := mcoll.Aggregate(ctx,
-		mongo.Pipeline{
-			// Match only numeric types that are not NaN
-			bson.D{{"$match", bson.D{
-				{"$expr", bson.D{
-					// Only allow if _id is not NaN
-					{"$ne", bson.A{"$_id", bson.D{{"$literal", math.NaN()}}}},
-				}},
-			}}},
-			// Group by type and find min/max
-			bson.D{{"$group", bson.D{
-				{"_id", bson.D{{"type", bson.D{{"$type", "$_id"}}}}},
-				{"minKey", bson.D{{"$min", "$_id"}}},
-				{"maxKey", bson.D{{"$max", "$_id"}}},
-			}}},
-		})
-	if err != nil {
-		return nil, errors.Wrap(err, "query")
-	}
-
 	var keyRanges []keyRange
 
-	err = cur.All(ctx, &keyRanges)
+	err := mdb.RunWithRetry(ctx, func(ctx context.Context) error {
+		cur, err := mcoll.Aggregate(ctx,
+			mongo.Pipeline{
+				// Match only numeric types that are not NaN
+				bson.D{{"$match", bson.D{
+					{"$expr", bson.D{
+						// Only allow if _id is not NaN
+						{"$ne", bson.A{"$_id", bson.D{{"$literal", math.NaN()}}}},
+					}},
+				}}},
+				// Group by type and find min/max
+				bson.D{{"$group", bson.D{
+					{"_id", bson.D{{"type", bson.D{{"$type", "$_id"}}}}},
+					{"minKey", bson.D{{"$min", "$_id"}}},
+					{"maxKey", bson.D{{"$max", "$_id"}}},
+				}}},
+			})
+		if err != nil {
+			return err //nolint:wrapcheck
+		}
+
+		return cur.All(ctx, &keyRanges) //nolint:wrapcheck
+	}, mdb.DefaultRetryInterval, mdb.DefaultMaxRetries)
 	if err != nil {
-		return nil, errors.Wrap(err, "all")
+		return nil, errors.Wrap(err, "query")
 	}
 
 	for i := range keyRanges {
@@ -1030,8 +1065,17 @@ func (cs *CappedSegmenter) Next(ctx context.Context) (*mongo.Cursor, error) {
 		return nil, errEOC
 	}
 
-	cur, err := cs.mcoll.Find(ctx, bson.D{},
-		options.Find().SetHint(bson.D{{"$natural", 1}}).SetBatchSize(cs.batchSize))
+	// Only the cursor-open Find is retried here; mid-cursor getMore failures during
+	// iteration are out of scope for PCSM-328 (tracked as a follow-up).
+	var cur *mongo.Cursor
+
+	err := mdb.RunWithRetry(ctx, func(ctx context.Context) error {
+		var inner error
+		cur, inner = cs.mcoll.Find(ctx, bson.D{},
+			options.Find().SetHint(bson.D{{"$natural", 1}}).SetBatchSize(cs.batchSize))
+
+		return inner //nolint:wrapcheck
+	}, mdb.DefaultRetryInterval, mdb.DefaultMaxRetries)
 	if err != nil {
 		return nil, errors.Wrap(err, "query")
 	}

--- a/pcsm/clone/copy.go
+++ b/pcsm/clone/copy.go
@@ -815,9 +815,16 @@ func (seg *Segmenter) doNext(ctx context.Context) (*mongo.Cursor, error) {
 	log.New("seg").With(log.NS(seg.mcoll.Database().Name(), seg.mcoll.Name())).
 		Tracef("[%v <=> %v]", seg.currIDRange.Min, maxKey)
 
-	cur, err := seg.mcoll.Find(ctx,
-		bson.D{{"_id", bson.D{{"$gte", seg.currIDRange.Min}, {"$lte", maxKey}}}},
-		options.Find().SetSort(bson.D{{"_id", 1}}).SetBatchSize(seg.batchSize))
+	var cur *mongo.Cursor
+
+	err = mdb.RunWithRetry(ctx, func(ctx context.Context) error {
+		var inner error
+		cur, inner = seg.mcoll.Find(ctx,
+			bson.D{{"_id", bson.D{{"$gte", seg.currIDRange.Min}, {"$lte", maxKey}}}},
+			options.Find().SetSort(bson.D{{"_id", 1}}).SetBatchSize(seg.batchSize))
+
+		return inner //nolint:wrapcheck
+	}, mdb.DefaultRetryInterval, mdb.DefaultMaxRetries)
 	if err != nil {
 		return nil, errors.Wrap(err, "query")
 	}
@@ -885,10 +892,16 @@ func (seg *Segmenter) handleNanIDDoc(
 // It uses two FindOne operations with sort directions of 1 (ascending) and -1 (descending)
 // to determine the full _id range. This is used to define the collection boundaries
 // when the _id type is uniform across all documents.
+// The backoff-sleep-only worst case is roughly 80s: three loops complete after
+// up to 15s of backoff each, then one loop exhausts after 35s and aborts the
+// function. Each FindOne call is separately bounded by MongoDB's per-operation
+// timeout; there is no single timeout budget for getIDKeyRange as a whole.
 func getIDKeyRange(ctx context.Context, mcoll *mongo.Collection) (keyRange, *bson.Raw, error) {
 	minIDOptions := options.FindOne().SetSort(bson.D{{"_id", 1}}).SetProjection(bson.D{{"_id", 1}})
 
-	minRaw, err := mcoll.FindOne(ctx, bson.D{}, minIDOptions).Raw()
+	minRaw, err := mdb.RunWithRetryVal(ctx, func(ctx context.Context) (bson.Raw, error) {
+		return mcoll.FindOne(ctx, bson.D{}, minIDOptions).Raw() //nolint:wrapcheck
+	}, mdb.DefaultRetryInterval, mdb.DefaultMaxRetries)
 	if err != nil {
 		return keyRange{}, nil, errors.Wrap(err, "min _id")
 	}
@@ -898,7 +911,9 @@ func getIDKeyRange(ctx context.Context, mcoll *mongo.Collection) (keyRange, *bso
 	if strings.Contains(minRaw.Lookup("_id").DebugString(), "NaN") {
 		nanDoc = minRaw
 
-		minRaw, err = mcoll.FindOne(ctx, bson.D{}, minIDOptions.SetSkip(1)).Raw()
+		minRaw, err = mdb.RunWithRetryVal(ctx, func(ctx context.Context) (bson.Raw, error) {
+			return mcoll.FindOne(ctx, bson.D{}, minIDOptions.SetSkip(1)).Raw() //nolint:wrapcheck
+		}, mdb.DefaultRetryInterval, mdb.DefaultMaxRetries)
 		if err != nil {
 			return keyRange{}, nil, errors.Wrap(err, "min _id (skip NaN)")
 		}
@@ -906,7 +921,9 @@ func getIDKeyRange(ctx context.Context, mcoll *mongo.Collection) (keyRange, *bso
 
 	maxIDOptions := options.FindOne().SetSort(bson.D{{"_id", -1}}).SetProjection(bson.D{{"_id", 1}})
 
-	maxRaw, err := mcoll.FindOne(ctx, bson.D{}, maxIDOptions).Raw()
+	maxRaw, err := mdb.RunWithRetryVal(ctx, func(ctx context.Context) (bson.Raw, error) {
+		return mcoll.FindOne(ctx, bson.D{}, maxIDOptions).Raw() //nolint:wrapcheck
+	}, mdb.DefaultRetryInterval, mdb.DefaultMaxRetries)
 	if err != nil {
 		return keyRange{}, nil, errors.Wrap(err, "max _id")
 	}
@@ -914,7 +931,9 @@ func getIDKeyRange(ctx context.Context, mcoll *mongo.Collection) (keyRange, *bso
 	if strings.Contains(maxRaw.Lookup("_id").DebugString(), "NaN") {
 		nanDoc = maxRaw
 
-		maxRaw, err = mcoll.FindOne(ctx, bson.D{}, maxIDOptions.SetSkip(1)).Raw()
+		maxRaw, err = mdb.RunWithRetryVal(ctx, func(ctx context.Context) (bson.Raw, error) {
+			return mcoll.FindOne(ctx, bson.D{}, maxIDOptions.SetSkip(1)).Raw() //nolint:wrapcheck
+		}, mdb.DefaultRetryInterval, mdb.DefaultMaxRetries)
 		if err != nil {
 			return keyRange{}, nil, errors.Wrap(err, "max _id (skip NaN)")
 		}
@@ -1033,8 +1052,15 @@ func (cs *CappedSegmenter) Next(ctx context.Context) (*mongo.Cursor, error) {
 		return nil, errEOC
 	}
 
-	cur, err := cs.mcoll.Find(ctx, bson.D{},
-		options.Find().SetHint(bson.D{{"$natural", 1}}).SetBatchSize(cs.batchSize))
+	var cur *mongo.Cursor
+
+	err := mdb.RunWithRetry(ctx, func(ctx context.Context) error {
+		var inner error
+		cur, inner = cs.mcoll.Find(ctx, bson.D{},
+			options.Find().SetHint(bson.D{{"$natural", 1}}).SetBatchSize(cs.batchSize))
+
+		return inner //nolint:wrapcheck
+	}, mdb.DefaultRetryInterval, mdb.DefaultMaxRetries)
 	if err != nil {
 		return nil, errors.Wrap(err, "query")
 	}

--- a/pcsm/clone/copy.go
+++ b/pcsm/clone/copy.go
@@ -815,18 +815,9 @@ func (seg *Segmenter) doNext(ctx context.Context) (*mongo.Cursor, error) {
 	log.New("seg").With(log.NS(seg.mcoll.Database().Name(), seg.mcoll.Name())).
 		Tracef("[%v <=> %v]", seg.currIDRange.Min, maxKey)
 
-	// Only the cursor-open Find is retried here; mid-cursor getMore failures during
-	// segment iteration are out of scope for PCSM-328 (tracked as a follow-up).
-	var cur *mongo.Cursor
-
-	err = mdb.RunWithRetry(ctx, func(ctx context.Context) error {
-		var inner error
-		cur, inner = seg.mcoll.Find(ctx,
-			bson.D{{"_id", bson.D{{"$gte", seg.currIDRange.Min}, {"$lte", maxKey}}}},
-			options.Find().SetSort(bson.D{{"_id", 1}}).SetBatchSize(seg.batchSize))
-
-		return inner //nolint:wrapcheck
-	}, mdb.DefaultRetryInterval, mdb.DefaultMaxRetries)
+	cur, err := seg.mcoll.Find(ctx,
+		bson.D{{"_id", bson.D{{"$gte", seg.currIDRange.Min}, {"$lte", maxKey}}}},
+		options.Find().SetSort(bson.D{{"_id", 1}}).SetBatchSize(seg.batchSize))
 	if err != nil {
 		return nil, errors.Wrap(err, "query")
 	}
@@ -894,16 +885,10 @@ func (seg *Segmenter) handleNanIDDoc(
 // It uses two FindOne operations with sort directions of 1 (ascending) and -1 (descending)
 // to determine the full _id range. This is used to define the collection boundaries
 // when the _id type is uniform across all documents.
-// The backoff-sleep-only worst case is roughly 80s: three loops complete after
-// up to 15s of backoff each, then one loop exhausts after 35s and aborts the
-// function. Each FindOne call is separately bounded by MongoDB's per-operation
-// timeout; there is no single timeout budget for getIDKeyRange as a whole.
 func getIDKeyRange(ctx context.Context, mcoll *mongo.Collection) (keyRange, *bson.Raw, error) {
 	minIDOptions := options.FindOne().SetSort(bson.D{{"_id", 1}}).SetProjection(bson.D{{"_id", 1}})
 
-	minRaw, err := mdb.RunWithRetryVal(ctx, func(ctx context.Context) (bson.Raw, error) {
-		return mcoll.FindOne(ctx, bson.D{}, minIDOptions).Raw() //nolint:wrapcheck
-	}, mdb.DefaultRetryInterval, mdb.DefaultMaxRetries)
+	minRaw, err := mcoll.FindOne(ctx, bson.D{}, minIDOptions).Raw()
 	if err != nil {
 		return keyRange{}, nil, errors.Wrap(err, "min _id")
 	}
@@ -913,9 +898,7 @@ func getIDKeyRange(ctx context.Context, mcoll *mongo.Collection) (keyRange, *bso
 	if strings.Contains(minRaw.Lookup("_id").DebugString(), "NaN") {
 		nanDoc = minRaw
 
-		minRaw, err = mdb.RunWithRetryVal(ctx, func(ctx context.Context) (bson.Raw, error) {
-			return mcoll.FindOne(ctx, bson.D{}, minIDOptions.SetSkip(1)).Raw() //nolint:wrapcheck
-		}, mdb.DefaultRetryInterval, mdb.DefaultMaxRetries)
+		minRaw, err = mcoll.FindOne(ctx, bson.D{}, minIDOptions.SetSkip(1)).Raw()
 		if err != nil {
 			return keyRange{}, nil, errors.Wrap(err, "min _id (skip NaN)")
 		}
@@ -923,9 +906,7 @@ func getIDKeyRange(ctx context.Context, mcoll *mongo.Collection) (keyRange, *bso
 
 	maxIDOptions := options.FindOne().SetSort(bson.D{{"_id", -1}}).SetProjection(bson.D{{"_id", 1}})
 
-	maxRaw, err := mdb.RunWithRetryVal(ctx, func(ctx context.Context) (bson.Raw, error) {
-		return mcoll.FindOne(ctx, bson.D{}, maxIDOptions).Raw() //nolint:wrapcheck
-	}, mdb.DefaultRetryInterval, mdb.DefaultMaxRetries)
+	maxRaw, err := mcoll.FindOne(ctx, bson.D{}, maxIDOptions).Raw()
 	if err != nil {
 		return keyRange{}, nil, errors.Wrap(err, "max _id")
 	}
@@ -933,9 +914,7 @@ func getIDKeyRange(ctx context.Context, mcoll *mongo.Collection) (keyRange, *bso
 	if strings.Contains(maxRaw.Lookup("_id").DebugString(), "NaN") {
 		nanDoc = maxRaw
 
-		maxRaw, err = mdb.RunWithRetryVal(ctx, func(ctx context.Context) (bson.Raw, error) {
-			return mcoll.FindOne(ctx, bson.D{}, maxIDOptions.SetSkip(1)).Raw() //nolint:wrapcheck
-		}, mdb.DefaultRetryInterval, mdb.DefaultMaxRetries)
+		maxRaw, err = mcoll.FindOne(ctx, bson.D{}, maxIDOptions.SetSkip(1)).Raw()
 		if err != nil {
 			return keyRange{}, nil, errors.Wrap(err, "max _id (skip NaN)")
 		}
@@ -1054,17 +1033,8 @@ func (cs *CappedSegmenter) Next(ctx context.Context) (*mongo.Cursor, error) {
 		return nil, errEOC
 	}
 
-	// Only the cursor-open Find is retried here; mid-cursor getMore failures during
-	// iteration are out of scope for PCSM-328 (tracked as a follow-up).
-	var cur *mongo.Cursor
-
-	err := mdb.RunWithRetry(ctx, func(ctx context.Context) error {
-		var inner error
-		cur, inner = cs.mcoll.Find(ctx, bson.D{},
-			options.Find().SetHint(bson.D{{"$natural", 1}}).SetBatchSize(cs.batchSize))
-
-		return inner //nolint:wrapcheck
-	}, mdb.DefaultRetryInterval, mdb.DefaultMaxRetries)
+	cur, err := cs.mcoll.Find(ctx, bson.D{},
+		options.Find().SetHint(bson.D{{"$natural", 1}}).SetBatchSize(cs.batchSize))
 	if err != nil {
 		return nil, errors.Wrap(err, "query")
 	}

--- a/pcsm/clone/copy.go
+++ b/pcsm/clone/copy.go
@@ -853,7 +853,8 @@ func (seg *Segmenter) findSegmentMaxKey(
 
 	err := mdb.RunWithRetry(ctx, func(ctx context.Context) error {
 		var inner error
-		raw, inner = seg.mcoll.FindOne(ctx,
+		raw, inner = seg.mcoll.FindOne(
+			ctx,
 			bson.D{{"_id", bson.D{{"$gt", minKey}, {"$lte", maxKey}}}},
 			options.FindOne().
 				SetSort(bson.D{{"_id", 1}}).
@@ -893,16 +894,15 @@ func (seg *Segmenter) handleNanIDDoc(
 // It uses two FindOne operations with sort directions of 1 (ascending) and -1 (descending)
 // to determine the full _id range. This is used to define the collection boundaries
 // when the _id type is uniform across all documents.
+// The backoff-sleep-only worst case is roughly 80s: three loops complete after
+// up to 15s of backoff each, then one loop exhausts after 35s and aborts the
+// function. Each FindOne call is separately bounded by MongoDB's per-operation
+// timeout; there is no single timeout budget for getIDKeyRange as a whole.
 func getIDKeyRange(ctx context.Context, mcoll *mongo.Collection) (keyRange, *bson.Raw, error) {
 	minIDOptions := options.FindOne().SetSort(bson.D{{"_id", 1}}).SetProjection(bson.D{{"_id", 1}})
 
-	var minRaw bson.Raw
-
-	err := mdb.RunWithRetry(ctx, func(ctx context.Context) error {
-		var inner error
-		minRaw, inner = mcoll.FindOne(ctx, bson.D{}, minIDOptions).Raw()
-
-		return inner //nolint:wrapcheck
+	minRaw, err := mdb.RunWithRetryVal(ctx, func(ctx context.Context) (bson.Raw, error) {
+		return mcoll.FindOne(ctx, bson.D{}, minIDOptions).Raw() //nolint:wrapcheck
 	}, mdb.DefaultRetryInterval, mdb.DefaultMaxRetries)
 	if err != nil {
 		return keyRange{}, nil, errors.Wrap(err, "min _id")
@@ -913,11 +913,8 @@ func getIDKeyRange(ctx context.Context, mcoll *mongo.Collection) (keyRange, *bso
 	if strings.Contains(minRaw.Lookup("_id").DebugString(), "NaN") {
 		nanDoc = minRaw
 
-		err = mdb.RunWithRetry(ctx, func(ctx context.Context) error {
-			var inner error
-			minRaw, inner = mcoll.FindOne(ctx, bson.D{}, minIDOptions.SetSkip(1)).Raw()
-
-			return inner //nolint:wrapcheck
+		minRaw, err = mdb.RunWithRetryVal(ctx, func(ctx context.Context) (bson.Raw, error) {
+			return mcoll.FindOne(ctx, bson.D{}, minIDOptions.SetSkip(1)).Raw() //nolint:wrapcheck
 		}, mdb.DefaultRetryInterval, mdb.DefaultMaxRetries)
 		if err != nil {
 			return keyRange{}, nil, errors.Wrap(err, "min _id (skip NaN)")
@@ -926,13 +923,8 @@ func getIDKeyRange(ctx context.Context, mcoll *mongo.Collection) (keyRange, *bso
 
 	maxIDOptions := options.FindOne().SetSort(bson.D{{"_id", -1}}).SetProjection(bson.D{{"_id", 1}})
 
-	var maxRaw bson.Raw
-
-	err = mdb.RunWithRetry(ctx, func(ctx context.Context) error {
-		var inner error
-		maxRaw, inner = mcoll.FindOne(ctx, bson.D{}, maxIDOptions).Raw()
-
-		return inner //nolint:wrapcheck
+	maxRaw, err := mdb.RunWithRetryVal(ctx, func(ctx context.Context) (bson.Raw, error) {
+		return mcoll.FindOne(ctx, bson.D{}, maxIDOptions).Raw() //nolint:wrapcheck
 	}, mdb.DefaultRetryInterval, mdb.DefaultMaxRetries)
 	if err != nil {
 		return keyRange{}, nil, errors.Wrap(err, "max _id")
@@ -941,11 +933,8 @@ func getIDKeyRange(ctx context.Context, mcoll *mongo.Collection) (keyRange, *bso
 	if strings.Contains(maxRaw.Lookup("_id").DebugString(), "NaN") {
 		nanDoc = maxRaw
 
-		err = mdb.RunWithRetry(ctx, func(ctx context.Context) error {
-			var inner error
-			maxRaw, inner = mcoll.FindOne(ctx, bson.D{}, maxIDOptions.SetSkip(1)).Raw()
-
-			return inner //nolint:wrapcheck
+		maxRaw, err = mdb.RunWithRetryVal(ctx, func(ctx context.Context) (bson.Raw, error) {
+			return mcoll.FindOne(ctx, bson.D{}, maxIDOptions.SetSkip(1)).Raw() //nolint:wrapcheck
 		}, mdb.DefaultRetryInterval, mdb.DefaultMaxRetries)
 		if err != nil {
 			return keyRange{}, nil, errors.Wrap(err, "max _id (skip NaN)")

--- a/pcsm/clone/copy.go
+++ b/pcsm/clone/copy.go
@@ -892,10 +892,6 @@ func (seg *Segmenter) handleNanIDDoc(
 // It uses two FindOne operations with sort directions of 1 (ascending) and -1 (descending)
 // to determine the full _id range. This is used to define the collection boundaries
 // when the _id type is uniform across all documents.
-// The backoff-sleep-only worst case is roughly 80s: three loops complete after
-// up to 15s of backoff each, then one loop exhausts after 35s and aborts the
-// function. Each FindOne call is separately bounded by MongoDB's per-operation
-// timeout; there is no single timeout budget for getIDKeyRange as a whole.
 func getIDKeyRange(ctx context.Context, mcoll *mongo.Collection) (keyRange, *bson.Raw, error) {
 	minIDOptions := options.FindOne().SetSort(bson.D{{"_id", 1}}).SetProjection(bson.D{{"_id", 1}})
 

--- a/pcsm/repl/bulk.go
+++ b/pcsm/repl/bulk.go
@@ -723,12 +723,20 @@ func handleDuplicateKeyError(
 		deleteOpts.SetCollation(simpleCollation)
 	}
 
-	_, err = coll.DeleteOne(ctx, bson.D{{Key: "_id", Value: docID}}, deleteOpts)
+	err = mdb.RunWithRetry(ctx, func(ctx context.Context) error {
+		_, inner := coll.DeleteOne(ctx, bson.D{{Key: "_id", Value: docID}}, deleteOpts)
+
+		return inner //nolint:wrapcheck
+	}, mdb.DefaultRetryInterval, mdb.DefaultMaxRetries)
 	if err != nil && !errors.Is(err, mongo.ErrNoDocuments) {
 		return errors.Wrap(err, "delete before insert")
 	}
 
-	_, err = coll.InsertOne(ctx, replacement)
+	err = mdb.RunWithRetry(ctx, func(ctx context.Context) error {
+		_, inner := coll.InsertOne(ctx, replacement)
+
+		return inner //nolint:wrapcheck
+	}, mdb.DefaultRetryInterval, mdb.DefaultMaxRetries)
 	if err != nil {
 		return errors.Wrap(err, "insert after delete")
 	}
@@ -765,7 +773,9 @@ func handleRecoverableUpdateError(
 
 	var doc bson.D
 
-	err := sourceColl.FindOne(ctx, filter).Decode(&doc)
+	err := mdb.RunWithRetry(ctx, func(ctx context.Context) error {
+		return sourceColl.FindOne(ctx, filter).Decode(&doc) //nolint:wrapcheck
+	}, mdb.DefaultRetryInterval, mdb.DefaultMaxRetries)
 	if errors.Is(err, mongo.ErrNoDocuments) {
 		// Doc deleted on source between the change event and the refetch.
 		// Delete on target idempotently; the eventual delete event from the
@@ -785,7 +795,11 @@ func handleRecoverableUpdateError(
 		replaceOpts.SetCollation(simpleCollation)
 	}
 
-	_, err = targetColl.ReplaceOne(ctx, filter, doc, replaceOpts)
+	err = mdb.RunWithRetry(ctx, func(ctx context.Context) error {
+		_, inner := targetColl.ReplaceOne(ctx, filter, doc, replaceOpts)
+
+		return inner //nolint:wrapcheck
+	}, mdb.DefaultRetryInterval, mdb.DefaultMaxRetries)
 	if err != nil {
 		return errors.Wrap(err, "replace target with source doc")
 	}
@@ -811,7 +825,11 @@ func deleteTargetAfterSourceMissing(
 		deleteOpts.SetCollation(simpleCollation)
 	}
 
-	_, err := targetColl.DeleteOne(ctx, filter, deleteOpts)
+	err := mdb.RunWithRetry(ctx, func(ctx context.Context) error {
+		_, inner := targetColl.DeleteOne(ctx, filter, deleteOpts)
+
+		return inner //nolint:wrapcheck
+	}, mdb.DefaultRetryInterval, mdb.DefaultMaxRetries)
 	if err != nil && !errors.Is(err, mongo.ErrNoDocuments) {
 		return errors.Wrap(err, "delete target after source missing")
 	}


### PR DESCRIPTION
[PCSM-328](https://jira.percona.com/browse/PCSM-328)

### Problem

A lot of MongoDB operations are issued straight through the driver with no retry wrapping. During a long multi-TB initial clone that's fragile: a single transient source error (a network blip, a one-off `MaxTimeMSExpired`) on any of these calls aborts the whole clone instead of being retried.
PCSM-323 fixed this for `findSegmentMaxKey`, but that was only the one call that was actively failing at the time. Everything else stayed unwrapped: the other segmenter read paths, the `mdb` topology and schema helpers used during clone setup and discovery, and the `pcsm/repl` bulk recovery paths.

### Solution

Wrap the remaining operations in the existing `mdb.RunWithRetry` (capped at `DefaultMaxRetries`), same as `findSegmentMaxKey`. Two shapes come up.
Single-shot ops (`FindOne`/`RunCommand` decoded in place, `Aggregate` drained with `cur.All`) wrap the whole call in one retry closure. Sentinel checks (`ErrNoDocuments`, `ErrNotFound`, namespace-not-found, index-not-found) stay outside the closure so they still fire, and the raw driver error is returned from inside the closure so `IsTransient` can still see the `RetryableWriteError` label.
Cursor-returning ops that hand a live cursor back to a long-lived caller (`Segmenter.doNext`, `CappedSegmenter.Next`) only wrap the cursor-open `Find`. Retrying a mid-cursor `getMore` needs checkpoint/restart plumbing we don't have yet, so it's called out in a comment and left as a follow-up.
`findSegmentMaxKey` and the catalog target ops were already wrapped, so they're untouched.

### Retry helper fixes
- a wasted backoff interval (up to 20s at the default 3-attempt/5s config) with no retry to follow
- the `time.Sleep` ignored context cancellation, so finalize/shutdown couldn't interrupt a backoff
- `IsTransient` detected the `RetryableWriteError` label with a direct type assertion, which a wrapped error slips past. Because the retry closures wrap the driver error before it reaches the classifier (both the clone `insertBatch` and the repl bulk apply paths), a retryable write could be misclassified as permanent; it now uses `errors.As` so the label survives wrapping.


[PCSM-328]: https://perconadev.atlassian.net/browse/PCSM-328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ