### PR TITLE
PCSM-369: Scope MongoDB operation timeout flag

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -150,6 +150,74 @@ func runPCSM(t *testing.T, args []string, env map[string]string) (string, string
 	return stdout.String(), stderr.String(), err
 }
 
+func TestMongoDBOperationTimeoutFlagRejectedByHTTPClientCommands(t *testing.T) {
+	t.Parallel()
+
+	for _, command := range []string{"status", "start", "pause", "resume", "finalize"} {
+		for _, args := range [][]string{
+			{"--mongodb-operation-timeout=1s", command},
+			{command, "--mongodb-operation-timeout=1s"},
+		} {
+			t.Run(strings.Join(args, " "), func(t *testing.T) {
+				t.Parallel()
+
+				_, stderr, err := runPCSM(t, args, nil)
+
+				require.Error(t, err)
+				assert.Contains(t, stderr, "unknown flag: --mongodb-operation-timeout")
+			})
+		}
+	}
+}
+
+func TestMongoDBOperationTimeoutFlagAcceptedByMongoDBCommands(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		args          []string
+		expectedError string
+	}{
+		{
+			name:          "server",
+			args:          []string{"--mongodb-operation-timeout=1s"},
+			expectedError: "source URI and target URI are empty",
+		},
+		{
+			name:          "reset",
+			args:          []string{"reset", "--mongodb-operation-timeout=1s"},
+			expectedError: "required flag --target not set",
+		},
+		{
+			name:          "reset recovery",
+			args:          []string{"reset", "recovery", "--mongodb-operation-timeout=1s"},
+			expectedError: "required flag --target not set",
+		},
+		{
+			name:          "reset members",
+			args:          []string{"reset", "members", "--mongodb-operation-timeout=1s"},
+			expectedError: "required flag --target not set",
+		},
+		{
+			name:          "reset lease",
+			args:          []string{"reset", "lease", "--mongodb-operation-timeout=1s"},
+			expectedError: "required flag --target not set",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, stderr, err := runPCSM(t, tt.args, nil)
+
+			require.Error(t, err)
+			assert.NotContains(t, stderr, "unknown flag")
+			assert.Contains(t, stderr, tt.expectedError)
+		})
+	}
+}
+
 type commandTestCase struct {
 	name         string
 	args         []string

--- a/main.go
+++ b/main.go
@@ -46,6 +46,8 @@ const (
 	ServerResponseTimeout   = 5 * time.Second
 )
 
+const mongoDBOperationTimeoutHelp = "Timeout for MongoDB operations (e.g., 30s, 5m)"
+
 var (
 	Version   = "v0.9.0" //nolint:gochecknoglobals
 	Platform  = ""       //nolint:gochecknoglobals
@@ -133,14 +135,12 @@ func newRootCmd() *cobra.Command {
 
 	rootCmd.PersistentFlags().Int("port", config.DefaultServerPort, "Port number")
 
-	// MongoDB client timeout (visible: commonly needed for debugging)
-	rootCmd.PersistentFlags().String("mongodb-operation-timeout", config.DefaultMongoDBOperationTimeout.String(),
-		"Timeout for MongoDB operations (e.g., 30s, 5m)")
-
 	// Root command specific flags
 	rootCmd.Flags().String("source", "", "MongoDB connection string for the source")
 	rootCmd.Flags().String("target", "", "MongoDB connection string for the target")
 	rootCmd.Flags().String("listen-host", "localhost", "Host to bind the HTTP server")
+	rootCmd.Flags().String("mongodb-operation-timeout", config.DefaultMongoDBOperationTimeout.String(),
+		mongoDBOperationTimeoutHelp)
 
 	rootCmd.Flags().String("group-name", config.DefaultGroup,
 		"HA group name, recorded and advertised for observability "+
@@ -411,6 +411,8 @@ func newResetCmd(cfg *config.Config) *cobra.Command {
 	}
 
 	cmd.PersistentFlags().String("target", "", "MongoDB connection string for the target")
+	cmd.PersistentFlags().String("mongodb-operation-timeout", config.DefaultMongoDBOperationTimeout.String(),
+		mongoDBOperationTimeoutHelp)
 
 	cmd.AddCommand(
 		newResetRecoveryCmd(cfg),


### PR DESCRIPTION
`--mongodb-operation-timeout` was inherited by HTTP client commands even though only server and reset paths create MongoDB clients. This scopes the flag to the root server and `reset` commands so `status`, `start`, `pause`, `resume`, and `finalize` fail with an unknown flag instead of silently ignoring it, and adds CLI regression coverage for both flag positions.