### PR TITLE
PCSM-356: Simplify hack script usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,11 +22,7 @@ The MongoDB containers use hostnames that must resolve on the host. Add these en
 - Go 1.25.0+
 - Python 3.13+ and [Poetry](https://python-poetry.org/) (for E2E tests and monitoring scripts)
 
-Install Python dependencies:
-
-```bash
-poetry install
-```
+Follow the [Python E2E test requirements](CONTRIBUTING.md#python-e2e-tests) to install dependencies and activate the project environment before running `hack/*.py` with `python`.
 
 If `poetry run` fails with a "bad interpreter" error (e.g. after a Python version change), use the virtualenv directly: `.venv/bin/pytest` instead of `poetry run pytest`.
 
@@ -490,15 +486,15 @@ Note: local `make pytest` and the GitHub Actions matrix do not cover identical s
 ### Change Stream Watcher
 
 ```bash
-poetry run python hack/change_stream.py -u "mongodb://src-mongos:27017"
-poetry run python hack/change_stream.py -u "mongodb://tgt-mongos:29017" --show-checkpoints
-poetry run python hack/change_stream.py -u "mongodb://rs00:30000"
+hack/change_stream.py -u "mongodb://src-mongos:27017"
+hack/change_stream.py -u "mongodb://tgt-mongos:29017" --show-checkpoints
+hack/change_stream.py -u "mongodb://rs00:30000"
 ```
 
 ### Write Operations Monitor
 
 ```bash
-poetry run python hack/monitor_writes.py -u "mongodb://src-mongos:27017"
+hack/monitor_writes.py -u "mongodb://src-mongos:27017"
 ```
 
 ### Metrics Stack

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,10 +157,12 @@ Python E2E tests require MongoDB clusters to be running and PCSM to be available
 - Python 3.13 or above
 - [Poetry](https://python-poetry.org/docs/#installation) for dependency management
 
-Install the Python dependencies:
+Install the Python dependencies and activate the project environment before executing
+`hack/*.py` directly:
 
 ```sh
 poetry install
+eval "$(poetry env activate)"
 ```
 
 #### 1. Deploy MongoDB clusters and run PCSM

--- a/hack/change_stream.py
+++ b/hack/change_stream.py
@@ -6,11 +6,12 @@ Watches MongoDB change stream and prints events in a compact JSON format.
 Useful for debugging and monitoring replication.
 
 Usage:
-    python hack/change_stream.py -u "mongodb://localhost:27017"
-    python hack/change_stream.py --uri "mongodb://rs00:30000" --show-checkpoints
+    export MONGO_URI="mongodb://localhost:27017"
+    hack/change_stream.py
+    MONGO_URI="mongodb://rs00:30000" hack/change_stream.py --show-checkpoints
 
 Options:
-    -u, --uri               MongoDB connection string (required)
+    -u, --uri               MongoDB connection string (default: $MONGO_URI)
     --show-checkpoints      Include PCSM checkpoint events (default: hidden)
 """
 
@@ -19,6 +20,7 @@ from signal import SIG_DFL, SIGINT, signal
 
 import bson.json_util as json
 import pymongo
+from mongo_uri import redact_uri, resolve_uri
 
 
 def parse_args():
@@ -27,11 +29,17 @@ def parse_args():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-    python hack/change_stream.py -u "mongodb://localhost:27017"
-    python hack/change_stream.py --uri "mongodb://rs00:30000" --show-checkpoints
+    MONGO_URI="mongodb://localhost:27017" hack/change_stream.py
+    MONGO_URI="mongodb://rs00:30000" hack/change_stream.py --show-checkpoints
         """,
     )
-    parser.add_argument("-u", "--uri", type=str, required=True, help="MongoDB connection string")
+    parser.add_argument(
+        "-u",
+        "--uri",
+        type=str,
+        default=None,
+        help="MongoDB connection string (default: $MONGO_URI)",
+    )
     parser.add_argument(
         "--show-checkpoints",
         action="store_true",
@@ -44,15 +52,16 @@ if __name__ == "__main__":
     signal(SIGINT, SIG_DFL)
 
     args = parse_args()
+    uri = resolve_uri(args.uri)
 
     print()
     print("PCSM Change Stream Watcher")
     print("=" * 45)
-    print(f"URI:                {args.uri}")
+    print(f"URI:                {redact_uri(uri)}")
     print(f"Show checkpoints:   {args.show_checkpoints}")
     print()
 
-    m = pymongo.MongoClient(args.uri)
+    m = pymongo.MongoClient(uri)
     for change in m.watch(show_expanded_events=True):
         del change["_id"]
         del change["wallTime"]

--- a/hack/compare-all.py
+++ b/hack/compare-all.py
@@ -5,33 +5,35 @@ Compare all databases and collections between source and target MongoDB clusters
 Compares databases, collections, indexes, collection options, document counts,
 and content hashes to verify data consistency between clusters.
 
+Reports every mismatch it finds and exits non-zero, instead of stopping at the
+first difference.
+
 Usage:
-    python hack/compare-all.py
+    hack/compare-all.py
+    SKIP_DBS=db_live hack/compare-all.py
 
 Environment variables:
-    SRC_URI  MongoDB connection string for source (default: mongodb://src-mongos:27017)
-    TGT_URI  MongoDB connection string for target (default: mongodb://tgt-mongos:29017)
+    SRC_URI   MongoDB connection string for source (default: mongodb://src-mongos:27017)
+    TGT_URI   MongoDB connection string for target (default: mongodb://tgt-mongos:29017)
+    SKIP_DBS  Comma-separated database names to exclude from the comparison
 """
 
+import argparse
 import hashlib
 import os
+import sys
 
 import bson
-import pymongo
 from pymongo import ASCENDING, MongoClient
 from pymongo.collection import Collection
 
-SRC_URI = os.environ.get("SRC_URI", "mongodb://src-mongos:27017")
-TGT_URI = os.environ.get("TGT_URI", "mongodb://tgt-mongos:29017")
-
-src = pymongo.MongoClient(SRC_URI)
-tgt = pymongo.MongoClient(TGT_URI)
+INTERNAL_DBS = frozenset(("admin", "config", "local", "percona_clustersync_mongodb"))
 
 
-def list_databases(client: MongoClient):
+def list_databases(client: MongoClient, skip_dbs: set[str] | frozenset[str]):
     """List all databases in the given MongoClient."""
     for name in client.list_database_names():
-        if name not in ("admin", "config", "local", "percona_clustersync_mongodb"):
+        if name not in skip_dbs:
             yield name
 
 
@@ -42,9 +44,9 @@ def list_collections(client: MongoClient, db: str):
             yield name
 
 
-def list_all_namespaces(client: MongoClient):
+def list_all_namespaces(client: MongoClient, skip_dbs: set[str] | frozenset[str]):
     """Return all namespaces in the target MongoDB."""
-    for db in list_databases(client):
+    for db in list_databases(client, skip_dbs):
         for coll in list_collections(client, db):
             yield f"{db}.{coll}"
 
@@ -61,40 +63,100 @@ def _coll_content(coll: Collection, sort=None):
     return count, md5.hexdigest()
 
 
-def compare_namespace(source: MongoClient, target: MongoClient, db: str, coll: str, sort=None):
-    """Compare the given namespace between source and target MongoDB."""
+def compare_namespace(
+    source: MongoClient, target: MongoClient, db: str, coll: str, sort=None
+) -> list[str]:
+    """Compare the given namespace between source and target MongoDB.
+
+    Returns one line per mismatch. An empty list means the namespace matches.
+    """
     ns = f"{db}.{coll}"
+    mismatches = []
 
     source_options = source[db][coll].options()
     target_options = target[db][coll].options()
-    assert source_options == target_options, f"{ns}: {source_options=} != {target_options=}"
+    if source_options != target_options:
+        mismatches.append(f"MISMATCH {ns}: options {source_options} vs {target_options}")
 
     if "viewOn" not in source_options:
         source_indexes = source[db][coll].index_information()
         target_indexes = target[db][coll].index_information()
-        assert source_indexes == target_indexes, f"{ns}: {source_indexes=} != {target_indexes=}"
+        if source_indexes != target_indexes:
+            mismatches.append(f"MISMATCH {ns}: indexes {source_indexes} vs {target_indexes}")
 
     source_count, source_hash = _coll_content(source[db][coll], sort)
     target_count, target_hash = _coll_content(target[db][coll], sort)
-    assert source_count == target_count, f"{ns}: {source_count=} != {target_count=}"
-    assert source_hash == target_hash, f"{ns}: {source_hash=} != {target_hash=}"
+    if source_count != target_count:
+        mismatches.append(f"MISMATCH {ns}: count {source_count} vs {target_count}")
+    if source_hash != target_hash:
+        mismatches.append(f"MISMATCH {ns}: content hash {source_hash} vs {target_hash}")
+
+    return mismatches
 
 
-# Main ===========================================================================
+def compare_clusters(
+    source: MongoClient,
+    target: MongoClient,
+    skip_dbs: set[str] | frozenset[str],
+) -> list[str]:
+    """Compare source and target clusters and return every mismatch."""
+    failures: list[str] = []
+    source_dbs = set(list_databases(source, skip_dbs))
+    target_dbs = set(list_databases(target, skip_dbs))
 
-sort = None
+    failures += [
+        f"MISMATCH {db}: database missing on target" for db in sorted(source_dbs - target_dbs)
+    ]
+    failures += [
+        f"MISMATCH {db}: database missing on source" for db in sorted(target_dbs - source_dbs)
+    ]
 
-source_dbs = set(list_databases(src))
-target_dbs = set(list_databases(tgt))
-assert source_dbs == target_dbs, f"{source_dbs} != {target_dbs}"
+    for db in sorted(source_dbs & target_dbs):
+        source_colls = set(list_collections(source, db))
+        target_colls = set(list_collections(target, db))
 
-for db in source_dbs:
-    print(f"Comparing {db}...")
-    source_colls = set(list_collections(src, db))
-    target_colls = set(list_collections(tgt, db))
-    print(f"  {db}: {source_colls} vs {target_colls}")
-    assert source_colls == target_colls, f"{db} :: {source_colls} != {target_colls}"
+        failures += [
+            f"MISMATCH {db}.{coll}: collection missing on target"
+            for coll in sorted(source_colls - target_colls)
+        ]
+        failures += [
+            f"MISMATCH {db}.{coll}: collection missing on source"
+            for coll in sorted(target_colls - source_colls)
+        ]
 
-    for coll in source_colls:
-        print(f"  Comparing {db}.{coll}...")
-        compare_namespace(src, tgt, db, coll, sort)
+        for coll in sorted(source_colls & target_colls):
+            print(f"Comparing {db}.{coll}...")
+            failures += compare_namespace(source, target, db, coll)
+
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[1])
+    parser.parse_args()
+
+    excluded_dbs = {
+        name.strip() for name in os.environ.get("SKIP_DBS", "").split(",") if name.strip()
+    }
+    skip_dbs = INTERNAL_DBS | excluded_dbs
+
+    if excluded_dbs:
+        print(f"Skipping databases: {', '.join(sorted(excluded_dbs))}\n")
+
+    source = MongoClient(os.environ.get("SRC_URI", "mongodb://src-mongos:27017"))
+    target = MongoClient(os.environ.get("TGT_URI", "mongodb://tgt-mongos:29017"))
+    failures = compare_clusters(source, target, skip_dbs)
+
+    if failures:
+        print()
+        for line in failures:
+            print(line)
+        print(f"\nFAILED: {len(failures)} mismatch(es)")
+        return 1
+
+    print("\nOK: source and target match")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hack/compare-all.py
+++ b/hack/compare-all.py
@@ -78,7 +78,7 @@ def compare_namespace(
     if source_options != target_options:
         mismatches.append(f"MISMATCH {ns}: options {source_options} vs {target_options}")
 
-    if "viewOn" not in source_options:
+    if "viewOn" not in source_options and "viewOn" not in target_options:
         source_indexes = source[db][coll].index_information()
         target_indexes = target[db][coll].index_information()
         if source_indexes != target_indexes:

--- a/hack/demo_writer.py
+++ b/hack/demo_writer.py
@@ -44,7 +44,6 @@ Environment variables:
 import argparse
 import os
 import random
-import signal
 import sys
 import threading
 import time
@@ -123,7 +122,12 @@ Environment variables:
         default=os.environ.get("TARGET_LABEL", "TARGET"),
         help="Label shown for the target cluster (default: $TARGET_LABEL or TARGET)",
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.rate <= 0:
+        parser.error("--rate must be greater than 0")
+    if args.doc_size < BASE_DOC_SIZE:
+        parser.error(f"--doc-size must be at least {BASE_DOC_SIZE} bytes")
+    return args
 
 
 def resolve_cluster_uri(name: str, *env_vars: str) -> str:
@@ -161,6 +165,7 @@ class DemoWriter:
 
         self.seq = 0
         self.ids = deque(maxlen=ID_BUFFER_SIZE)
+        self.last_ack_at = None
         self.t0 = None
         self.t1 = None
 
@@ -235,15 +240,17 @@ class DemoWriter:
         while not self._stop:
             if self._pause:
                 if not self._paused_signal.is_set():
-                    self.t0 = time.monotonic()
+                    self.t0 = self.last_ack_at if self.last_ack_at is not None else time.monotonic()
                     self._paused_signal.set()
                 time.sleep(0.02)
                 continue
 
             acked = self._do_op()
-            if acked and self._await_resume and not self._resumed_signal.is_set():
-                self.t1 = time.monotonic()
-                self._resumed_signal.set()
+            if acked:
+                self.last_ack_at = time.monotonic()
+                if self._await_resume and not self._resumed_signal.is_set():
+                    self.t1 = self.last_ack_at
+                    self._resumed_signal.set()
 
             time.sleep(self.interval)
 
@@ -382,8 +389,6 @@ def main():
 
     writer = DemoWriter(source, target, args)
     ticker = PauseTicker()
-
-    signal.signal(signal.SIGINT, lambda signum, frame: writer.stop())
 
     print("PCSM Demo Writer")
     print(f"  source:     {args.source_label}")

--- a/hack/demo_writer.py
+++ b/hack/demo_writer.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+"""
+PCSM Demo Writer
+
+Continuous application-style write load for a live migration demo. Writes a mix of
+inserts, updates and deletes into a single namespace, and can be paused, repointed
+from the source cluster to the target cluster, and resumed with a single command.
+
+The pause/repoint/resume sequence measures the application write gap during
+cutover: the stopwatch starts once the last write to the source is acknowledged
+and stops once the first write to the target is acknowledged.
+
+Connection strings are read from the environment and never printed: the output
+shows cluster labels only.
+
+Usage:
+    export SOURCE_URI="mongodb+srv://..."   # or SRC_URI
+    export TARGET_URI="mongodb://..."       # or TGT_URI
+    hack/demo_writer.py --source-label atlas-m20 --target-label psmdb-rs
+
+Commands (type and press Enter):
+    pause      stop writing, start the stopwatch
+    repoint    switch to the target cluster (only while paused)
+    resume     start writing again, stop the stopwatch
+    status     print the current state
+    quit       stop the writer and exit
+
+Options:
+    -r, --rate          Operations per second (default: 2)
+    --database          Database to write to (default: db_live)
+    --collection        Collection to write to (default: collection_0)
+    --doc-size          Target document size in bytes (default: 5120)
+    --seed              Random seed for document generation (default: 42)
+    --source-label      Label shown for the source cluster (default: $SOURCE_LABEL or SOURCE)
+    --target-label      Label shown for the target cluster (default: $TARGET_LABEL or TARGET)
+
+Environment variables:
+    SOURCE_URI / SRC_URI   MongoDB connection string for the source cluster
+    TARGET_URI / TGT_URI   MongoDB connection string for the target cluster
+    SOURCE_LABEL           Default label for the source cluster
+    TARGET_LABEL           Default label for the target cluster
+"""
+
+import argparse
+import os
+import random
+import signal
+import sys
+import threading
+import time
+from collections import deque
+from datetime import UTC, datetime
+
+import pymongo
+from generator import BASE_DOC_SIZE, DEFAULT_DOC_SIZE, DEFAULT_SEED, generate_document
+from pymongo.errors import PyMongoError
+
+DEFAULT_DATABASE = "db_live"
+DEFAULT_COLLECTION = "collection_0"
+DEFAULT_RATE = 2.0
+ID_BUFFER_SIZE = 500
+PAUSE_TICK_INTERVAL = 5
+OP_KINDS = ["insert", "update", "delete"]
+OP_WEIGHTS = [70, 20, 10]
+STATUSES = ["active", "pending", "archived"]
+ACK_TIMEOUT = 30
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="PCSM Demo Writer - pausable, repointable write load",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+    hack/demo_writer.py
+    hack/demo_writer.py -r 5 --source-label atlas-m20 --target-label psmdb-rs
+
+Environment variables:
+    SOURCE_URI / SRC_URI   MongoDB connection string for the source cluster
+    TARGET_URI / TGT_URI   MongoDB connection string for the target cluster
+        """,
+    )
+    parser.add_argument(
+        "-r",
+        "--rate",
+        type=float,
+        default=DEFAULT_RATE,
+        help=f"Operations per second (default: {DEFAULT_RATE})",
+    )
+    parser.add_argument(
+        "--database",
+        type=str,
+        default=DEFAULT_DATABASE,
+        help=f"Database to write to (default: {DEFAULT_DATABASE})",
+    )
+    parser.add_argument(
+        "--collection",
+        type=str,
+        default=DEFAULT_COLLECTION,
+        help=f"Collection to write to (default: {DEFAULT_COLLECTION})",
+    )
+    parser.add_argument(
+        "--doc-size",
+        type=int,
+        default=DEFAULT_DOC_SIZE,
+        help=f"Target document size in bytes (default: {DEFAULT_DOC_SIZE})",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=DEFAULT_SEED,
+        help=f"Random seed for document generation (default: {DEFAULT_SEED})",
+    )
+    parser.add_argument(
+        "--source-label",
+        type=str,
+        default=os.environ.get("SOURCE_LABEL", "SOURCE"),
+        help="Label shown for the source cluster (default: $SOURCE_LABEL or SOURCE)",
+    )
+    parser.add_argument(
+        "--target-label",
+        type=str,
+        default=os.environ.get("TARGET_LABEL", "TARGET"),
+        help="Label shown for the target cluster (default: $TARGET_LABEL or TARGET)",
+    )
+    return parser.parse_args()
+
+
+def resolve_cluster_uri(name: str, *env_vars: str) -> str:
+    """Return the first connection string set in the given environment variables."""
+    for var in env_vars:
+        value = os.environ.get(var)
+        if value:
+            return value
+
+    print(f"ERROR: no {name} URI: set {' or '.join(env_vars)}")
+    sys.exit(1)
+
+
+def timestamp() -> str:
+    """Wall clock timestamp with millisecond precision."""
+    return datetime.now().strftime("%H:%M:%S.%f")[:-3]
+
+
+class DemoWriter:
+    """Single-threaded write loop with pause, repoint and resume controls."""
+
+    def __init__(self, source, target, args):
+        self.source = source
+        self.target = target
+        self.client = source
+        self.side = "source"
+        self.labels = {"source": args.source_label, "target": args.target_label}
+
+        self.database = args.database
+        self.collection = args.collection
+        self.namespace = f"{args.database}.{args.collection}"
+        self.interval = 1.0 / args.rate
+        self.seed = args.seed
+        self.padding = max(0, args.doc_size - BASE_DOC_SIZE)
+
+        self.seq = 0
+        self.ids = deque(maxlen=ID_BUFFER_SIZE)
+        self.t0 = None
+        self.t1 = None
+
+        self._pause = False
+        self._stop = False
+        self._await_resume = False
+        self._paused_signal = threading.Event()
+        self._resumed_signal = threading.Event()
+
+    # Write loop ---------------------------------------------------------------
+
+    @property
+    def label(self) -> str:
+        return self.labels[self.side]
+
+    def _coll(self):
+        return self.client[self.database][self.collection]
+
+    def _log(self, op: str, seq: int) -> None:
+        print(f"{timestamp()}  {self.label:<12} {op:<6}  {self.namespace}  seq={seq}")
+
+    def _insert(self) -> int:
+        self.seq += 1
+        doc = generate_document(self.seq, self.seed, self.padding)
+        doc["written_at"] = datetime.now(UTC)
+        doc["metadata"]["source"] = "demo"
+        self._coll().insert_one(doc)
+        self.ids.append(doc["_id"])
+        return self.seq
+
+    def _update(self) -> None:
+        doc_id = random.choice(self.ids)
+        result = self._coll().update_one(
+            {"_id": doc_id},
+            {
+                "$set": {
+                    "status": random.choice(STATUSES),
+                    "written_at": datetime.now(UTC),
+                }
+            },
+        )
+        if result.matched_count == 0:
+            self.ids.remove(doc_id)
+
+    def _delete(self) -> None:
+        doc_id = random.choice(self.ids)
+        self._coll().delete_one({"_id": doc_id})
+        self.ids.remove(doc_id)
+
+    def _do_op(self) -> bool:
+        op = random.choices(OP_KINDS, weights=OP_WEIGHTS)[0]
+        if op != "insert" and not self.ids:
+            op = "insert"
+
+        try:
+            if op == "insert":
+                self._log(op, self._insert())
+            elif op == "update":
+                self._update()
+                self._log(op, self.seq)
+            else:
+                self._delete()
+                self._log(op, self.seq)
+        except PyMongoError as e:
+            print(f"{timestamp()}  {self.label:<12} ERROR  {op}: {type(e).__name__}")
+            return False
+
+        return True
+
+    def run(self) -> None:
+        """Write loop. Runs on its own thread until stop() is called."""
+        while not self._stop:
+            if self._pause:
+                if not self._paused_signal.is_set():
+                    self.t0 = time.monotonic()
+                    self._paused_signal.set()
+                time.sleep(0.02)
+                continue
+
+            acked = self._do_op()
+            if acked and self._await_resume and not self._resumed_signal.is_set():
+                self.t1 = time.monotonic()
+                self._resumed_signal.set()
+
+            time.sleep(self.interval)
+
+    # Controls -----------------------------------------------------------------
+
+    def pause(self) -> None:
+        """Stop writing and start the stopwatch once the last write is acknowledged."""
+        self._paused_signal.clear()
+        self._pause = True
+        if not self._paused_signal.wait(timeout=ACK_TIMEOUT):
+            raise TimeoutError("writer did not acknowledge pause")
+
+    def repoint(self) -> None:
+        """Switch to the target cluster. Only swaps after the target answers a ping."""
+        self.target.admin.command("ping")
+        self.client = self.target
+        self.side = "target"
+
+    def resume(self) -> float:
+        """Start writing again and stop the stopwatch on the first acknowledged write."""
+        self._await_resume = True
+        self._resumed_signal.clear()
+        self._pause = False
+        if not self._resumed_signal.wait(timeout=ACK_TIMEOUT):
+            raise TimeoutError("writer did not acknowledge resume")
+
+        self._await_resume = False
+        if self.t0 is None or self.t1 is None:
+            raise RuntimeError("writer stopwatch is incomplete")
+        return self.t1 - self.t0
+
+    def stop(self) -> None:
+        self._stop = True
+        self._pause = False
+
+
+class PauseTicker:
+    """Prints how long writes have been paused, once every PAUSE_TICK_INTERVAL seconds."""
+
+    def __init__(self):
+        self._stop = threading.Event()
+        self._thread = None
+
+    def start(self) -> None:
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def _run(self) -> None:
+        started = time.monotonic()
+        while not self._stop.wait(PAUSE_TICK_INTERVAL):
+            print(f"{timestamp()}  ... writes paused for {time.monotonic() - started:.0f}s")
+
+    def stop(self) -> None:
+        self._stop.set()
+
+
+HELP = """Commands: pause | repoint | resume | status | quit"""
+
+
+def handle_command(command: str, writer: DemoWriter, ticker: PauseTicker) -> bool:
+    """Run one command. Returns False when the writer should exit."""
+    if command in ("quit", "exit"):
+        return False
+
+    if command == "status":
+        state = "PAUSED" if writer._pause else "WRITING"
+        print(
+            f"  {state}  side={writer.label}  namespace={writer.namespace}  "
+            f"seq={writer.seq}  buffered_ids={len(writer.ids)}"
+        )
+        return True
+
+    if command == "pause":
+        if writer._pause:
+            print("  REJECTED: already paused")
+            return True
+        writer.pause()
+        print(f"\n  WRITES PAUSED on {writer.label} - stopwatch running\n")
+        ticker.start()
+        return True
+
+    if command == "repoint":
+        if not writer._pause:
+            print("  REJECTED: pause before repointing")
+            return True
+        if writer.side == "target":
+            print(f"  REJECTED: already writing to {writer.label}")
+            return True
+        try:
+            writer.repoint()
+        except PyMongoError as e:
+            print(f"  REJECTED: target did not answer ping: {type(e).__name__}")
+            return True
+        print(f"  REPOINT -> {writer.label}  ping ok")
+        return True
+
+    if command == "resume":
+        if not writer._pause:
+            print("  REJECTED: not paused")
+            return True
+        elapsed = writer.resume()
+        ticker.stop()
+        print("")
+        print("  " + "=" * 46)
+        print(f"  APPLICATION WRITES PAUSED FOR  {elapsed:.3f} s")
+        print("  " + "=" * 46)
+        print(f"  now writing to {writer.label}\n")
+        return True
+
+    print(f"  unknown command: {command!r}")
+    print(f"  {HELP}")
+    return True
+
+
+def main():
+    args = parse_args()
+
+    source_uri = resolve_cluster_uri("source", "SOURCE_URI", "SRC_URI")
+    target_uri = resolve_cluster_uri("target", "TARGET_URI", "TGT_URI")
+
+    source = None
+    target = None
+    try:
+        source = pymongo.MongoClient(source_uri)
+        source.admin.command("ping")
+        target = pymongo.MongoClient(target_uri)
+        target.admin.command("ping")
+    except PyMongoError as e:
+        if source is not None:
+            source.close()
+        if target is not None:
+            target.close()
+        print(f"ERROR: unable to connect to source or target cluster: {type(e).__name__}")
+        sys.exit(1)
+
+    writer = DemoWriter(source, target, args)
+    ticker = PauseTicker()
+
+    signal.signal(signal.SIGINT, lambda signum, frame: writer.stop())
+
+    print("PCSM Demo Writer")
+    print(f"  source:     {args.source_label}")
+    print(f"  target:     {args.target_label}")
+    print(f"  namespace:  {writer.namespace}")
+    print(f"  rate:       {args.rate} ops/s")
+    print(f"  {HELP}\n")
+
+    thread = threading.Thread(target=writer.run, daemon=True)
+    thread.start()
+
+    try:
+        while True:
+            command = input().strip().lower()
+            if not command:
+                continue
+            if not handle_command(command, writer, ticker):
+                break
+    except (EOFError, KeyboardInterrupt):
+        pass
+    finally:
+        ticker.stop()
+        writer.stop()
+        thread.join(timeout=5)
+        source.close()
+        target.close()
+        print("\nWriter stopped.")
+
+
+if __name__ == "__main__":
+    main()

--- a/hack/drop-all.py
+++ b/hack/drop-all.py
@@ -5,10 +5,10 @@ Drop all user databases from MongoDB clusters.
 Drops all databases except system databases (admin, config, local, percona_mongolink).
 
 Usage:
-    python hack/drop-all.py           # Drop from both source and target
-    python hack/drop-all.py -s        # Drop from source only
-    python hack/drop-all.py -t        # Drop from target only
-    python hack/drop-all.py -s -t     # Drop from both source and target
+    hack/drop-all.py           # Drop from both source and target
+    hack/drop-all.py -s        # Drop from source only
+    hack/drop-all.py -t        # Drop from target only
+    hack/drop-all.py -s -t     # Drop from both source and target
 
 Environment variables:
     SRC_URI  MongoDB connection string for source (default: mongodb://src-mongos:27017)

--- a/hack/generator.py
+++ b/hack/generator.py
@@ -7,14 +7,15 @@ Deterministic and reproducible - same config produces identical operation sequen
 Useful for measuring PCSM replication performance.
 
 Usage:
-    python hack/generator.py -r 100 -u "mongodb://localhost:27017"
-    python hack/generator.py -r 500 -u "mongodb://localhost:27017" -d 120 --doc-size 10240
-    python hack/generator.py -r 1000 -u "mongodb://localhost:27017" --txn-percent 20 --txn-size 5
-    python hack/generator.py -r 1000 -u "mongodb://mongos:27017" --sharded --drop
+    export MONGO_URI="mongodb://localhost:27017"
+    hack/generator.py -r 100
+    hack/generator.py -r 500 -d 120 --doc-size 10240
+    hack/generator.py -r 1000 --txn-percent 20 --txn-size 5
+    MONGO_URI="mongodb://mongos:27017" hack/generator.py -r 1000 --sharded --drop
 
 Options:
     -r, --rate              Target inserts per second (required)
-    -u, --uri               MongoDB connection string (required)
+    -u, --uri               MongoDB connection string (default: $MONGO_URI)
     -d, --duration          Duration in seconds (default: 60)
     --doc-size              Target document size in bytes (default: 5120)
     --txn-percent           Percentage of operations within transactions (0-100, default: 0)
@@ -38,6 +39,7 @@ from datetime import UTC, datetime
 import pymongo
 import pymongo.errors
 from bson import ObjectId
+from mongo_uri import redact_uri, resolve_uri
 
 # Constants for deterministic generation
 DEFAULT_SEED = 42
@@ -66,13 +68,19 @@ def parse_args():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-    python hack/generator.py --rate 100 --uri "mongodb://localhost:27017"
-    python hack/generator.py -r 500 -u "mongodb://localhost:27017" -d 60
-    python hack/generator.py -r 1000 -u "mongodb://mongos:27017" --sharded --drop
+    MONGO_URI="mongodb://localhost:27017" hack/generator.py --rate 100
+    MONGO_URI="mongodb://localhost:27017" hack/generator.py -r 500 -d 60
+    MONGO_URI="mongodb://mongos:27017" hack/generator.py -r 1000 --sharded --drop
         """,
     )
     parser.add_argument("-r", "--rate", type=int, required=True, help="Target inserts per second")
-    parser.add_argument("-u", "--uri", type=str, required=True, help="MongoDB connection string")
+    parser.add_argument(
+        "-u",
+        "--uri",
+        type=str,
+        default=None,
+        help="MongoDB connection string (default: $MONGO_URI)",
+    )
     parser.add_argument(
         "-d",
         "--duration",
@@ -451,6 +459,7 @@ def run_writer(
 
 def main():
     args = parse_args()
+    args.uri = resolve_uri(args.uri)
 
     # Setup signal handlers
     signal.signal(signal.SIGINT, signal_handler)
@@ -483,7 +492,7 @@ def main():
     print("PCSM Writer")
     print("=" * 45)
     print(f"Target rate:        {args.rate} ops/sec")
-    print(f"URI:                {args.uri}")
+    print(f"URI:                {redact_uri(args.uri)}")
     print(f"Duration:           {args.duration} seconds")
     print(f"Document size:      {args.doc_size} bytes")
     print(f"Txn percent:        {args.txn_percent}%")

--- a/hack/loader.py
+++ b/hack/loader.py
@@ -309,6 +309,22 @@ def main():
     # Calculate parameters
     params = calculate_parameters(args.size, args.databases, args.collections_per_db)
 
+    # Print configuration before any destructive or long-running work
+    print()
+    print("PCSM Source Loader")
+    print("=" * 45)
+    print(f"Target size:        {args.size} GB")
+    print(f"URI:                {redact_uri(args.uri)}")
+    print(f"Databases:          {params['num_databases']}")
+    print(f"Collections per DB: {params['collections_per_db']}")
+    print(f"Total collections:  {params['total_collections']}")
+    print(f"Total docs:         {params['total_docs']:,}")
+    print(f"Doc size:           {DOC_SIZE_BYTES:,} bytes")
+    print(f"Workers:            {args.workers}")
+    print(f"Batch size:         {args.batch_size}")
+    print(f"Sharded:            {args.sharded}")
+    print()
+
     # Connect to MongoDB
     try:
         client = pymongo.MongoClient(args.uri, serverSelectionTimeoutMS=5000)
@@ -374,21 +390,6 @@ def main():
         for f in failures:
             print(f"  {f['full_name']}: {f['error']}")
         sys.exit(1)
-
-    # Print configuration
-    print()
-    print("PCSM Source Loader")
-    print("=" * 45)
-    print(f"Target size:        {args.size} GB")
-    print(f"URI:                {redact_uri(args.uri)}")
-    print(f"Databases:          {params['num_databases']}")
-    print(f"Collections per DB: {params['collections_per_db']}")
-    print(f"Total collections:  {params['total_collections']}")
-    print(f"Total docs:         {params['total_docs']:,}")
-    print(f"Doc size:           {DOC_SIZE_BYTES:,} bytes")
-    print(f"Workers:            {args.workers}")
-    print(f"Batch size:         {args.batch_size}")
-    print(f"Sharded:            {args.sharded}")
 
     # Verification
     print()

--- a/hack/loader.py
+++ b/hack/loader.py
@@ -6,13 +6,14 @@ Loads a specified amount of data into MongoDB with deterministic,
 reproducible document generation. Docker-friendly with throttled inserts.
 
 Usage:
-    python hack/loader.py --size 10 --uri "mongodb://localhost:27017"
-    python hack/loader.py -s 5 -u "mongodb://localhost:27017" --drop
-    python hack/loader.py -s 5 -u "mongodb://mongos:27017" --sharded
+    export MONGO_URI="mongodb://localhost:27017"
+    hack/loader.py --size 10
+    hack/loader.py -s 5 --drop
+    MONGO_URI="mongodb://mongos:27017" hack/loader.py -s 5 --sharded
 
 Options:
     -s, --size              Size in GB to load (required)
-    -u, --uri               MongoDB connection string (required)
+    -u, --uri               MongoDB connection string (default: $MONGO_URI)
     --databases             Number of databases (default: 1)
     --collections-per-db    Collections per database (default: 1)
     --workers               Number of parallel workers (default: 4)
@@ -31,6 +32,7 @@ from datetime import UTC, datetime
 import pymongo
 import pymongo.errors
 from bson import ObjectId
+from mongo_uri import redact_uri, resolve_uri
 
 # Constants for deterministic generation
 SEED = 42
@@ -46,13 +48,19 @@ def parse_args():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-    python hack/loader.py --size 10 --uri "mongodb://src-mongos:27017"
-    python hack/loader.py -s 5 -u "mongodb://src-mongos:27017" --drop
-    python hack/loader.py -s 5 -u "mongodb://mongos:27017" --sharded
+    MONGO_URI="mongodb://src-mongos:27017" hack/loader.py --size 10
+    MONGO_URI="mongodb://src-mongos:27017" hack/loader.py -s 5 --drop
+    MONGO_URI="mongodb://mongos:27017" hack/loader.py -s 5 --sharded
         """,
     )
     parser.add_argument("-s", "--size", type=float, required=True, help="Size in GB to load")
-    parser.add_argument("-u", "--uri", type=str, required=True, help="MongoDB connection string")
+    parser.add_argument(
+        "-u",
+        "--uri",
+        type=str,
+        default=None,
+        help="MongoDB connection string (default: $MONGO_URI)",
+    )
     parser.add_argument(
         "--databases",
         type=int,
@@ -293,28 +301,13 @@ def format_bytes(size_bytes: float) -> str:
 
 def main():
     args = parse_args()
+    args.uri = resolve_uri(args.uri)
 
     # Set global seed for reproducibility
     random.seed(SEED)
 
     # Calculate parameters
     params = calculate_parameters(args.size, args.databases, args.collections_per_db)
-
-    # Print configuration
-    print()
-    print("PCSM Source Loader")
-    print("=" * 45)
-    print(f"Target size:        {args.size} GB")
-    print(f"URI:                {args.uri}")
-    print(f"Databases:          {params['num_databases']}")
-    print(f"Collections per DB: {params['collections_per_db']}")
-    print(f"Total collections:  {params['total_collections']}")
-    print(f"Total docs:         {params['total_docs']:,}")
-    print(f"Doc size:           {DOC_SIZE_BYTES:,} bytes")
-    print(f"Workers:            {args.workers}")
-    print(f"Batch size:         {args.batch_size}")
-    print(f"Sharded:            {args.sharded}")
-    print()
 
     # Connect to MongoDB
     try:
@@ -381,6 +374,21 @@ def main():
         for f in failures:
             print(f"  {f['full_name']}: {f['error']}")
         sys.exit(1)
+
+    # Print configuration
+    print()
+    print("PCSM Source Loader")
+    print("=" * 45)
+    print(f"Target size:        {args.size} GB")
+    print(f"URI:                {redact_uri(args.uri)}")
+    print(f"Databases:          {params['num_databases']}")
+    print(f"Collections per DB: {params['collections_per_db']}")
+    print(f"Total collections:  {params['total_collections']}")
+    print(f"Total docs:         {params['total_docs']:,}")
+    print(f"Doc size:           {DOC_SIZE_BYTES:,} bytes")
+    print(f"Workers:            {args.workers}")
+    print(f"Batch size:         {args.batch_size}")
+    print(f"Sharded:            {args.sharded}")
 
     # Verification
     print()

--- a/hack/mongo_uri.py
+++ b/hack/mongo_uri.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""
+MongoDB URI helpers.
+
+Connection strings carry credentials, so they should not be typed on the command
+line (shell history, visible process arguments) or printed verbatim. Single-cluster
+scripts read MONGO_URI; dual-cluster scripts use SRC_URI and TGT_URI.
+
+Usage:
+    export MONGO_URI="mongodb://localhost:27017"
+    hack/generator.py -r 100
+
+    MONGO_URI="$TGT_URI" hack/change_stream.py
+"""
+
+import os
+import re
+import sys
+
+URI_ENV_VAR = "MONGO_URI"
+
+_CREDENTIALS = re.compile(r"://[^@/]*@")
+
+
+def redact_uri(uri: str) -> str:
+    """Mask credentials in a connection string so it is safe to display."""
+    return _CREDENTIALS.sub("://***@", uri)
+
+
+def resolve_uri(uri: str | None) -> str:
+    """Return the URI from the --uri argument or MONGO_URI, whichever is set.
+
+    Prints an error and exits when neither is available.
+    """
+    resolved = uri or os.environ.get(URI_ENV_VAR)
+    if not resolved:
+        print(f"ERROR: no MongoDB URI: pass --uri or set {URI_ENV_VAR}")
+        sys.exit(1)
+
+    return resolved

--- a/hack/monitor_writes.py
+++ b/hack/monitor_writes.py
@@ -6,11 +6,12 @@ Monitors write operations per second on MongoDB cluster.
 Works with both replica sets and sharded clusters (mongos).
 
 Usage:
-    python hack/monitor_writes.py -u "mongodb://localhost:27017"
-    python hack/monitor_writes.py -u "mongodb://user:pass@mongos:27017" --interval 5
+    export MONGO_URI="mongodb://localhost:27017"
+    hack/monitor_writes.py
+    hack/monitor_writes.py --interval 5
 
 Options:
-    -u, --uri       MongoDB connection string (required)
+    -u, --uri       MongoDB connection string (default: $MONGO_URI)
     --interval      Sampling interval in seconds (default: 1)
 """
 
@@ -19,6 +20,7 @@ import sys
 import time
 
 import pymongo
+from mongo_uri import redact_uri, resolve_uri
 
 
 def parse_args():
@@ -27,11 +29,17 @@ def parse_args():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-    python hack/monitor_writes.py -u "mongodb://localhost:27017"
-    python hack/monitor_writes.py -u "mongodb://user:pass@mongos:27017" --interval 5
+    MONGO_URI="mongodb://localhost:27017" hack/monitor_writes.py
+    MONGO_URI="mongodb://mongos:27017" hack/monitor_writes.py --interval 5
         """,
     )
-    parser.add_argument("-u", "--uri", type=str, required=True, help="MongoDB connection string")
+    parser.add_argument(
+        "-u",
+        "--uri",
+        type=str,
+        default=None,
+        help="MongoDB connection string (default: $MONGO_URI)",
+    )
     parser.add_argument(
         "--interval",
         type=int,
@@ -43,15 +51,16 @@ Examples:
 
 def main():
     args = parse_args()
+    uri = resolve_uri(args.uri)
 
     try:
-        client = pymongo.MongoClient(args.uri, serverSelectionTimeoutMS=5000)
+        client = pymongo.MongoClient(uri, serverSelectionTimeoutMS=5000)
         client.admin.command("ping")
     except Exception as e:
         print(f"ERROR: Failed to connect to MongoDB: {e}")
         sys.exit(1)
 
-    print(f"Monitoring writes on {args.uri} (Ctrl+C to stop)")
+    print(f"Monitoring writes on {redact_uri(uri)} (Ctrl+C to stop)")
     print()
 
     prev = client.admin.command("serverStatus")["opcounters"]

--- a/hack/oplog_stream.py
+++ b/hack/oplog_stream.py
@@ -1,12 +1,34 @@
 #!/usr/bin/env python3
+"""
+Stream entries from a MongoDB replica set oplog.
+
+Usage:
+    export MONGO_URI="mongodb://rs10:30100,rs11:30101,rs12:30102"
+    hack/oplog_stream.py
+"""
+
+import argparse
 
 import bson.json_util as json
 import pymongo
+from mongo_uri import resolve_uri
 
-if __name__ == "__main__":
-    MONGODB_URI = "mongodb://rs10:30100,rs11:30101,rs12:30102"
-    m = pymongo.MongoClient(MONGODB_URI, readPreference="primary")
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Stream the MongoDB oplog")
+    parser.add_argument(
+        "-u",
+        "--uri",
+        help="MongoDB connection string (default: $MONGO_URI)",
+    )
+    args = parser.parse_args()
+
+    m = pymongo.MongoClient(resolve_uri(args.uri), readPreference="primary")
     for change in m.local["oplog.rs"].find():
         del change["_id"]
         del change["wallTime"]
         print(json.dumps(change))
+
+
+if __name__ == "__main__":
+    main()

--- a/hack/rs/run.sh
+++ b/hack/rs/run.sh
@@ -1,5 +1,30 @@
 #!/usr/bin/env bash
 
+usage() {
+    echo "Usage: $0 [--source-only|--target-only]"
+}
+
+if (( $# > 1 )); then
+    usage >&2
+    exit 1
+fi
+
+MODE="both"
+case "${1:-}" in
+    "") ;;
+    --source-only) MODE="source" ;;
+    --target-only) MODE="target" ;;
+    -h | --help)
+        usage
+        exit 0
+        ;;
+    *)
+        echo "Unknown argument: $1" >&2
+        usage >&2
+        exit 1
+        ;;
+esac
+
 BASE=$(dirname "$(dirname "$0")")
 
 # shellcheck source=/dev/null
@@ -9,16 +34,28 @@ RDIR="$BASE/rs"
 
 export compose="$RDIR/compose.yml"
 
-dcf up -d rs00 rs01 rs02 rs10 rs11 rs12
+services=()
+if [[ "$MODE" != "target" ]]; then
+    services+=(rs00 rs01 rs02)
+fi
+if [[ "$MODE" != "source" ]]; then
+    services+=(rs10 rs11 rs12)
+fi
 
-mwait "rs00:30000"
-mwait "rs01:30001"
-mwait "rs02:30002"
+dcf up -d "${services[@]}"
 
-rsinit "scripts/rs0" "rs00:30000"
+if [[ "$MODE" != "target" ]]; then
+    mwait "rs00:30000"
+    mwait "rs01:30001"
+    mwait "rs02:30002"
 
-mwait "rs10:30100"
-mwait "rs11:30101"
-mwait "rs12:30102"
+    rsinit "scripts/rs0" "rs00:30000"
+fi
 
-rsinit "scripts/rs1" "rs10:30100"
+if [[ "$MODE" != "source" ]]; then
+    mwait "rs10:30100"
+    mwait "rs11:30101"
+    mwait "rs12:30102"
+
+    rsinit "scripts/rs1" "rs10:30100"
+fi

--- a/tests/test_hack_clis.py
+++ b/tests/test_hack_clis.py
@@ -1,0 +1,94 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(autouse=True)
+def drop_all_database():
+    yield
+
+
+def run_script(script: str, *args: str, env: dict[str, str] | None = None):
+    command_env = os.environ.copy()
+    command_env["PATH"] = os.pathsep.join((str(Path(sys.executable).parent), command_env["PATH"]))
+    if env:
+        command_env.update(env)
+
+    return subprocess.run(
+        [PROJECT_ROOT / "hack" / script, *args],
+        cwd=PROJECT_ROOT,
+        env=command_env,
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=False,
+    )
+
+
+def test_compare_all_help_exits_without_connecting():
+    result = run_script(
+        "compare-all.py",
+        "--help",
+        env={
+            "SRC_URI": "mongodb://127.0.0.1:1/?serverSelectionTimeoutMS=100",
+            "TGT_URI": "mongodb://127.0.0.1:1/?serverSelectionTimeoutMS=100",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == ""
+
+
+def test_oplog_stream_help_exits_without_connecting(tmp_path: Path):
+    (tmp_path / "sitecustomize.py").write_text(
+        "import pymongo\n"
+        "def reject_connection(*args, **kwargs):\n"
+        "    raise RuntimeError('unexpected MongoDB connection')\n"
+        "pymongo.MongoClient = reject_connection\n"
+    )
+
+    result = run_script(
+        "oplog_stream.py",
+        "--help",
+        env={"PYTHONPATH": str(tmp_path)},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == ""
+
+
+def test_oplog_stream_uses_mongo_uri(tmp_path: Path):
+    (tmp_path / "sitecustomize.py").write_text(
+        "import os\n"
+        "import pymongo\n"
+        "class EmptyCollection:\n"
+        "    def find(self):\n"
+        "        return ()\n"
+        "class LocalDatabase:\n"
+        "    def __getitem__(self, name):\n"
+        "        return EmptyCollection()\n"
+        "class FakeClient:\n"
+        "    def __init__(self, uri, **kwargs):\n"
+        "        if uri != os.environ['EXPECTED_MONGO_URI']:\n"
+        "            raise RuntimeError('unexpected MongoDB URI')\n"
+        "        self.local = LocalDatabase()\n"
+        "pymongo.MongoClient = FakeClient\n"
+    )
+    uri = "mongodb://example.invalid:27017"
+
+    result = run_script(
+        "oplog_stream.py",
+        env={
+            "EXPECTED_MONGO_URI": uri,
+            "MONGO_URI": uri,
+            "PYTHONPATH": str(tmp_path),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == ""

--- a/tests/test_hack_clis.py
+++ b/tests/test_hack_clis.py
@@ -1,11 +1,30 @@
+import importlib.util
 import os
+import selectors
+import signal
 import subprocess
 import sys
+import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_script(name: str):
+    path = PROJECT_ROOT / "hack" / name
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(path.parent))
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.pop(0)
+    return module
 
 
 @pytest.fixture(autouse=True)
@@ -30,6 +49,21 @@ def run_script(script: str, *args: str, env: dict[str, str] | None = None):
     )
 
 
+def wait_for_output(process: subprocess.Popen, marker: bytes, timeout: float = 5) -> None:
+    selector = selectors.DefaultSelector()
+    selector.register(process.stdout, selectors.EVENT_READ)
+    deadline = time.monotonic() + timeout
+    output = b""
+    while marker not in output:
+        events = selector.select(max(0, deadline - time.monotonic()))
+        if not events:
+            raise TimeoutError(f"process did not print {marker!r}")
+        chunk = os.read(process.stdout.fileno(), 4096)
+        if not chunk:
+            raise RuntimeError(f"process exited before printing {marker!r}: {output!r}")
+        output += chunk
+
+
 def test_compare_all_help_exits_without_connecting():
     result = run_script(
         "compare-all.py",
@@ -42,6 +76,205 @@ def test_compare_all_help_exits_without_connecting():
 
     assert result.returncode == 0, result.stderr
     assert result.stderr == ""
+
+
+def test_compare_namespace_skips_indexes_when_only_target_is_view():
+    compare_all = load_script("compare-all.py")
+
+    class FakeCollection:
+        def __init__(self, options):
+            self._options = options
+
+        def options(self):
+            return self._options
+
+        def index_information(self):
+            raise AssertionError("view indexes must not be read")
+
+        def find_raw_batches(self, **kwargs):
+            return ()
+
+    class FakeClient:
+        def __init__(self, options):
+            self.database = FakeDatabase(options)
+
+        def __getitem__(self, name):
+            return self.database
+
+    class FakeDatabase:
+        def __init__(self, options):
+            self.collection = FakeCollection(options)
+
+        def __getitem__(self, name):
+            return self.collection
+
+    mismatches = compare_all.compare_namespace(
+        FakeClient({}),
+        FakeClient({"viewOn": "items"}),
+        "db",
+        "items",
+    )
+
+    assert len(mismatches) == 1
+
+
+def test_demo_writer_pause_uses_last_acknowledged_write_time(monkeypatch):
+    demo_writer = load_script("demo_writer.py")
+    args = SimpleNamespace(
+        source_label="SOURCE",
+        target_label="TARGET",
+        database="db",
+        collection="items",
+        rate=2.0,
+        seed=42,
+        doc_size=demo_writer.BASE_DOC_SIZE,
+    )
+    writer = demo_writer.DemoWriter(object(), object(), args)
+    clock = {"now": 10.0, "sleeps": 0}
+
+    monkeypatch.setattr(writer, "_do_op", lambda: True)
+    monkeypatch.setattr(demo_writer.time, "monotonic", lambda: clock["now"])
+
+    def advance_to_pause(interval):
+        clock["sleeps"] += 1
+        if clock["sleeps"] == 1:
+            clock["now"] = 11.0
+            writer._pause = True
+        else:
+            writer._stop = True
+
+    monkeypatch.setattr(demo_writer.time, "sleep", advance_to_pause)
+
+    writer.run()
+
+    assert writer.t0 == 10.0
+
+
+@pytest.mark.parametrize("rate", ["0", "-1"])
+def test_demo_writer_rejects_nonpositive_rate(rate: str):
+    result = run_script("demo_writer.py", "--rate", rate)
+
+    assert result.returncode == 2
+
+
+def test_demo_writer_rejects_document_smaller_than_base():
+    result = run_script("demo_writer.py", "--doc-size", "519")
+
+    assert result.returncode == 2
+
+
+def test_demo_writer_sigint_exits_interactive_process(tmp_path: Path):
+    (tmp_path / "sitecustomize.py").write_text(
+        "import pymongo\n"
+        "class Admin:\n"
+        "    def command(self, name):\n"
+        "        return {'ok': 1}\n"
+        "class Collection:\n"
+        "    def insert_one(self, doc):\n"
+        "        return None\n"
+        "class Database:\n"
+        "    def __getitem__(self, name):\n"
+        "        return Collection()\n"
+        "class FakeClient:\n"
+        "    admin = Admin()\n"
+        "    def __init__(self, uri):\n"
+        "        pass\n"
+        "    def __getitem__(self, name):\n"
+        "        return Database()\n"
+        "    def close(self):\n"
+        "        pass\n"
+        "pymongo.MongoClient = FakeClient\n"
+    )
+    command_env = os.environ.copy()
+    command_env.update(
+        {
+            "PATH": os.pathsep.join((str(Path(sys.executable).parent), command_env["PATH"])),
+            "PYTHONPATH": str(tmp_path),
+            "PYTHONUNBUFFERED": "1",
+            "SOURCE_URI": "mongodb://source.invalid",
+            "TARGET_URI": "mongodb://target.invalid",
+        }
+    )
+    process = subprocess.Popen(
+        [PROJECT_ROOT / "hack" / "demo_writer.py"],
+        cwd=PROJECT_ROOT,
+        env=command_env,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+    try:
+        wait_for_output(process, b"Commands: pause | repoint | resume | status | quit")
+        process.stdin.write(b"status\n")
+        process.stdin.flush()
+        wait_for_output(process, b"WRITING  side=SOURCE")
+        process.send_signal(signal.SIGINT)
+        try:
+            returncode = process.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            returncode = None
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait()
+
+    assert returncode == 0
+
+
+def test_loader_prints_redacted_configuration_before_drop(monkeypatch, capsys):
+    loader = load_script("loader.py")
+    uri = "mongodb://user:secret@localhost:27017"
+    observed = {}
+
+    class StopAfterDrop(Exception):
+        pass
+
+    class FakeAdmin:
+        def command(self, name):
+            return {"ok": 1}
+
+    class FakeClient:
+        admin = FakeAdmin()
+
+    monkeypatch.setattr(
+        loader,
+        "parse_args",
+        lambda: SimpleNamespace(
+            uri=None,
+            size=1,
+            databases=1,
+            collections_per_db=1,
+            drop=True,
+            sharded=False,
+            workers=1,
+            batch_size=1,
+        ),
+    )
+    monkeypatch.setattr(loader, "resolve_uri", lambda value: uri)
+    monkeypatch.setattr(loader.pymongo, "MongoClient", lambda *args, **kwargs: FakeClient())
+    monkeypatch.setattr(
+        loader,
+        "calculate_parameters",
+        lambda *args: {
+            "num_databases": 1,
+            "collections_per_db": 1,
+            "total_collections": 1,
+            "total_docs": 1,
+            "work_items": [],
+        },
+    )
+
+    def stop_after_drop(*args):
+        observed["output"] = capsys.readouterr().out
+        raise StopAfterDrop
+
+    monkeypatch.setattr(loader, "drop_collections", stop_after_drop)
+
+    with pytest.raises(StopAfterDrop):
+        loader.main()
+
+    assert "mongodb://***@localhost:27017" in observed["output"]
 
 
 def test_oplog_stream_help_exits_without_connecting(tmp_path: Path):


### PR DESCRIPTION
Hardenings and improvements I came across while working on the demo/presentation.

Standardize runnable Python scripts on `hack/<script>.py`, keep Poetry setup in one place, and resolve MongoDB URIs through environment variables. `hack/rs/run.sh` now handles source-only and target-only startup. `compare-all.py` and `oplog_stream.py` parse CLI arguments before connecting, with focused regression tests. Also adds `demo_writer.py` for the source-to-target demo flow.