### PR TITLE
PCSM-335: Log format and UTC timezone

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -18,6 +18,7 @@ const TimeFieldFormat = "2006-01-02T15:04:05.000Z07:00"
 //   - output: the output writer (os.Stdout for server, os.Stderr for client commands).
 func InitGlobals(level zerolog.Level, json, noColor bool, output io.Writer) *zerolog.Logger {
 	zerolog.TimeFieldFormat = TimeFieldFormat
+	zerolog.TimestampFunc = func() time.Time { return time.Now().UTC() }
 	zerolog.DurationFieldUnit = time.Second
 	zerolog.DurationFieldInteger = false
 
@@ -27,6 +28,7 @@ func InitGlobals(level zerolog.Level, json, noColor bool, output io.Writer) *zer
 			w.Out = output
 			w.NoColor = noColor
 			w.TimeFormat = TimeFieldFormat
+			w.TimeLocation = time.UTC
 		})
 	}
 

--- a/log/log.go
+++ b/log/log.go
@@ -9,7 +9,7 @@ import (
 	"github.com/rs/zerolog"
 )
 
-const TimeFieldFormat = "2006-01-02 15:04:05.000"
+const TimeFieldFormat = "2006-01-02T15:04:05.000Z07:00"
 
 // InitGlobals initializes the logger with the specified level and settings.
 //   - level: the log level (e.g., debug, info, warn, error).


### PR DESCRIPTION
[PCSM-335](https://perconadev.atlassian.net/browse/PCSM-335)
[PCSM-336](https://perconadev.atlassian.net/browse/PCSM-336)

### Problem

PCSM log timestamps used a custom format without timezone information, rendered
in the host's local timezone. 

```
2026-08-13 10:38:06.396 INF Percona ClusterSync for MongoDB v0.9.0
```

### Solution

Emit log timestamps in RFC 3339 format and always in UTC, regardless of the
host's local timezone. 

```
2026-08-13T08:44:22.043Z INF Percona ClusterSync for MongoDB v0.9.0
```

[PCSM-335]: https://perconadev.atlassian.net/browse/PCSM-335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PCSM-336]: https://perconadev.atlassian.net/browse/PCSM-336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ