### PR TITLE
PCSM-359: Follow-up: resume before first uncommitted worker event

### DIFF
--- a/pcsm/repl/worker.go
+++ b/pcsm/repl/worker.go
@@ -3,7 +3,6 @@ package repl
 import (
 	"context"
 	"hash/fnv"
-	"math"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -540,7 +539,9 @@ func (p *workerPool) ReleaseBarrier() {
 //     imposes no constraint and is skipped.
 //   - If the worker was routed events but has not committed any
 //     (lastCommittedTS == nil, e.g. its first bulk write failed), the safe
-//     resume floor is strictly before the first routed event.
+//     resume floor is the first routed event. startAtOperationTime is
+//     inclusive, so the event is replayed without requiring an older oplog
+//     timestamp.
 //   - Otherwise the worker's committed lastCommittedTS is used.
 //
 // The returned timestamp is the minimum of these per-worker effective values.
@@ -562,13 +563,13 @@ func (p *workerPool) Checkpoint() bson.Timestamp {
 
 		committed := w.lastCommittedTS.Load()
 		if committed == nil {
-			// Worker received events but never committed. Resume before its
-			// first event so every routed event is replayed.
+			// Worker received events but never committed. Resume at its first
+			// event so every routed event is replayed.
 			firstRouted := w.firstRoutedTS.Load()
 			if firstRouted == nil {
 				firstRouted = routed
 			}
-			effective = tsPredecessor(*firstRouted)
+			effective = *firstRouted
 		} else {
 			effective = *committed
 		}
@@ -580,21 +581,6 @@ func (p *workerPool) Checkpoint() bson.Timestamp {
 	}
 
 	return minTS
-}
-
-// tsPredecessor returns the largest bson.Timestamp strictly less than ts.
-// For (T, I) with I > 0 it returns (T, I-1); when I == 0 and T > 0 it
-// returns (T-1, math.MaxUint32). For the zero timestamp it returns the
-// zero timestamp (there is nothing smaller).
-func tsPredecessor(ts bson.Timestamp) bson.Timestamp {
-	switch {
-	case ts.I > 0:
-		return bson.Timestamp{T: ts.T, I: ts.I - 1}
-	case ts.T > 0:
-		return bson.Timestamp{T: ts.T - 1, I: math.MaxUint32}
-	default:
-		return bson.Timestamp{}
-	}
 }
 
 // Idle returns true when every worker that has been routed events has

--- a/pcsm/repl/worker.go
+++ b/pcsm/repl/worker.go
@@ -50,6 +50,7 @@ type worker struct {
 	routedEventCh chan *routedEvent
 
 	lastCommittedTS atomic.Pointer[bson.Timestamp] // last committed timestamp
+	firstRoutedTS   atomic.Pointer[bson.Timestamp] // first timestamp dispatched to this worker
 	lastRoutedTS    atomic.Pointer[bson.Timestamp] // last timestamp dispatched to this worker
 	lastPendingTS   bson.Timestamp                 // timestamp of last event in current batch
 
@@ -476,6 +477,7 @@ func (p *workerPool) Route(change *ChangeEvent, ns catalog.Namespace) {
 	w := p.workers[workerIdx]
 
 	ts := change.ClusterTime
+	w.firstRoutedTS.CompareAndSwap(nil, &ts)
 	w.lastRoutedTS.Store(&ts)
 
 	w.routedEventCh <- &routedEvent{
@@ -537,14 +539,13 @@ func (p *workerPool) ReleaseBarrier() {
 //   - If the worker was never routed an event (lastRoutedTS == nil), it
 //     imposes no constraint and is skipped.
 //   - If the worker was routed events but has not committed any
-//     (lastCommitedTS == nil, e.g. its first bulk write failed), the safe resume
-//     floor is strictly before the routed event(s). We use the predecessor
-//     of lastRoutedTS as a conservative bound.
-//   - Otherwise the worker's committed lastCommitedTS is used.
+//     (lastCommittedTS == nil, e.g. its first bulk write failed), the safe
+//     resume floor is strictly before the first routed event.
+//   - Otherwise the worker's committed lastCommittedTS is used.
 //
 // The returned timestamp is the minimum of these per-worker effective values.
-// A nil lastCommitedTS on a worker that has been routed events must never be silently
-// skipped: doing so would let the checkpoint advance past the worker's
+// A nil lastCommittedTS on a worker that has been routed events must never be
+// silently skipped: doing so would let the checkpoint advance past the worker's
 // uncommitted routed events, causing silent event loss on resume.
 func (p *workerPool) Checkpoint() bson.Timestamp {
 	var minTS bson.Timestamp
@@ -561,9 +562,13 @@ func (p *workerPool) Checkpoint() bson.Timestamp {
 
 		committed := w.lastCommittedTS.Load()
 		if committed == nil {
-			// Worker received events but never committed. Safe floor is
-			// strictly before the routed event(s).
-			effective = tsPredecessor(*routed)
+			// Worker received events but never committed. Resume before its
+			// first event so every routed event is replayed.
+			firstRouted := w.firstRoutedTS.Load()
+			if firstRouted == nil {
+				firstRouted = routed
+			}
+			effective = tsPredecessor(*firstRouted)
 		} else {
 			effective = *committed
 		}

--- a/pcsm/repl/worker_checkpoint_test.go
+++ b/pcsm/repl/worker_checkpoint_test.go
@@ -1,7 +1,6 @@
 package repl //nolint
 
 import (
-	"math"
 	"testing"
 	"time"
 
@@ -76,8 +75,8 @@ func TestCheckpoint_DoesNotAdvancePastFailedWorker(t *testing.T) {
 }
 
 // TestCheckpoint_DoesNotAdvancePastFirstUncommittedEvent verifies that a worker
-// with multiple routed events and no committed bulk resumes before the first
-// event, not immediately before the last routed event.
+// with multiple routed events and no committed bulk resumes at the first event,
+// not immediately before the last routed event.
 func TestCheckpoint_DoesNotAdvancePastFirstUncommittedEvent(t *testing.T) {
 	t.Parallel()
 
@@ -97,53 +96,6 @@ func TestCheckpoint_DoesNotAdvancePastFirstUncommittedEvent(t *testing.T) {
 	pool.Route(first.change, first.ns)
 	pool.Route(last.change, last.ns)
 
-	assert.Equal(t, tsPredecessor(firstTS), pool.Checkpoint(),
-		"checkpoint must resume before the first routed event when no event has committed")
-}
-
-// TestTsPredecessor verifies tsPredecessor returns the largest bson.Timestamp
-// strictly less than the input, with correct wrap-around from (T, 0) to
-// (T-1, math.MaxUint32) and saturation at the zero timestamp.
-func TestTsPredecessor(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name string
-		in   bson.Timestamp
-		want bson.Timestamp
-	}{
-		{
-			name: "decrements I when I > 0",
-			in:   bson.Timestamp{T: 100, I: 5},
-			want: bson.Timestamp{T: 100, I: 4},
-		},
-		{
-			name: "wraps to previous T when I == 0",
-			in:   bson.Timestamp{T: 100, I: 0},
-			want: bson.Timestamp{T: 99, I: math.MaxUint32},
-		},
-		{
-			name: "saturates at zero timestamp",
-			in:   bson.Timestamp{T: 0, I: 0},
-			want: bson.Timestamp{T: 0, I: 0},
-		},
-		{
-			name: "T == 1, I == 0 wraps to (0, MaxUint32)",
-			in:   bson.Timestamp{T: 1, I: 0},
-			want: bson.Timestamp{T: 0, I: math.MaxUint32},
-		},
-		{
-			name: "I == 1 decrements to (T, 0) without wrapping",
-			in:   bson.Timestamp{T: 42, I: 1},
-			want: bson.Timestamp{T: 42, I: 0},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got := tsPredecessor(tt.in)
-			assert.Equal(t, tt.want, got)
-		})
-	}
+	assert.Equal(t, firstTS, pool.Checkpoint(),
+		"checkpoint must resume at the first routed event when no event has committed")
 }

--- a/pcsm/repl/worker_checkpoint_test.go
+++ b/pcsm/repl/worker_checkpoint_test.go
@@ -75,6 +75,32 @@ func TestCheckpoint_DoesNotAdvancePastFailedWorker(t *testing.T) {
 			"in (T_fail, cp) on resume.", cp, tsFail)
 }
 
+// TestCheckpoint_DoesNotAdvancePastFirstUncommittedEvent verifies that a worker
+// with multiple routed events and no committed bulk resumes before the first
+// event, not immediately before the last routed event.
+func TestCheckpoint_DoesNotAdvancePastFirstUncommittedEvent(t *testing.T) {
+	t.Parallel()
+
+	pool := &workerPool{
+		workers: []*worker{{
+			id:            "0",
+			routedEventCh: make(chan *routedEvent, 2),
+		}},
+		numWorkers: 1,
+	}
+
+	firstTS := bson.Timestamp{T: 100, I: 1}
+	lastTS := bson.Timestamp{T: 100, I: 10}
+	first := makeInsertEventWithTS("first-uncommitted", firstTS)
+	last := makeInsertEventWithTS("last-uncommitted", lastTS)
+
+	pool.Route(first.change, first.ns)
+	pool.Route(last.change, last.ns)
+
+	assert.Equal(t, tsPredecessor(firstTS), pool.Checkpoint(),
+		"checkpoint must resume before the first routed event when no event has committed")
+}
+
 // TestTsPredecessor verifies tsPredecessor returns the largest bson.Timestamp
 // strictly less than the input, with correct wrap-around from (T, 0) to
 // (T-1, math.MaxUint32) and saturation at the zero timestamp.


### PR DESCRIPTION
[PCSM-359](https://perconadev.atlassian.net/browse/PCSM-359)

Follow-up to #257.

### Problem

A worker with multiple routed events and no completed first bulk used the predecessor of `lastRoutedTS` as its checkpoint. Restarting from that timestamp skipped earlier uncommitted events.

### Solution

Track the first routed timestamp for the worker-pool lifetime and resume before it until the first bulk commits. Adds a regression case with multiple routed events and no committed bulk.

### Verification

`make lint`, `make test`, and `MONGO_VERSION=7.0 make test-integration` pass. The ReplicaSet E2E scope passed 203 tests. A live forced restart recovered 2,001 uncommitted events and produced matching source/target document hashes.

[PCSM-359]: https://perconadev.atlassian.net/browse/PCSM-359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ