### PR TITLE
PCSM-370: Pin CI tools and harden Trivy scan

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           python-version: "3.13"
       - name: Install ruff
-        run: pip install ruff
+        run: pip install ruff==0.16.1
       - name: Ruff check
         run: ruff check tests/ hack/
       - name: Ruff format check

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -34,5 +34,5 @@ jobs:
           severity: HIGH,CRITICAL
           ignore-unfixed: true
           exit-code: '1'
+          # Reuse the Trivy binary installed by the SBOM generation step.
           skip-setup-trivy: true
-          version: v0.72.0

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -2,6 +2,9 @@ name: Scan
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   scan:
     name: Trivy
@@ -12,17 +15,24 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Download latest trivy
-        run: |
-          mkdir -p ${{ github.workspace }}/trivy
-          LATEST_TRIVY_VERSION=$(curl --retry 5 --retry-connrefused --retry-delay 5 --fail -s https://api.github.com/repos/aquasecurity/trivy/releases/latest | jq -r .tag_name)
-          TRIVY_VERSION_STRIPPED=$(echo "$LATEST_TRIVY_VERSION" | sed 's/^v//')
-          wget --tries=5 --retry-connrefused --waitretry=5 -O ${{ github.workspace }}/trivy/trivy.tar.gz \
-              https://github.com/aquasecurity/trivy/releases/download/$LATEST_TRIVY_VERSION/trivy_${TRIVY_VERSION_STRIPPED}_Linux-64bit.tar.gz && break || sleep 5
-          tar -xzf ${{ github.workspace }}/trivy/trivy.tar.gz -C ${{ github.workspace }}/trivy
-
       - name: Generate SBOM
-        run: ${{ github.workspace }}/trivy/trivy fs --format cyclonedx --output ${{ github.workspace }}/sbom.json ${{ github.workspace }}
+        # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: cyclonedx
+          output: sbom.json
+          version: v0.72.0
 
       - name: Run trivy scan on SBOM
-        run: ${{ github.workspace }}/trivy/trivy sbom ${{ github.workspace }}/sbom.json --severity HIGH,CRITICAL --ignore-unfixed --exit-code=1
+        # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          scan-type: sbom
+          scan-ref: sbom.json
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: '1'
+          skip-setup-trivy: true
+          version: v0.72.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,4 @@
+---
 version: "2"
 linters:
   default: all
@@ -6,9 +7,14 @@ linters:
     - cyclop
     - depguard
     - dupl
+    # Both exhaustruct major versions conflict with the project's
+    # selective struct literals.
     - exhaustruct
+    - exhaustruct_v5
     - funlen
     - gocognit
+    # gomodguard is deprecated; gomodguard_v2 remains enabled by default.
+    - gomodguard
     - nolintlint
     - varnamelen
     - wsl
@@ -44,6 +50,7 @@ linters:
       - third_party$
       - builtin$
       - examples$
+      - ^tmp/
 formatters:
   enable:
     - gofmt
@@ -55,3 +62,4 @@ formatters:
       - third_party$
       - builtin$
       - examples$
+      - ^tmp/

--- a/poetry.lock
+++ b/poetry.lock
@@ -408,4 +408,4 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "fb96e60adf920e712e4678609e3539db660cad6d088a4a8fdc5d0f50b2aa61a5"
+content-hash = "9512f485c7c4593cee33bfed053f0072d70928ef74e88fb59a7112e6bfb8d199"

--- a/poetry.lock
+++ b/poetry.lock
@@ -361,30 +361,30 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<8)"]
 
 [[package]]
 name = "ruff"
-version = "0.9.10"
+version = "0.16.1"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "ruff-0.9.10-py3-none-linux_armv6l.whl", hash = "sha256:eb4d25532cfd9fe461acc83498361ec2e2252795b4f40b17e80692814329e42d"},
-    {file = "ruff-0.9.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:188a6638dab1aa9bb6228a7302387b2c9954e455fb25d6b4470cb0641d16759d"},
-    {file = "ruff-0.9.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5284dcac6b9dbc2fcb71fdfc26a217b2ca4ede6ccd57476f52a587451ebe450d"},
-    {file = "ruff-0.9.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:47678f39fa2a3da62724851107f438c8229a3470f533894b5568a39b40029c0c"},
-    {file = "ruff-0.9.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:99713a6e2766b7a17147b309e8c915b32b07a25c9efd12ada79f217c9c778b3e"},
-    {file = "ruff-0.9.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:524ee184d92f7c7304aa568e2db20f50c32d1d0caa235d8ddf10497566ea1a12"},
-    {file = "ruff-0.9.10-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:df92aeac30af821f9acf819fc01b4afc3dfb829d2782884f8739fb52a8119a16"},
-    {file = "ruff-0.9.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de42e4edc296f520bb84954eb992a07a0ec5a02fecb834498415908469854a52"},
-    {file = "ruff-0.9.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d257f95b65806104b6b1ffca0ea53f4ef98454036df65b1eda3693534813ecd1"},
-    {file = "ruff-0.9.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b60dec7201c0b10d6d11be00e8f2dbb6f40ef1828ee75ed739923799513db24c"},
-    {file = "ruff-0.9.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d838b60007da7a39c046fcdd317293d10b845001f38bcb55ba766c3875b01e43"},
-    {file = "ruff-0.9.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ccaf903108b899beb8e09a63ffae5869057ab649c1e9231c05ae354ebc62066c"},
-    {file = "ruff-0.9.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:f9567d135265d46e59d62dc60c0bfad10e9a6822e231f5b24032dba5a55be6b5"},
-    {file = "ruff-0.9.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5f202f0d93738c28a89f8ed9eaba01b7be339e5d8d642c994347eaa81c6d75b8"},
-    {file = "ruff-0.9.10-py3-none-win32.whl", hash = "sha256:bfb834e87c916521ce46b1788fbb8484966e5113c02df216680102e9eb960029"},
-    {file = "ruff-0.9.10-py3-none-win_amd64.whl", hash = "sha256:f2160eeef3031bf4b17df74e307d4c5fb689a6f3a26a2de3f7ef4044e3c484f1"},
-    {file = "ruff-0.9.10-py3-none-win_arm64.whl", hash = "sha256:5fd804c0327a5e5ea26615550e706942f348b197d5475ff34c19733aee4b2e69"},
-    {file = "ruff-0.9.10.tar.gz", hash = "sha256:9bacb735d7bada9cfb0f2c227d3658fc443d90a727b47f206fb33f52f3c0eac7"},
+    {file = "ruff-0.16.1-py3-none-linux_armv6l.whl", hash = "sha256:58edb313b88f0c5460a26adf5f39a37a3be789494a15e3e411e35fa78b89f9a0"},
+    {file = "ruff-0.16.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fde5a99e2f97479af66edd6622c6d5a2a7592c77cf4153d9e4428f5eeb55b60c"},
+    {file = "ruff-0.16.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e0d4c20532fca4f7fa609369161d968dd28f65d83dabbd61d8e9c7edbf7001f6"},
+    {file = "ruff-0.16.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30affbcedf59ad5703d9c91f82266e02b47739f797e1a7b6e158e5526a6dae38"},
+    {file = "ruff-0.16.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:24e9c631573cbca9d20f1283f8f479b2afa4a8503504822bd71a293889f16743"},
+    {file = "ruff-0.16.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b41bdd48fb420987a9b5212e4957c26ad4abce401fa9ea9d4d85843727945f4f"},
+    {file = "ruff-0.16.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b0d1e1393b7648079e13669de1c1f4fde06d4583e84d8fd5c1551e0a77a2aa75"},
+    {file = "ruff-0.16.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:07bf434b1c95f4e093be4532068ef4fcf00924eb2ade8796075980902d6fd54a"},
+    {file = "ruff-0.16.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39897739f112253ee4fdd2e8aa9a4f9ded99fb2be367d5f31dfa4ded6025584c"},
+    {file = "ruff-0.16.1-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:82ae3c0c0d74daf17b968a10b7b3bb3ef297ab7de0c1f749646b25e690ccb150"},
+    {file = "ruff-0.16.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4d5f2ed10f8242d83fc08d521301089364e3375375705356f20c0e31606ef3ef"},
+    {file = "ruff-0.16.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a4665b309891f83f3e3c25447935f1213e9abbd4b5640af7a1f2def9f8d413c1"},
+    {file = "ruff-0.16.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:26e9ca5c9bc3971f20d3cf18a957f52ffd6a5f6564ff15c4912a144dcac22494"},
+    {file = "ruff-0.16.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:67e1e1e3fa4f0c82f0e36d4cd61e661f6e7a6196cb1aa92fe0828fa7b8f257cd"},
+    {file = "ruff-0.16.1-py3-none-win32.whl", hash = "sha256:d31765e131295b8445caf301e3e8a85b34d1b9b211b4109b7ba457888b051806"},
+    {file = "ruff-0.16.1-py3-none-win_amd64.whl", hash = "sha256:09b05e8b90c2cb06ad63464350e7a45e8e44a2dfe52072ebfba6666ca8d3f596"},
+    {file = "ruff-0.16.1-py3-none-win_arm64.whl", hash = "sha256:dbaadaac38c70239f056d306b7476f246b0bf000fa6b3876402acbf5b227eaf8"},
+    {file = "ruff-0.16.1.tar.gz", hash = "sha256:fedad7c801dabd3fb9741d76aca39246e6ddd9ca446a015875207bf19f1e6bc7"},
 ]
 
 [[package]]
@@ -408,4 +408,4 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "2c9c0649554ac37ace8beeabbdd68e8ca298cb3a6931104b6011009a36874bb5"
+content-hash = "fb96e60adf920e712e4678609e3539db660cad6d088a4a8fdc5d0f50b2aa61a5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ pytest-timeout = "^2.4.0"
 requests = "^2.33.0"
 
 [tool.poetry.group.dev.dependencies]
-ruff = "^0.16.1"
+ruff = "0.16.1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ pytest-timeout = "^2.4.0"
 requests = "^2.33.0"
 
 [tool.poetry.group.dev.dependencies]
-ruff = "^0.9.0"
+ruff = "^0.16.1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,7 +97,7 @@ def drop_all_database(source_conn: MongoClient, target_conn: MongoClient):
     testing.drop_all_database(target_conn)
 
 
-PCSM_PROC: subprocess.Popen = None
+PCSM_PROC: subprocess.Popen | None = None
 
 
 def _pcsm_url(request: pytest.FixtureRequest):


### PR DESCRIPTION
Pins Ruff 0.16.1 in Poetry and Python CI so both use the same linter. Replaces the ad-hoc Trivy download with pinned `trivy-action` SBOM steps, updates golangci for renamed v2 linters, and types the optional test PCSM process correctly.

Checks: `make lint`, `make lint-py`, `poetry check --lock`, pytest collection.