### PR TITLE
PCSM-356: Bind local Compose ports to loopback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 .idea/
 
 .dev
-.env
+*.env
 
 /bin/
 /tmp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,7 +349,7 @@ Sharded topology shown as primary. RS variants use the URIs from the Connection 
 
 ### HA Multi-Instance Testing
 
-`hack/ha/` runs a 3-node PCSM HA group (`pcsm0`/`pcsm1`/`pcsm2`) in Docker against already-running clusters, for manual failover testing. The instances join the cluster's Docker network and reach it via the same hostnames the host uses; API ports `2242`/`2243`/`2244` are published to the host.
+`hack/ha/` runs a 3-node PCSM HA group (`pcsm0`/`pcsm1`/`pcsm2`) in Docker against already-running clusters, for manual failover testing. The instances join the cluster's Docker network and reach it via the same hostnames the host uses; API ports `2242`/`2243`/`2244` are published on host loopback. Prometheus reaches the instances over the shared `pcsm-metrics` Docker network.
 
 ```bash
 # 1. Start clusters first (RS shown; use hack/sh/run.sh for sharded)
@@ -503,9 +503,9 @@ poetry run python hack/monitor_writes.py -u "mongodb://src-mongos:27017"
 
 ### Metrics Stack
 
-`make metrics-up` brings up the bundled Prometheus + Grafana stack against the local PCSM `/metrics` endpoint. `make metrics-down` stops it.
+`make metrics-up` creates the shared `pcsm-metrics` Docker network and starts the bundled Prometheus + Grafana stack. `make metrics-down` stops the stack; the external network remains for startup-order independence.
 
-The bundled Prometheus scrapes all three HA hack ports (`2242`–`2244`); down targets for single-instance runs are harmless. Because `/metrics` is served on every role but only the ACTIVE instance drives replication, the Grafana board scopes gauge panels to the ACTIVE instance (`<metric> and on(instance) (percona_clustersync_mongodb_ha_active == 1)`) so a demoted ex-ACTIVE's frozen gauges don't render, and aggregates counter-rate panels with `sum(...)` (a demoted instance's `rate()` is 0).
+The bundled Prometheus scrapes `pcsm0`/`pcsm1`/`pcsm2` through Docker DNS; targets remain down until the HA group starts. A host-run PCSM is not scraped because its default loopback listener is unreachable from the Prometheus container. Because `/metrics` is served on every role but only the ACTIVE instance drives replication, the Grafana board scopes gauge panels to the ACTIVE instance (`<metric> and on(instance) (percona_clustersync_mongodb_ha_active == 1)`) so a demoted ex-ACTIVE's frozen gauges don't render, and aggregates counter-rate panels with `sum(...)` (a demoted instance's `rate()` is 0).
 
 ### HA Metrics
 

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ clean:
 
 # Start Prometheus + Grafana metrics stack (Grafana: http://localhost:3000, Prometheus: http://localhost:9090)
 metrics-up:
+	docker network inspect pcsm-metrics >/dev/null 2>&1 || docker network create pcsm-metrics
 	docker compose -f hack/metrics/docker-compose.yml up -d
 
 # Stop metrics stack

--- a/hack/ha/compose.yml
+++ b/hack/ha/compose.yml
@@ -9,6 +9,8 @@
 #   PCSM_HA_NETWORK  external docker network of the running clusters
 #   PCSM_SOURCE_URI  source cluster URI
 #   PCSM_TARGET_URI  target cluster URI
+#
+# PCSM APIs have no authentication; publish them on loopback only.
 
 x-pcsm-common: &pcsm-common
   image: pcsm:dev
@@ -28,7 +30,7 @@ services:
     hostname: pcsm0
     command: ["--port", "2242"]
     ports:
-      - "2242:2242"
+      - "127.0.0.1:2242:2242"
 
   pcsm1:
     <<: *pcsm-common
@@ -36,7 +38,7 @@ services:
     hostname: pcsm1
     command: ["--port", "2243"]
     ports:
-      - "2243:2243"
+      - "127.0.0.1:2243:2243"
 
   pcsm2:
     <<: *pcsm-common
@@ -44,7 +46,7 @@ services:
     hostname: pcsm2
     command: ["--port", "2244"]
     ports:
-      - "2244:2244"
+      - "127.0.0.1:2244:2244"
 
 networks:
   clusters:

--- a/hack/ha/compose.yml
+++ b/hack/ha/compose.yml
@@ -11,11 +11,13 @@
 #   PCSM_TARGET_URI  target cluster URI
 #
 # PCSM APIs have no authentication; publish them on loopback only.
+# Prometheus reaches each instance over the shared pcsm-metrics network.
 
 x-pcsm-common: &pcsm-common
   image: pcsm:dev
   networks:
     - clusters
+    - metrics
   environment:
     PCSM_SOURCE_URI: ${PCSM_SOURCE_URI}
     PCSM_TARGET_URI: ${PCSM_TARGET_URI}
@@ -52,3 +54,6 @@ networks:
   clusters:
     external: true
     name: ${PCSM_HA_NETWORK}
+  metrics:
+    external: true
+    name: pcsm-metrics

--- a/hack/ha/run.sh
+++ b/hack/ha/run.sh
@@ -10,7 +10,7 @@
 #
 # The instances join the cluster's Docker network and reach it via the same
 # hostnames the host uses (rs00, src-mongos, ...). API ports 2242-2244 are
-# published to the host, so `pcsm <cmd> --port 2242` and curl work from the host.
+# published on host loopback, while Prometheus scrapes them over pcsm-metrics.
 
 set -euo pipefail
 
@@ -52,6 +52,12 @@ if ! docker network inspect "$NETWORK" >/dev/null 2>&1; then
     exit 1
 fi
 
+METRICS_NETWORK="pcsm-metrics"
+if ! docker network inspect "$METRICS_NETWORK" >/dev/null 2>&1; then
+    echo "Creating shared metrics network '$METRICS_NETWORK'..."
+    docker network create "$METRICS_NETWORK" >/dev/null
+fi
+
 export PCSM_HA_NETWORK="$NETWORK"
 export PCSM_SOURCE_URI="$SOURCE_URI"
 export PCSM_TARGET_URI="$TARGET_URI"
@@ -69,7 +75,7 @@ if [[ "$RESET" == "true" ]]; then
     docker run --rm --network "$NETWORK" pcsm:dev reset --target "$TARGET_URI"
 fi
 
-echo "Starting HA group (source=$SOURCE_URI target=$TARGET_URI network=$NETWORK)..."
+echo "Starting HA group (source=$SOURCE_URI target=$TARGET_URI network=$NETWORK metrics=$METRICS_NETWORK)..."
 docker compose -f "$COMPOSE" up -d
 
 echo

--- a/hack/metrics/docker-compose.yml
+++ b/hack/metrics/docker-compose.yml
@@ -1,3 +1,4 @@
+# Grafana grants anonymous Admin access; publish monitoring ports on loopback only.
 services:
   prometheus:
     image: prom/prometheus:latest
@@ -5,7 +6,7 @@ services:
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
     ports:
-      - "9090:9090"
+      - "127.0.0.1:9090:9090"
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
@@ -21,6 +22,6 @@ services:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     depends_on:
       - prometheus

--- a/hack/metrics/docker-compose.yml
+++ b/hack/metrics/docker-compose.yml
@@ -7,8 +7,9 @@ services:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
     ports:
       - "127.0.0.1:9090:9090"
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+    networks:
+      - default
+      - metrics
 
   grafana:
     image: grafana/grafana:latest
@@ -25,3 +26,8 @@ services:
       - "127.0.0.1:3000:3000"
     depends_on:
       - prometheus
+
+networks:
+  metrics:
+    external: true
+    name: pcsm-metrics

--- a/hack/metrics/prometheus.yml
+++ b/hack/metrics/prometheus.yml
@@ -5,11 +5,10 @@ global:
 scrape_configs:
   - job_name: "pcsm"
     static_configs:
-      # All PCSM HA instances are scraped. Every instance serves /metrics on all
-      # roles; the ACTIVE one drives replication metrics, STANDBYs export their
-      # HA state (ha_active=0). Extra targets that are down (single-instance
-      # deployments) simply show as "down" in Prometheus and are harmless.
+      # HA instances share the pcsm-metrics network with Prometheus and are
+      # reached through Docker DNS because their published API ports are
+      # loopback-only. Targets show as down until the HA group starts.
       - targets:
-          - "host.docker.internal:2242" # default pcsm port (hack/ha pcsm0)
-          - "host.docker.internal:2243" # hack/ha pcsm1
-          - "host.docker.internal:2244" # hack/ha pcsm2
+          - "pcsm0:2242"
+          - "pcsm1:2243"
+          - "pcsm2:2244"

--- a/hack/rs/compose.yml
+++ b/hack/rs/compose.yml
@@ -1,3 +1,4 @@
+# Local test clusters run without authentication; publish ports on loopback only.
 services:
   rs00:
     image: "percona/percona-server-mongodb:${SRC_MONGO_VERSION:-${MONGO_VERSION:-8.0}}"
@@ -11,7 +12,7 @@ services:
       # Overrides image's glibc.pthread.rseq=0 — that tunable alone does NOT fix this.
       - GLIBC_TUNABLES=glibc.cpu.hwcaps=-SHSTK
       - PERCONA_TELEMETRY_DISABLE=1
-    ports: ["30000:30000"]
+    ports: ["127.0.0.1:30000:30000"]
     volumes: ["rs00:/data/db", "./mongo/:/cfg:ro"]
     # Test harness only: PCSM-322 needs failpoints on source RS members.
     # Deliberately excluded from target RS members and sharded topology.
@@ -33,7 +34,7 @@ services:
     environment:
       - GLIBC_TUNABLES=glibc.cpu.hwcaps=-SHSTK
       - PERCONA_TELEMETRY_DISABLE=1
-    ports: ["30001:30001"]
+    ports: ["127.0.0.1:30001:30001"]
     volumes: ["rs01:/data/db", "./mongo/:/cfg:ro"]
     command:
       [
@@ -53,7 +54,7 @@ services:
     environment:
       - GLIBC_TUNABLES=glibc.cpu.hwcaps=-SHSTK
       - PERCONA_TELEMETRY_DISABLE=1
-    ports: ["30002:30002"]
+    ports: ["127.0.0.1:30002:30002"]
     volumes: ["rs02:/data/db", "./mongo/:/cfg:ro"]
     command:
       [
@@ -73,7 +74,7 @@ services:
     environment:
       - GLIBC_TUNABLES=glibc.cpu.hwcaps=-SHSTK
       - PERCONA_TELEMETRY_DISABLE=1
-    ports: ["30100:30100"]
+    ports: ["127.0.0.1:30100:30100"]
     volumes: ["rs10:/data/db", "./mongo/:/cfg:ro"]
     command:
       [
@@ -92,7 +93,7 @@ services:
     environment:
       - GLIBC_TUNABLES=glibc.cpu.hwcaps=-SHSTK
       - PERCONA_TELEMETRY_DISABLE=1
-    ports: ["30101:30101"]
+    ports: ["127.0.0.1:30101:30101"]
     volumes: ["rs11:/data/db", "./mongo/:/cfg:ro"]
     command:
       [
@@ -111,7 +112,7 @@ services:
     environment:
       - GLIBC_TUNABLES=glibc.cpu.hwcaps=-SHSTK
       - PERCONA_TELEMETRY_DISABLE=1
-    ports: ["30102:30102"]
+    ports: ["127.0.0.1:30102:30102"]
     volumes: ["rs12:/data/db", "./mongo/:/cfg:ro"]
     command:
       [

--- a/hack/sh/compose.yml
+++ b/hack/sh/compose.yml
@@ -1,3 +1,4 @@
+# Local test clusters run without authentication; publish ports on loopback only.
 services:
 
   # ----------------- Source -----------------
@@ -12,7 +13,7 @@ services:
       # due to C++ coroutine stack pivoting triggering hardware CET trap (MongoDB BugID 3392546).
       - GLIBC_TUNABLES=glibc.cpu.hwcaps=-SHSTK
       - PERCONA_TELEMETRY_DISABLE=1
-    ports: ["27017:27017"]
+    ports: ["127.0.0.1:27017:27017"]
     volumes: ["./mongo/:/cfg:ro"]
     command:
       [
@@ -32,7 +33,7 @@ services:
     environment:
       - GLIBC_TUNABLES=glibc.cpu.hwcaps=-SHSTK
       - PERCONA_TELEMETRY_DISABLE=1
-    ports: ["27000:27000"]
+    ports: ["127.0.0.1:27000:27000"]
     volumes: ["src-cfg0:/data/db", "./mongo/:/cfg:ro"]
     command:
       [
@@ -54,7 +55,7 @@ services:
     environment:
       - GLIBC_TUNABLES=glibc.cpu.hwcaps=-SHSTK
       - PERCONA_TELEMETRY_DISABLE=1
-    ports: ["30000:30000"]
+    ports: ["127.0.0.1:30000:30000"]
     volumes: ["src-rs00:/data/db", "./mongo/:/cfg:ro"]
     command:
       [
@@ -76,7 +77,7 @@ services:
     environment:
       - GLIBC_TUNABLES=glibc.cpu.hwcaps=-SHSTK
       - PERCONA_TELEMETRY_DISABLE=1
-    ports: ["30100:30100"]
+    ports: ["127.0.0.1:30100:30100"]
     volumes: ["src-rs10:/data/db", "./mongo/:/cfg:ro"]
     command:
       [
@@ -98,7 +99,7 @@ services:
     environment:
       - GLIBC_TUNABLES=glibc.cpu.hwcaps=-SHSTK
       - PERCONA_TELEMETRY_DISABLE=1
-    ports: ["30200:30200"]
+    ports: ["127.0.0.1:30200:30200"]
     volumes: ["src-rs20:/data/db", "./mongo/:/cfg:ro"]
     command:
       [
@@ -121,7 +122,7 @@ services:
     environment:
       - GLIBC_TUNABLES=glibc.cpu.hwcaps=-SHSTK
       - PERCONA_TELEMETRY_DISABLE=1
-    ports: ["29017:27017"]
+    ports: ["127.0.0.1:29017:27017"]
     volumes: ["./mongo/:/cfg:ro"]
     command:
       [
@@ -141,7 +142,7 @@ services:
     environment:
       - GLIBC_TUNABLES=glibc.cpu.hwcaps=-SHSTK
       - PERCONA_TELEMETRY_DISABLE=1
-    ports: ["28000:28000"]
+    ports: ["127.0.0.1:28000:28000"]
     volumes: ["tgt-cfg0:/data/db", "./mongo/:/cfg:ro"]
     command:
       [
@@ -163,7 +164,7 @@ services:
     environment:
       - GLIBC_TUNABLES=glibc.cpu.hwcaps=-SHSTK
       - PERCONA_TELEMETRY_DISABLE=1
-    ports: ["40000:40000"]
+    ports: ["127.0.0.1:40000:40000"]
     volumes: ["tgt-rs00:/data/db", "./mongo/:/cfg:ro"]
     command:
       [
@@ -185,7 +186,7 @@ services:
     environment:
       - GLIBC_TUNABLES=glibc.cpu.hwcaps=-SHSTK
       - PERCONA_TELEMETRY_DISABLE=1
-    ports: ["40100:40100"]
+    ports: ["127.0.0.1:40100:40100"]
     volumes: ["tgt-rs10:/data/db", "./mongo/:/cfg:ro"]
     command:
       [
@@ -207,7 +208,7 @@ services:
     environment:
       - GLIBC_TUNABLES=glibc.cpu.hwcaps=-SHSTK
       - PERCONA_TELEMETRY_DISABLE=1
-    ports: ["40200:40200"]
+    ports: ["127.0.0.1:40200:40200"]
     volumes: ["tgt-rs20:/data/db", "./mongo/:/cfg:ro"]
     command:
       [


### PR DESCRIPTION
## Problem

This stemmed from preparing a presentation to demo PCSM. While setting up the demo, I noticed the local Compose stacks publish unauthenticated MongoDB and PCSM API ports on every host interface. Prometheus and Grafana were exposed too, with Grafana allowing anonymous Admin access.

Binding those ports to loopback breaks the existing HA metrics path through `host.docker.internal`, since containers cannot reach host ports published only on loopback.

## Solution

Bind all 21 published ports to `127.0.0.1`. Prometheus now joins a shared `pcsm-metrics` network and scrapes `pcsm0`, `pcsm1`, and `pcsm2` through Docker DNS. Grafana stays on the private Compose network. Both HA-first and metrics-first startup orders work.

## Verification

- all 21 rendered port mappings use `host_ip: 127.0.0.1`
- all three HA Prometheus targets are healthy in both startup orders
- Grafana datasource works while Grafana remains isolated from the PCSM API network
- loopback connections succeed and LAN-interface connections are refused
- full CI suite passes, including RS and sharded E2E matrices